### PR TITLE
[Feature] New hook API

### DIFF
--- a/src/ClassExtension/Hook/CastObjectHook.php
+++ b/src/ClassExtension/Hook/CastObjectHook.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for casting object to another type
+ */
+class CastObjectHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'cast_object';
+
+    /**
+     * Object instance to perform casting
+     */
+    protected CData $object;
+
+    /**
+     * Holds a return value
+     */
+    protected CData $returnValue;
+
+    /**
+     * Cast type
+     */
+    protected int $type;
+
+    /**
+     * typedef int (*zend_object_cast_t)(zval *readobj, zval *retval, int type);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): int
+    {
+        [$this->object, $this->returnValue, $this->type] = $rawArguments;
+
+        $result = ($this->userHandler)($this);
+        ReflectionValue::fromValueEntry($this->returnValue)->setNativeValue($result);
+
+        return Core::SUCCESS;
+    }
+
+    /**
+     * Returns the cast type
+     *
+     * @see ReflectionValue class constants, like ReflectionValue::IS_DOUBLE
+     */
+    public function getCastType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns an object instance
+     */
+    public function getObject(): object
+    {
+        ReflectionValue::fromValueEntry($this->object)->getNativeValue($objectInstance);
+
+        return $objectInstance;
+    }
+
+    /**
+     * Returns result of casting (eg from call to proceed)
+     */
+    public function getResult()
+    {
+        ReflectionValue::fromValueEntry($this->returnValue)->getNativeValue($result);
+
+        return $result;
+    }
+
+    /**
+     * Proceeds with object casting
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+        $result = ($this->originalHandler)($this->object, $this->returnValue, $this->type);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/Hook/CompareValuesHook.php
+++ b/src/ClassExtension/Hook/CompareValuesHook.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for performing operation on object
+ */
+class CompareValuesHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'compare';
+
+    /**
+     * Holds a return value
+     */
+    protected CData $returnValue;
+
+    /**
+     * First operand
+     */
+    protected CData $op1;
+
+    /**
+     * Second operand
+     */
+    protected CData $op2;
+
+    /**
+     * typedef int (*zend_object_compare_zvals_t)(zval *result, zval *op1, zval *op2);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): int
+    {
+        [$this->returnValue, $this->op1, $this->op2] = $rawArguments;
+
+        $result = ($this->userHandler)($this);
+        ReflectionValue::fromValueEntry($this->returnValue)->setNativeValue($result);
+
+        return Core::SUCCESS;
+    }
+
+    /**
+     * Returns first operand
+     */
+    public function getFirst()
+    {
+        ReflectionValue::fromValueEntry($this->op1)->getNativeValue($value);
+
+        return $value;
+    }
+
+    /**
+     * Returns second operand
+     */
+    public function getSecond()
+    {
+        ReflectionValue::fromValueEntry($this->op2)->getNativeValue($value);
+
+        return $value;
+    }
+
+    /**
+     * Returns result of casting (eg from call to proceed)
+     */
+    public function getResult()
+    {
+        ReflectionValue::fromValueEntry($this->returnValue)->getNativeValue($result);
+
+        return $result;
+    }
+
+    /**
+     * Proceeds with object comparison
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+        $result = ($this->originalHandler)($this->returnValue, $this->op1, $this->op2);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/Hook/CreateObjectHook.php
+++ b/src/ClassExtension/Hook/CreateObjectHook.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionClass;
+
+/**
+ * Receiving hook for performing operation on object
+ */
+class CreateObjectHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'create_object';
+
+    private CData $classType;
+
+    /**
+     * Returns a raw class type (zend_class_entry)
+     */
+    public function getClassType(): CData
+    {
+        return $this->classType;
+    }
+
+    /**
+     * Changes a class type to create
+     */
+    public function setClassType(CData $classType): void
+    {
+        $this->classType = $classType;
+    }
+
+    /**
+     * zend_object* (*create_object)(zend_class_entry *class_type);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): CData
+    {
+        [$this->classType] = $rawArguments;
+
+        return ($this->userHandler)($this);
+    }
+
+    /**
+     * Proceeds with object creation
+     */
+    public function proceed()
+    {
+        if ($this->originalHandler === null) {
+            $object = ReflectionClass::newInstanceRaw($this->classType);
+        } else {
+            $object = ($this->originalHandler)($this->classType);
+        }
+
+        return $object;
+    }
+}

