### PR TITLE
Ignore inheritance of create_object handler for children non-internal classes

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -182,6 +182,9 @@ class Core
     public const ZEND_USER_FUNCTION =       2;
     public const ZEND_EVAL_CODE =           4;
 
+    public const ZEND_INTERNAL_CLASS = 1;
+    public const ZEND_USER_CLASS     = 2;
+
     /**
      * User opcode handler return values
      */

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -321,6 +321,16 @@ class ReflectionClass extends NativeReflectionClass
         return $refMethod;
     }
 
+    public function isInternal()
+    {
+        return ord($this->pointer->type) === Core::ZEND_INTERNAL_CLASS;
+    }
+
+    public function isUserDefined()
+    {
+        return ord($this->pointer->type) === Core::ZEND_USER_CLASS;
+    }
+
     /**
      * Removes given methods from the class
      *
@@ -837,8 +847,8 @@ class ReflectionClass extends NativeReflectionClass
     public function setCreateObjectHandler(Closure $handler): void
     {
         // User handlers are only allowed with std_object_handler (when create_object handler is empty)
-        if ($this->pointer->create_object !== null) {
-            throw new \LogicException("Create object handler is available for user-defined classes only");
+        if ($this->isInternal()) {
+            trigger_error("Create object handler is available for user-defined classes only", E_USER_ERROR);
         }
         self::allocateClassObjectHandlers($this->getName());
 


### PR DESCRIPTION
As create_object handler is copied from the parent class, we should ignore situations when we are trying to

extend a class that already has necessary create_object handler installed by Z-engine.
Only internal classes should be ignored as we can't allocate memory for them and to perform initialization