### PR TITLE
[Fix] Resolve scope issues in native callbacks for properties

### DIFF
--- a/src/ClassExtension/Hook/GetPropertiesForHook.php
+++ b/src/ClassExtension/Hook/GetPropertiesForHook.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ZEngine\ClassExtension\Hook;
 
 use FFI\CData;
+use ZEngine\Core;
 use ZEngine\Hook\AbstractHook;
 use ZEngine\Reflection\ReflectionValue;
 
@@ -78,7 +79,15 @@ class GetPropertiesForHook extends AbstractHook
             throw new \LogicException('Original handler is not available');
         }
 
-        $result = ($this->originalHandler)($this->object, $this->purpose);
+        // As we will play with EG(fake_scope), we won't be able to access private or protected members, need to unpack
+        $originalHandler = $this->originalHandler;
+
+        $object  = $this->object;
+        $purpose = $this->purpose;
+
+        $previousScope = Core::$executor->setFakeScope($object->value->obj->ce);
+        $result        = ($originalHandler)($object, $purpose);
+        Core::$executor->setFakeScope($previousScope);
 
         return $result;
     }

--- a/src/ClassExtension/Hook/GetPropertyPointerHook.php
+++ b/src/ClassExtension/Hook/GetPropertyPointerHook.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace ZEngine\ClassExtension\Hook;
 
 use FFI\CData;
+use ZEngine\Core;
 use ZEngine\Hook\AbstractHook;
 use ZEngine\Reflection\ReflectionValue;
 
@@ -95,7 +96,17 @@ class GetPropertyPointerHook extends AbstractHook
             throw new \LogicException('Original handler is not available');
         }
 
-        $result = ($this->originalHandler)($this->object, $this->member, $this->type, $this->cacheSlot);
+        // As we will play with EG(fake_scope), we won't be able to access private or protected members, need to unpack
+        $originalHandler = $this->originalHandler;
+
+        $object    = $this->object;
+        $member    = $this->member;
+        $type      = $this->type;
+        $cacheSlot = $this->cacheSlot;
+
+        $previousScope = Core::$executor->setFakeScope($object->value->obj->ce);
+        $result        = ($originalHandler)($object, $member, $type, $cacheSlot);
+        Core::$executor->setFakeScope($previousScope);
 
         return $result;
     }

--- a/src/ClassExtension/Hook/WritePropertyHook.php
+++ b/src/ClassExtension/Hook/WritePropertyHook.php
@@ -108,7 +108,17 @@ class WritePropertyHook extends AbstractHook
             throw new \LogicException('Original handler is not available');
         }
 
-        $result = ($this->originalHandler)($this->object, $this->member, $this->value, $this->cacheSlot);
+        // As we will play with EG(fake_scope), we won't be able to access private or protected members, need to unpack
+        $originalHandler = $this->originalHandler;
+
+        $object    = $this->object;
+        $member    = $this->member;
+        $value     = $this->value;
+        $cacheSlot = $this->cacheSlot;
+
+        $previousScope = Core::$executor->setFakeScope($object->value->obj->ce);
+        $result        = ($originalHandler)($object, $member, $value, $cacheSlot);
+        Core::$executor->setFakeScope($previousScope);
 
         return $result;
     }

--- a/src/System/Executor.php
+++ b/src/System/Executor.php
@@ -63,4 +63,17 @@ class Executor
 
         return $executionState;
     }
+
+    /**
+     * Set a new fake scope and returns previous value (to restore it later)
+     *
+     * @return CData|null
+     */
+    public function setFakeScope(?CData $newScope): ?CData
+    {
+        $oldScope = $this->pointer->fake_scope;
+        $this->pointer->fake_scope = $newScope;
+
+        return $oldScope;
+    }
 }

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -294,13 +294,17 @@ class ReflectionClassTest extends TestCase
         $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
         $this->refClass->setCreateObjectHandler($handler);
         $this->refClass->setReadPropertyHandler(function (ReadPropertyHook $hook) {
-            // Return the name of field as value
-            return $hook->getMemberName();
+            $value = $hook->proceed();
+            return $value * 2;
         });
         $instance = new TestClass();
         $value    = $instance->property;
         $this->assertNotSame(42, $value);
-        $this->assertSame('property', $value);
+        $this->assertSame(42 * 2, $value);
+
+        // This check address https://github.com/lisachenko/z-engine/issues/32
+        $secret = $instance->tellSecret();
+        $this->assertSame(100500 * 2, $secret);
     }
 
     /**
@@ -318,6 +322,9 @@ class ReflectionClassTest extends TestCase
         $instance->property = 10;
         $this->assertNotSame(42, $instance->property);
         $this->assertSame(20, $instance->property);
+
+        // This check address https://github.com/lisachenko/z-engine/issues/32
+        $instance->setSecret(200);
     }
 
     /**

--- a/tests/Stub/TestClass.php
+++ b/tests/Stub/TestClass.php
@@ -18,6 +18,8 @@ class TestClass
 
     public int $property = 42;
 
+    private int $secret = 100500;
+
     /**
      * This method will be removed during the test, do not call it or use it
      */
@@ -30,5 +32,15 @@ class TestClass
     {
         // If we make this method static in runtime, then $this won't be passed to it
         return isset($this) ? get_class($this) : null;
+    }
+
+    public function setSecret(int $newSecret): void
+    {
+        $this->secret = $newSecret;
+    }
+
+    public function tellSecret(): int
+    {
+        return $this->secret;
     }
 }


### PR DESCRIPTION
This PR resolves #32 by manipulating `EG(fake_scope)` to change scope for native callback call.