--- a/src/ClassExtension/Hook/DoOperationHook.php
+++ b/src/ClassExtension/Hook/DoOperationHook.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for performing operation on object
+ */
+class DoOperationHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'do_operation';
+
+    /**
+     * Operation opcode
+     */
+    protected int $opCode;
+
+    /**
+     * Holds a return value
+     */
+    protected CData $returnValue;
+
+    /**
+     * First operand
+     */
+    protected CData $op1;
+
+    /**
+     * Second operand
+     */
+    protected CData $op2;
+
+    /**
+     * typedef int (*zend_object_do_operation_t)(zend_uchar opcode, zval *result, zval *op1, zval *op2);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): int
+    {
+        [$this->opCode, $this->returnValue, $this->op1, $this->op2] = $rawArguments;
+
+        $result = ($this->userHandler)($this);
+        ReflectionValue::fromValueEntry($this->returnValue)->setNativeValue($result);
+
+        return Core::SUCCESS;
+    }
+
+    /**
+     * Returns an opcode
+     */
+    public function getOpcode(): int
+    {
+        return $this->opCode;
+    }
+
+    /**
+     * Returns first operand
+     */
+    public function getFirst()
+    {
+        ReflectionValue::fromValueEntry($this->op1)->getNativeValue($value);
+
+        return $value;
+    }
+
+    /**
+     * Returns second operand
+     */
+    public function getSecond()
+    {
+        ReflectionValue::fromValueEntry($this->op2)->getNativeValue($value);
+
+        return $value;
+    }
+
+    /**
+     * Returns result of casting (eg from call to proceed)
+     */
+    public function getResult()
+    {
+        ReflectionValue::fromValueEntry($this->returnValue)->getNativeValue($result);
+
+        return $result;
+    }
+
+    /**
+     * Proceeds with object custom operation
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+        $result = ($this->originalHandler)($this->opCode, $this->returnValue, $this->op1, $this->op2);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/Hook/GetPropertiesForHook.php
+++ b/src/ClassExtension/Hook/GetPropertiesForHook.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for casting to array, debugging, etc
+ */
+class GetPropertiesForHook extends AbstractHook
+{
+
+    protected const HOOK_FIELD = 'get_properties_for';
+
+    /**
+     * Object instance
+     */
+    protected CData $object;
+
+    /**
+     * Calling reason
+     *
+     * @see zend_prop_purpose enumeration
+     */
+    protected int $purpose;
+
+    /**
+     * zend_array *(*zend_object_get_properties_for_t)(zval *object, zend_prop_purpose purpose);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments)
+    {
+        [$this->object, $this->purpose] = $rawArguments;
+
+        $result   = ($this->userHandler)($this);
+        $refValue = new ReflectionValue($result);
+
+        return $refValue->getRawArray();
+    }
+
+    /**
+     * Returns an object instance
+     */
+    public function getObject(): object
+    {
+        ReflectionValue::fromValueEntry($this->object)->getNativeValue($objectInstance);
+
+        return $objectInstance;
+    }
+
+    /**
+     * Returns the purpose
+     */
+    public function getPurpose(): int
+    {
+        return $this->purpose;
+    }
+
+    /**
+     * Proceeds with default handler
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        $result = ($this->originalHandler)($this->object, $this->purpose);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/Hook/GetPropertyPointerHook.php
+++ b/src/ClassExtension/Hook/GetPropertyPointerHook.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for indirect property access (by reference or via $this->field++)
+ */
+class GetPropertyPointerHook extends AbstractHook
+{
+
+    protected const HOOK_FIELD = 'get_property_ptr_ptr';
+
+    /**
+     * Object instance
+     */
+    protected CData $object;
+
+    /**
+     * Member name
+     */
+    protected CData $member;
+
+    /**
+     * Hook access type
+     */
+    protected int $type;
+
+    /**
+     * Internal cache slot (for native callback only)
+     */
+    private ?CData $cacheSlot;
+
+    /**
+     * typedef zval *(*zend_object_get_property_ptr_ptr_t)(zval *object, zval *member, int type, void **cache_slot)
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments)
+    {
+        [$this->object, $this->member, $this->type, $this->cacheSlot] = $rawArguments;
+
+        $result = ($this->userHandler)($this);
+
+        return $result;
+    }
+
+    /**
+     * Returns an object instance
+     */
+    public function getObject(): object
+    {
+        ReflectionValue::fromValueEntry($this->object)->getNativeValue($objectInstance);
+
+        return $objectInstance;
+    }
+
+    /**
+     * Returns a member name
+     */
+    public function getMemberName(): string
+    {
+        ReflectionValue::fromValueEntry($this->member)->getNativeValue($memberName);
+
+        return $memberName;
+    }
+
+    /**
+     * Returns the access type
+     */
+    public function getAccessType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * Proceeds with default handler
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        $result = ($this->originalHandler)($this->object, $this->member, $this->type, $this->cacheSlot);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/Hook/InterfaceGetsImplementedHook.php
+++ b/src/ClassExtension/Hook/InterfaceGetsImplementedHook.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionClass;
+
+/**
+ * Receiving hook for interface implementation
+ */
+class InterfaceGetsImplementedHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'interface_gets_implemented';
+
+    /**
+     * Interface type that is implemented
+     */
+    protected CData $interfaceType;
+
+    /**
+     * Class that implements interface
+     */
+    protected CData $classType;
+
+    /**
+     * int (*interface_gets_implemented)(zend_class_entry *iface, zend_class_entry *class_type);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): int
+    {
+        [$this->interfaceType, $this->classType] = $rawArguments;
+
+        $result = ($this->userHandler)($this);
+
+        return $result;
+    }
+
+    /**
+     * Returns a class that implements interface
+     */
+    public function getClass(): ReflectionClass
+    {
+        return ReflectionClass::fromCData($this->classType);
+    }
+
+    /**
+     * Proceeds with default handler
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        $result = ($this->originalHandler)($this->interfaceType, $this->classType);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/Hook/ReadPropertyHook.php
+++ b/src/ClassExtension/Hook/ReadPropertyHook.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for object field read operation
+ */
+class ReadPropertyHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'read_property';
+
+    /**
+     * Object instance
+     */
+    protected CData $object;
+
+    /**
+     * Member name
+     */
+    protected CData $member;
+
+    /**
+     * Hook access type
+     */
+    protected int $type;
+
+    /**
+     * Internal cache slot (for native callback only)
+     */
+    private ?CData $cacheSlot;
+
+    /**
+     * Internal pointer of retval (for native callback only)
+     */
+    private ?CData $rv;
+
+    /**
+     * typedef zval *(*zend_object_read_property_t)(zval *object, zval *member, int type, void **cache_slot, zval *rv);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): CData
+    {
+        [$this->object, $this->member, $this->type, $this->cacheSlot, $this->rv] = $rawArguments;
+
+        $result   = ($this->userHandler)($this);
+        $refValue = new ReflectionValue($result);
+
+        return $refValue->getRawValue();
+    }
+
+    /**
+     * Returns an object instance
+     */
+    public function getObject(): object
+    {
+        ReflectionValue::fromValueEntry($this->object)->getNativeValue($objectInstance);
+
+        return $objectInstance;
+    }
+
+    /**
+     * Returns a member name
+     */
+    public function getMemberName(): string
+    {
+        ReflectionValue::fromValueEntry($this->member)->getNativeValue($memberName);
+
+        return $memberName;
+    }
+
+    /**
+     * Returns the access type
+     */
+    public function getAccessType(): int
+    {
+        return $this->type;
+    }
+
+    /**
+     * Proceeds with default handler
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        $result = ($this->originalHandler)($this->object, $this->member, $this->type, $this->cacheSlot, $this->rv);
+
+        ReflectionValue::fromValueEntry($result)->getNativeValue($phpResult);
+
+        return $phpResult;
+    }
+}

--- a/src/ClassExtension/Hook/WritePropertyHook.php
+++ b/src/ClassExtension/Hook/WritePropertyHook.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Receiving hook for object field write operation
+ */
+class WritePropertyHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'write_property';
+
+    /**
+     * Object instance
+     */
+    protected CData $object;
+
+    /**
+     * Member name
+     */
+    protected CData $member;
+
+    /**
+     * Value to write
+     */
+    protected CData $value;
+
+    /**
+     * Internal cache slot (for native callback only)
+     */
+    private ?CData $cacheSlot;
+
+    /**
+     * typedef zval *(*zend_object_write_property_t)(zval *object, zval *member, zval *value, void **cache_slot);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): CData
+    {
+        [$this->object, $this->member, $this->value, $this->cacheSlot] = $rawArguments;
+
+        $result = ($this->userHandler)($this);
+        ReflectionValue::fromValueEntry($this->value)->setNativeValue($result);
+
+        return $this->proceed();
+    }
+
+    /**
+     * Returns an object instance
+     */
+    public function getObject(): object
+    {
+        ReflectionValue::fromValueEntry($this->object)->getNativeValue($objectInstance);
+
+        return $objectInstance;
+    }
+
+    /**
+     * Returns a member name
+     */
+    public function getMemberName(): string
+    {
+        ReflectionValue::fromValueEntry($this->member)->getNativeValue($memberName);
+
+        return $memberName;
+    }
+
+    /**
+     * Returns value to write
+     */
+    public function getValue()
+    {
+        ReflectionValue::fromValueEntry($this->value)->getNativeValue($value);
+
+        return $value;
+    }
+
+    /**
+     * Returns value to write
+     *
+     * @param mixed $newValue Value to set
+     */
+    public function setValue($newValue)
+    {
+        ReflectionValue::fromValueEntry($this->value)->setNativeValue($newValue);
+    }
+
+    /**
+     * Proceeds with default handler
+     */
+    protected function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        $result = ($this->originalHandler)($this->object, $this->member, $this->value, $this->cacheSlot);
+
+        return $result;
+    }
+}

