### PR TITLE
[Feature] Interface gets implemented handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ immutable instances of objects.
 Important reminder: you **MUST** install the `create_object` handler first in order to install hooks in runtime. Also
 you can not install the `create_object` handler for the object if it is internal one.
 
+There is one extra method called `setInterfaceGetsImplementedHandler` which is useful for installing special handler for
+interfaces. The `interface_gets_implemented` callback uses the same memory slot as `create_object` handler for object,
+and will be called each time when any class will implement this interface. This gives interesting options for
+automatic class extensions registration, for example, if a class implements the `ObjectCreateInterface` then
+automatically call `ReflectionClass->installExtensionHandlers()` for it in callback.
+
 Code of Conduct
 --------------
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -304,16 +304,6 @@ class Core
     }
 
     /**
-     * Creates a PHP string from $size bytes of memory area pointed by
-     * $source. If size is omitted, $source must be zero terminated
-     * array of C chars.
-     */
-    public static function string(CData $source, int $size = 0): string
-    {
-        return FFI::string($source, $size);
-    }
-
-    /**
      * Creates a new instance of specific type
      *
      * @param string $type Name of the type

--- a/src/Type/StringEntry.php
+++ b/src/Type/StringEntry.php
@@ -15,6 +15,7 @@ namespace ZEngine\Type;
 use FFI\CData;
 use ReflectionClass;
 use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
 
 /**
  * This class wraps PHP's zend_string structure and provide an API for working with it
@@ -85,7 +86,13 @@ class StringEntry implements ReferenceCountedInterface
      */
     public function getStringValue(): string
     {
-        return Core::string(Core::cast('char *', $this->pointer->val), $this->pointer->len);
+        $entry = ReflectionValue::newEntry(ReflectionValue::IS_STRING, $this->pointer[0]);
+        $entry->getNativeValue($realString);
+
+        // TODO: Incapsulate memory management into ReflectionValue->release() method
+        Core::free($entry->getRawValue());
+
+        return $realString;
     }
 
     /**

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -219,6 +219,27 @@ class ReflectionClassTest extends TestCase
         $this->markTestIncomplete('Initialization object handler brings segfaults thus run it separately');
     }
 
+    public function testInstallInterfaceGetsImplementedHandler(): void
+    {
+        $log = '';
+        $refInterface = new ReflectionClass(TestInterface::class);
+        $refInterface->setInterfaceGetsImplementedHandler(function (ReflectionClass $classType) use (&$log) {
+            $log = 'Class ' . $classType->getName() . ' implements interface';
+        });
+
+        // Check that log line is empty now
+        $this->assertSame('', $log);
+
+        // Now we expect that at this point of time our callback will be called
+        $anonymousInterfaceImplementation = new class implements TestInterface {};
+
+        // Of course, we should get an instance of our TestInterface
+        $this->assertInstanceOf(TestInterface::class, $anonymousInterfaceImplementation);
+
+        // ... and log entry will contain a record about anonymous class that implements interface
+        $this->assertStringContainsString('class@anonymous', $log);
+    }
+
     /**
      * @runInSeparateProcess
      */


### PR DESCRIPTION
In the engine, each class entry has a union field:
```
    union {
        zend_object* (*create_object)(zend_class_entry *class_type);
        int (*interface_gets_implemented)(zend_class_entry *iface, zend_class_entry *class_type); /* a class implements this interface */
    };
```

Whereas `create_object` handler is used for object initialization, the`interface_gets_implemented` handler is used for interfaces as a general callback when class implements this concrete interface. This callback can be used for interesting features like automatic class registration/configuration via callback.

There is a requirement for this handler (and interfaces): it should be installed before the first declaration of any class that implements this interface, otherwise you will receive a segfault on second call in FPM, because handler will 