### PR TITLE
Implement redefinition of internal functions

### DIFF
--- a/tests/Reflection/ReflectionFunctionTest.php
+++ b/tests/Reflection/ReflectionFunctionTest.php
@@ -76,12 +76,25 @@ class ReflectionFunctionTest extends TestCase
         });
         // Check that all main info were preserved
         $this->assertFalse($this->refFunction->isClosure());
-        $this->assertTrue($this->refFunction->isRedefined());
         $this->assertSame('testFunction', $this->refFunction->getShortName());
 
         $result = testFunction();
 
         // Our function now returns Yes instead of Test
         $this->assertSame('Yes', $result);
+    }
+
+    public function testRedefineInternalFunc(): void
+    {
+        $originalValue = zend_version();
+        $refFunction   = new ReflectionFunction('zend_version');
+
+        $refFunction->redefine(function () {
+            return 'Z-Engine';
+        });
+
+        $modifiedValue = zend_version();
+        $this->assertNotSame($originalValue, $modifiedValue);
+        $this->assertSame('Z-Engine', $modifiedValue);
     }
 }

--- a/tests/Reflection/ReflectionMethodTest.php
+++ b/tests/Reflection/ReflectionMethodTest.php
@@ -197,7 +197,6 @@ class ReflectionMethodTest extends TestCase
         });
         // Check that all main info were preserved
         $this->assertFalse($this->refMethod->isClosure());
-        $this->assertTrue($this->refMethod->isRedefined());
         $this->assertSame('reflectedMethod', $this->refMethod->getName());
 
         $test   = new TestClass();


### PR DESCRIPTION
This PR introduces redefinition of internal functions, like `date()`, etc via FFI `Closure` native binding.