--- a/src/ClassExtension/ObjectCastInterface.php
+++ b/src/ClassExtension/ObjectCastInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace ZEngine\ClassExtension;
 
+use ZEngine\ClassExtension\Hook\CastObjectHook;
+
 /**
  * Interface ObjectCastInterface allows to cast given object to scalar values, like integer, floats, etc
  */
@@ -20,10 +22,9 @@ interface ObjectCastInterface
     /**
      * Performs casting of given object to another value
      *
-     * @param object $instance Instance of object that should be casted
-     * @param int $typeTo Type of casting, @see ReflectionValue::IS_* constants
+     * @param CastObjectHook $hook Instance of current hook
      *
      * @return mixed Casted value
      */
-    public static function __cast(object $instance, int $typeTo);
+    public static function __cast(CastObjectHook $hook);
 }

--- a/src/ClassExtension/ObjectCompareValuesInterface.php
+++ b/src/ClassExtension/ObjectCompareValuesInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace ZEngine\ClassExtension;
 
+use ZEngine\ClassExtension\Hook\CompareValuesHook;
+
 /**
  * Interface ObjectCompareValuesInterface allows to perform comparison of objects
  */
@@ -20,10 +22,9 @@ interface ObjectCompareValuesInterface
     /**
      * Performs comparison of given object with another value
      *
-     * @param mixed $one     First side of operation
-     * @param mixed $another Another side of operation
+     * @param CompareValuesHook $hook Instance of current hook
      *
      * @return int Result of comparison: 1 is greater, -1 is less, 0 is equal
      */
