### PR TITLE
[Feature] Implement userland object handlers

### DIFF
--- a/include/engine_x64_nts.h
+++ b/include/engine_x64_nts.h
@@ -1109,3 +1109,6 @@ ZEND_API user_opcode_handler_t zend_get_user_opcode_handler(zend_uchar opcode);
  * Zend inheritance API
  */
 ZEND_API void zend_do_inheritance_ex(zend_class_entry *ce, zend_class_entry *parent_ce, zend_bool checked);
+ZEND_API zend_object ZEND_FASTCALL *zend_objects_new(zend_class_entry *ce);
+ZEND_API void ZEND_FASTCALL zend_object_std_init(zend_object *object, zend_class_entry *ce);
+ZEND_API void object_properties_init(zend_object *object, zend_class_entry *class_type);

--- a/src/ClassExtension/ObjectCastInterface.php
+++ b/src/ClassExtension/ObjectCastInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+/**
+ * Interface ObjectCastInterface allows to cast given object to scalar values, like integer, floats, etc
+ */
+interface ObjectCastInterface
+{
+    /**
+     * Performs casting of given object to another value
+     *
+     * @param object $instance Instance of object that should be casted
+     * @param int $typeTo Type of casting, @see ReflectionValue::IS_* constants
+     *
+     * @return mixed Casted value
+     */
+    public static function __cast(object $instance, int $typeTo);
+}

--- a/src/ClassExtension/ObjectCompareValuesInterface.php
+++ b/src/ClassExtension/ObjectCompareValuesInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+/**
+ * Interface ObjectCompareValuesInterface allows to perform comparison of objects
+ */
+interface ObjectCompareValuesInterface
+{
+    /**
+     * Performs comparison of given object with another value
+     *
+     * @param mixed $one     First side of operation
+     * @param mixed $another Another side of operation
+     *
+     * @return int Result of comparison: 1 is greater, -1 is less, 0 is equal
+     */
+    public static function __compare($one, $another): int;
+}

--- a/src/ClassExtension/ObjectCreateInterface.php
+++ b/src/ClassExtension/ObjectCreateInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use Closure;
+use FFI\CData;
+
+/**
+ * Interface ObjectCreateInterface allows to hook into the object initialization process (eg new FooBar())
+ */
+interface ObjectCreateInterface
+{
+    /**
+     * Performs low-level initialization of object during new instances creation
+     *
+     * @param CData   $classType Class type to initialize (zend_class_entry)
+     * @param Closure $initializer Original initializer that accepts a zend_class_entry and creates a new zend_object
+     *
+     * @return CData Pointer to the zend_object instance
+     */
+    public static function __init(CData $classType, Closure $initializer): CData;
+}

--- a/src/ClassExtension/ObjectCreateTrait.php
+++ b/src/ClassExtension/ObjectCreateTrait.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use Closure;
+use FFI\CData;
+
+/**
+ * Trait ObjectCreateTrait contains default hook implementation for object initialization
+ */
+trait ObjectCreateTrait
+{
+    /**
+     * Performs low-level initialization of object during new instances creation
+     *
+     * @param CData   $classType Class type to initialize (zend_class_entry)
+     * @param Closure $initializer Original initializer that accepts a zend_class_entry and creates a new zend_object
+     *
+     * @return CData Pointer to the zend_object instance
+     */
+    public static function __init(CData $classType, Closure $initializer): CData
+    {
+        return $initializer($classType);
+    }
+}

--- a/src/ClassExtension/ObjectDoOperationInterface.php
+++ b/src/ClassExtension/ObjectDoOperationInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+/**
+ * Interface ObjectDoOperationInterface allows to perform math operations (aka operator overloading) on object
+ */
+interface ObjectDoOperationInterface
+{
+    /**
+     * Performs casting of given object to another value
+     *
+     * @param int $opCode Operation code
+     * @param mixed $left left side of operation
+     * @param mixed $right Right side of operation
+     *
+     * @return mixed Result of operation value
+     */
+    public static function __doOperation(int $opCode, $left, $right);
+}

--- a/src/Core.php
+++ b/src/Core.php
@@ -366,4 +366,12 @@ class Core
 
         return $size;
     }
+
+    /**
+     * Returns standard object handlers
+     */
+    public static function getStandardObjectHandlers(): CData
+    {
+        return self::$engine->std_object_handlers;
+    }
 }

--- a/tests/Stub/NativeNumber.php
+++ b/tests/Stub/NativeNumber.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use ZEngine\ClassExtension\ObjectCastInterface;
+use ZEngine\ClassExtension\ObjectCompareValuesInterface;
+use ZEngine\ClassExtension\ObjectCreateInterface;
+use ZEngine\ClassExtension\ObjectCreateTrait;
+use ZEngine\ClassExtension\ObjectDoOperationInterface;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\System\OpCode;
+
+class NativeNumber implements
+    ObjectCreateInterface,
+    ObjectCompareValuesInterface,
+    ObjectDoOperationInterface,
+    ObjectCastInterface
+{
+    use ObjectCreateTrait;
+
+    private $value;
+
+    public function __construct($value)
+    {
+        if (!is_numeric($value)) {
+            throw new \InvalidArgumentException('Only numeric values are allowed');
+        }
+        $this->value = $value;
+    }
+
+    /**
+     * @param NativeNumber $instance
+     * @inheritDoc
+     */
+    public static function __cast(object $instance, int $typeTo)
+    {
+        switch ($typeTo) {
+            case ReflectionValue::_IS_NUMBER:
+            case ReflectionValue::IS_LONG:
+                return (int) $instance->value;
+            case ReflectionValue::IS_DOUBLE:
+                return (float) $instance->value;
+        }
+
+        throw new \UnexpectedValueException('Can not cast number to the ' . ReflectionValue::name($typeTo));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function __compare($one, $another): int
+    {
+        $left  = self::getNumericValue($one);
+        $right = self::getNumericValue($another);
+
+        return $left <=> $right;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function __doOperation(int $opCode, $left, $right)
+    {
+        $left  = self::getNumericValue($left);
+        $right = self::getNumericValue($right);
+        switch ($opCode) {
+            case OpCode::ADD:
+                $result = $left + $right;
+                break;
+            case OpCode::SUB:
+                $result = $left - $right;
+                break;
+            case OpCode::MUL:
+                $result = $left * $right;
+                break;
+            case OpCode::DIV:
+                $result = $left / $right;
+                break;
+            default:
+                throw new \UnexpectedValueException("Opcode " . OpCode::name($opCode) . " wasn't held.");
+        }
+
+        return new static($result);
+    }
+
+    /**
+     * @param $one
+     *
+     * @return int|string
+     */
+    private static function getNumericValue($one)
+    {
+        if ($one instanceof NativeNumber) {
+            $left = $one->value;
+        } elseif (is_numeric($one)) {
+            $left = $one;
+        } else {
+            throw new \UnexpectedValueException('NativeNumber can be compared only with numeric values and itself');
+        }
+
+        return $left;
+}
+}


### PR DESCRIPTION
This PR introduces ability to install `zend_object.handlers` from userland, thus giving access to comparison, casting, operator overloading and more.