-    public static function __compare($one, $another): int;
+    public static function __compare(CompareValuesHook $hook): int;
 }

--- a/src/ClassExtension/ObjectCreateInterface.php
+++ b/src/ClassExtension/ObjectCreateInterface.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace ZEngine\ClassExtension;
 
-use Closure;
 use FFI\CData;
+use ZEngine\ClassExtension\Hook\CreateObjectHook;
 
 /**
  * Interface ObjectCreateInterface allows to hook into the object initialization process (eg new FooBar())
@@ -23,10 +23,9 @@ interface ObjectCreateInterface
     /**
      * Performs low-level initialization of object during new instances creation
      *
-     * @param CData   $classType Class type to initialize (zend_class_entry)
-     * @param Closure $initializer Original initializer that accepts a zend_class_entry and creates a new zend_object
+     * @param CreateObjectHook $hook Hook instance that provides proceed() and setClassType() method
      *
      * @return CData Pointer to the zend_object instance
      */
-    public static function __init(CData $classType, Closure $initializer): CData;
+    public static function __init(CreateObjectHook $hook): CData;
 }

--- a/src/ClassExtension/ObjectCreateTrait.php
+++ b/src/ClassExtension/ObjectCreateTrait.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace ZEngine\ClassExtension;
 
-use Closure;
 use FFI\CData;
+use ZEngine\ClassExtension\Hook\CreateObjectHook;
 
 /**
  * Trait ObjectCreateTrait contains default hook implementation for object initialization
@@ -23,13 +23,12 @@ trait ObjectCreateTrait
     /**
      * Performs low-level initialization of object during new instances creation
      *
-     * @param CData   $classType Class type to initialize (zend_class_entry)
-     * @param Closure $initializer Original initializer that accepts a zend_class_entry and creates a new zend_object
+     * @param CreateObjectHook $hook Hook instance that provides proceed() and setClassType() method
      *
      * @return CData Pointer to the zend_object instance
      */
-    public static function __init(CData $classType, Closure $initializer): CData
+    public static function __init(CreateObjectHook $hook): CData
     {
-        return $initializer($classType);
+        return $hook->proceed();
     }
 }

--- a/src/ClassExtension/ObjectDoOperationInterface.php
+++ b/src/ClassExtension/ObjectDoOperationInterface.php
@@ -12,19 +12,19 @@ declare(strict_types=1);
 
 namespace ZEngine\ClassExtension;
 
+use ZEngine\ClassExtension\Hook\DoOperationHook;
+
 /**
  * Interface ObjectDoOperationInterface allows to perform math operations (aka operator overloading) on object
  */
 interface ObjectDoOperationInterface
 {
     /**
-     * Performs casting of given object to another value
+     * Performs an operation on given object
      *
-     * @param int $opCode Operation code
-     * @param mixed $left left side of operation
-     * @param mixed $right Right side of operation
+     * @param DoOperationHook $hook Instance of current hook
      *
      * @return mixed Result of operation value
      */
-    public static function __doOperation(int $opCode, $left, $right);
+    public static function __doOperation(DoOperationHook $hook);
 }

--- a/src/ClassExtension/ObjectGetPropertiesForInterface.php
+++ b/src/ClassExtension/ObjectGetPropertiesForInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use ZEngine\ClassExtension\Hook\GetPropertiesForHook;
+
+/**
+ * Interface ObjectGetPropertiesForInterface allows to intercept casting to arrays, debug queries for object, etc
+ */
+interface ObjectGetPropertiesForInterface
+{
+    /**
+     * Returns a hash-map (array) representation of object (for casting to array, json encoding, var dumping)
+     *
+     * @param GetPropertiesForHook $hook Instance of current hook
+     *
+     * @return array Key-value pair of fields
+     */
+    public static function __getFields(GetPropertiesForHook $hook): array;
+}

--- a/src/ClassExtension/ObjectGetPropertyPointerInterface.php
+++ b/src/ClassExtension/ObjectGetPropertyPointerInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use ZEngine\ClassExtension\Hook\GetPropertyPointerHook;
+
+/**
+ * Interface ObjectGetPropertyPointerInterface allows to intercept creation of pointers to properties (indirect changes)
+ */
+interface ObjectGetPropertyPointerInterface
+{
+    /**
+     * Returns a pointer to an object's field
+     *
+     * @param GetPropertyPointerHook $hook Instance of current hook
+     *
+     * @return mixed Value to return
+     */
+    public static function __fieldPointer(GetPropertyPointerHook $hook);
+}

--- a/src/ClassExtension/ObjectReadPropertyInterface.php
+++ b/src/ClassExtension/ObjectReadPropertyInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use ZEngine\ClassExtension\Hook\ReadPropertyHook;
+
+/**
+ * Interface ObjectReadPropertyInterface allows to intercept property reads and modify values
+ */
+interface ObjectReadPropertyInterface
+{
+    /**
+     * Performs reading of object's field
+     *
+     * @param ReadPropertyHook $hook Instance of current hook
+     *
+     * @return mixed Value to return
+     */
+    public static function __fieldRead(ReadPropertyHook $hook);
+}

--- a/src/ClassExtension/ObjectWritePropertyInterface.php
+++ b/src/ClassExtension/ObjectWritePropertyInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use ZEngine\ClassExtension\Hook\WritePropertyHook;
+
+/**
+ * Interface ObjectWritePropertyInterface allows to intercept property writes and modify values
+ */
+interface ObjectWritePropertyInterface
+{
+    /**
+     * Performs writing of value to object's field
+     *
+     * @param WritePropertyHook $hook Instance of current hook
+     *
+     * @return mixed New value to write, return given $value if you don't want to adjust it
+     */
+    public static function __fieldWrite(WritePropertyHook $hook);
+}

--- a/src/Core.php
+++ b/src/Core.php
@@ -388,8 +388,6 @@ class Core
      */
     private static function preloadFrameworkClasses(): void
     {
-        $hasOpcache = function_exists('opcache_compile_file');
-
         $dir = new RecursiveDirectoryIterator(__DIR__, RecursiveDirectoryIterator::KEY_AS_PATHNAME);
 
         /** @var \SplFileInfo[] $iterator */
@@ -398,12 +396,8 @@ class Core
             if (!$fileInfo->isFile()) {
                 continue;
             }
-            $sourceFile = $fileInfo->getPathname();
-            if (!$hasOpcache) {
-                include_once $sourceFile;
-            } elseif (!opcache_is_script_cached($sourceFile)) {
-                opcache_compile_file($sourceFile);
-            }
+
+            include_once $fileInfo->getPathname();
         }
     }
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -12,15 +12,16 @@ declare(strict_types=1);
 
 namespace ZEngine;
 
+use Closure;
 use FFI;
 use FFI\CData;
 use FFI\CType;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use ZEngine\AbstractSyntaxTree\NodeFactory;
 use ZEngine\Macro\DefinitionLoader;
 use ZEngine\System\Compiler;
 use ZEngine\System\Executor;
+use ZEngine\System\Hook\AstProcessHook;
 
 /**
  * Class Core
@@ -373,14 +374,12 @@ class Core
     /**
      * Installs a hook for the `zend_ast_process` engine global callback
      *
-     * @param callable $callback function(NodeInterface $node): void callback
+     * @param Closure $handler function(NodeInterface $node): void callback
      */
-    public static function setASTProcessHandler(callable $callback): void
+    public static function setASTProcessHandler(Closure $handler): void
     {
-        self::$engine->zend_ast_process = function (CData $ast) use ($callback): void {
-            $node = NodeFactory::fromCData($ast);
-            $callback($node);
-        };
+        $hook = new AstProcessHook($handler, self::$engine);
+        $hook->install();
     }
 
     /**

--- a/src/Hook/AbstractHook.php
+++ b/src/Hook/AbstractHook.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Hook;
+
+use Closure;
+use FFI;
+use FFI\CData;
+
+/**
+ * AbstractHook provides reusable template for installing a hook in the PHP engine
+ */
+abstract class AbstractHook implements HookInterface
+{
+    /**
+     * This field should be updated in children class and accessed through LSB
+     */
+    protected const HOOK_FIELD = 'unknown';
+
+    /**
+     * Custom user handler
+     */
+    protected Closure $userHandler;
+
+    /**
+     * Holds an original handler (if present)
+     */
+    protected ?CData $originalHandler;
+
+    /**
+     * Contains a top-level structure that contains a field with hook
+     *
+     * @var CData|FFI Either raw C structure or global FFI object itself
+     */
+    private $rawStructure;
+
+    public function __construct(Closure $userHandler, $rawStructure)
+    {
+        assert($rawStructure instanceof FFI || $rawStructure instanceof CData, 'Invalid container');
+        $this->userHandler     = $userHandler;
+        $this->rawStructure    = $rawStructure;
+        $this->originalHandler = $rawStructure->{static::HOOK_FIELD};
+    }
+
+    /**
+     * Performs installation of current hook
+     *
+     * <span style="color:red; font-weight: bold">WARNING!</span>
+     * Please note, that this functionality is not supported on all libffi platforms, is not efficient and leaks
+     * resources by the end of request.
+     *
+     * @link https://www.php.net/manual/en/ffi.examples-callback.php
+     */
+    final public function install(): void
+    {
+        $this->rawStructure->{static::HOOK_FIELD} = Closure::fromCallable([$this, 'handle']);
+    }
+
+    /**
+     * Checks if an original handler is present to call it later with proceed
+     */
+    final public function hasOriginalHandler(): bool
+    {
+        return $this->originalHandler !== null;
+    }
+
+    /**
+     * Automatic hook restore, this destructor ensures that there won't be any dead C pointers to PHP structures
+     */
+    final public function __destruct()
+    {
+        $this->rawStructure->{static::HOOK_FIELD} = $this->originalHandler;
+    }
+
+    /**
+     * Internal CData fields could result in segfaults, so let's hide everything
+     */
+    final public function __debugInfo(): array
+    {
+        return [
+            'userHandler' => $this->userHandler
+        ];
+    }
+}

--- a/src/Hook/HookInterface.php
+++ b/src/Hook/HookInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Hook;
+
+interface HookInterface
+{
+    /**
+     * This method accepts raw C arguments for current hook and performs handling of this callback
+     *
+     * @param mixed ...$rawArguments
+     */
+    public function handle(...$rawArguments);
+
+    /**
+     * Performs installation of current hook
+     */
+    public function install(): void;
+
+    /**
+     * Checks if original handler is present to call it later with proceed
+     */
+    public function hasOriginalHandler(): bool;
+}

--- a/src/Reflection/ReflectionValue.php
+++ b/src/Reflection/ReflectionValue.php
@@ -118,17 +118,16 @@ class ReflectionValue implements ReferenceCountedInterface
     /**
      * ReflectionValue constructor.
      *
-     * @TODO: Stack frame is destroyed after call to the constructor, so information will be lost outside this scope
-     * @TODO: Temporary declared as private to find the way to extract original value
-     *
      * @param mixed $value Any value to be reflected
      */
-    private function __construct($value)
+    public function __construct($value)
     {
         // Trick here is to look at internal structures and steal pointer to our value from current frame
         $selfExecutionState = Core::$executor->getExecutionState();
         $valueEntry         = $selfExecutionState->getArgument(0);
-        $this->pointer      = $valueEntry->pointer;
+        $newEntry           = self::newEntry($valueEntry->getType(), $valueEntry->getRawValue()[0]);
+        $valueEntry->copy($newEntry->getRawValue());
+        $this->pointer = $newEntry->getRawValue();
     }
 
     /**

--- a/src/Reflection/ReflectionValue.php
+++ b/src/Reflection/ReflectionValue.php
@@ -271,6 +271,18 @@ class ReflectionValue implements ReferenceCountedInterface
     }
 
     /**
+     * Type-friendly getter to return zend_array directly
+     */
+    public function getRawArray(): CData
+    {
+        if ($this->pointer->u1->v->type !== self::IS_ARRAY) {
+            throw new \UnexpectedValueException('Array entry is available only for the type IS_ARRAY');
+        }
+
+        return $this->pointer->value->arr;
+    }
+
+    /**
      * Type-friendly getter to return zend_object directly
      */
     public function getRawObject(): CData

--- a/src/System/Hook/AstProcessHook.php
+++ b/src/System/Hook/AstProcessHook.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2020, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\System\Hook;
+
+use FFI\CData;
+use ZEngine\AbstractSyntaxTree\NodeFactory;
+use ZEngine\AbstractSyntaxTree\NodeInterface;
+use ZEngine\Hook\AbstractHook;
+
+/**
+ * Receiving hook for processing an AST
+ */
+class AstProcessHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'zend_ast_process';
+
+    /**
+     * Instance of top-level AST node
+     */
+    protected CData $ast;
+
+    /**
+     * typedef void (*zend_ast_process_t)(zend_ast *ast);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): void
+    {
+        [$this->ast] = $rawArguments;
+
+        ($this->userHandler)($this);
+    }
+
+    /**
+     * Returns a top-level node element
+     */
+    public function getAST(): NodeInterface
+    {
+        return NodeFactory::fromCData($this->ast);
+    }
+
+    /**
+     * Proceeds with default callback
+     */
+    public function proceed()
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+        ($this->originalHandler)($this->ast);
+    }
+}

--- a/tests/Reflection/ReflectionValueTest.php
+++ b/tests/Reflection/ReflectionValueTest.php
@@ -22,6 +22,17 @@ use ZEngine\Type\StringEntry;
 class ReflectionValueTest extends TestCase
 {
     /**
+     * @dataProvider valueTypeProvider
+     */
+    public function testConstructorWorks($value, int $expectedType)
+    {
+        $refValue = new ReflectionValue($value);
+        $type     = $refValue->getType() & 0xFF;
+
+        $this->assertSame($expectedType, $type);
+    }
+
+    /**
      * @dataProvider valueProvider
      */
     public function testGetNativeValue($value): void

--- a/tests/Stub/TestClass.php
+++ b/tests/Stub/TestClass.php
@@ -16,6 +16,8 @@ class TestClass
 {
     public const SOME_CONST = 123;
 
+    public int $property = 42;
+
     /**
      * This method will be removed during the test, do not call it or use it
      */


### PR DESCRIPTION
This PR refactors a lot of low-level code into more general and reusable `Hook` classes. Each hook is responsible for handling raw arguments from C callback, convert them to PHP representation, and provide methods to receive these values in user-defined callbacks.

`HookInterface` is declared as following:

```php
interface HookInterface
{
    /**
     * This method accepts raw C arguments for current hook and performs handling of this callback
     *
     * @param mixed ...$rawArguments
     */
    public function handle(...$rawArguments);

    /**
     * Performs installation of current hook
     */
    public function install(): void;

    /**
     * Checks if original handler is present to call it later with proceed
     */
    public function hasOriginalHandler(): bool;
}
```