### PR TITLE
fix(reflection): wire orphaned ClassExtension interfaces into installExtensionHandlers()

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -741,6 +741,21 @@ class ReflectionClass extends NativeReflectionClass
             $handler = parent::getMethod('__fieldPointer')->getClosure();
             $this->setGetPropertyPointerHandler($handler);
         }
+
+        if ($this->implementsInterface(ObjectHasPropertyInterface::class)) {
+            $handler = parent::getMethod('__fieldIsset')->getClosure();
+            $this->setHasPropertyHandler($handler);
+        }
+
+        if ($this->implementsInterface(ObjectUnsetPropertyInterface::class)) {
+            $handler = parent::getMethod('__fieldUnset')->getClosure();
+            $this->setUnsetPropertyHandler($handler);
+        }
+
+        if ($this->implementsInterface(ObjectGetPropertiesForInterface::class)) {
+            $handler = parent::getMethod('__getFields')->getClosure();
+            $this->setGetPropertiesForHandler($handler);
+        }
     }
 
     public function __debugInfo()

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -33,6 +33,7 @@ use ZEngine\Core;
 use ZEngine\Stub\NativeNumber;
 use ZEngine\Stub\TestClass;
 use ZEngine\Stub\TestInterface;
+use ZEngine\Stub\TestPropertyHandlers;
 use ZEngine\Stub\TestTrait;
 use ZEngine\System\OpCode;
 
@@ -470,6 +471,56 @@ class ReflectionClassTest extends TestCase
         $this->markTestIncomplete('Initialization object handler brings segfaults thus run it separately');
     }
 
+
+    #[Group('internal')]
+    #[RunInSeparateProcess]
+    public function testInstallExtensionHandlersWiresHasProperty(): void
+    {
+        TestPropertyHandlers::$log = [];
+        $refClass                  = new ReflectionClass(TestPropertyHandlers::class);
+        $refClass->installExtensionHandlers();
+
+        $instance = new TestPropertyHandlers();
+        // The hook proceeds with the default behavior for the initialized property...
+        $this->assertTrue(isset($instance->property));
+        $this->assertContains('isset:property', TestPropertyHandlers::$log);
+        // ...but reports the null-valued "absent" field (invisible for the default
+        // handler) as existing, proving that the hook is installed
+        $this->assertTrue(isset($instance->absent));
+        $this->assertContains('isset:absent', TestPropertyHandlers::$log);
+    }
+
+    #[Group('internal')]
+    #[RunInSeparateProcess]
+    public function testInstallExtensionHandlersWiresUnsetProperty(): void
+    {
+        TestPropertyHandlers::$log = [];
+        $refClass                  = new ReflectionClass(TestPropertyHandlers::class);
+        $refClass->installExtensionHandlers();
+
+        $instance = new TestPropertyHandlers();
+        unset($instance->property);
+        // The hook swallows the unset, so the property should survive
+        $this->assertSame(42, $instance->property);
+        $this->assertContains('unset:property', TestPropertyHandlers::$log);
+    }
+
+    #[Group('internal')]
+    #[RunInSeparateProcess]
+    public function testInstallExtensionHandlersWiresGetPropertiesFor(): void
+    {
+        TestPropertyHandlers::$log = [];
+        $refClass                  = new ReflectionClass(TestPropertyHandlers::class);
+        $refClass->installExtensionHandlers();
+
+        $instance  = new TestPropertyHandlers();
+        $castValue = (array) $instance;
+
+        // The hook is called instead of the default handler, so no real fields are returned
+        $this->assertArrayNotHasKey('property', $castValue);
+        $this->assertSame(['a' => 1, 'b' => true, 'c' => 42.0], $castValue);
+        $this->assertContains('fields:' . TestPropertyHandlers::class, TestPropertyHandlers::$log);
+    }
 
     public function testInstallExtensionHandlers(): void
     {

--- a/tests/Stub/TestPropertyHandlers.php
+++ b/tests/Stub/TestPropertyHandlers.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use FFI\CData;
+use ZEngine\ClassExtension\Hook\CreateObjectHook;
+use ZEngine\ClassExtension\Hook\GetPropertiesForHook;
+use ZEngine\ClassExtension\Hook\HasPropertyHook;
+use ZEngine\ClassExtension\Hook\UnsetPropertyHook;
+use ZEngine\ClassExtension\ObjectCreateInterface;
+use ZEngine\ClassExtension\ObjectGetPropertiesForInterface;
+use ZEngine\ClassExtension\ObjectHasPropertyInterface;
+use ZEngine\ClassExtension\ObjectUnsetPropertyInterface;
+
+/**
+ * Stub class that declares the has_property/unset_property/get_properties_for hooks
+ * via the declarative ClassExtension interfaces (see installExtensionHandlers())
+ */
+class TestPropertyHandlers implements
+    ObjectCreateInterface,
+    ObjectGetPropertiesForInterface,
+    ObjectHasPropertyInterface,
+    ObjectUnsetPropertyInterface
+{
+    /**
+     * Trace of hook invocations, used by tests to assert that handlers were called
+     *
+     * @var list<string>
+     */
+    public static array $log = [];
+
+    public ?int $property = 42;
+
+    public ?int $absent = null;
+
+    /**
+     * Same behavior as ObjectCreateTrait::__init(), but typed strictly so that this
+     * stub stays clean at PHPStan level max without a baseline entry
+     *
+     * @inheritDoc
+     */
+    public static function __init(CreateObjectHook $hook): CData
+    {
+        $object = $hook->proceed();
+        if (!$object instanceof CData) {
+            throw new \UnexpectedValueException('Expected a zend_object pointer from the default create handler');
+        }
+
+        return $object;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function __fieldIsset(HasPropertyHook $hook): int
+    {
+        self::$log[] = 'isset:' . $hook->getMemberName();
+
+        // Report the (null-valued) "absent" field as existing to prove that the hook controls the result
+        if ($hook->getMemberName() === 'absent') {
+            return 1;
+        }
+
+        return $hook->proceed();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function __fieldUnset(UnsetPropertyHook $hook): void
+    {
+        // Swallow the unset (do not call proceed) to prove that the hook controls the result
+        self::$log[] = 'unset:' . $hook->getMemberName();
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return array<string, bool|float|int>
+     */
+    public static function __getFields(GetPropertiesForHook $hook): array
+    {
+        self::$log[] = 'fields:' . get_class($hook->getObject());
+
+        return ['a' => 1, 'b' => true, 'c' => 42.0];
+    }
+}


### PR DESCRIPTION
Fixes #65

## Summary

`ReflectionClass::installExtensionHandlers()` auto-wired only 7 of the 10 declarative `ZEngine\ClassExtension\*Interface` contracts. A class implementing `ObjectHasPropertyInterface`, `ObjectUnsetPropertyInterface` or `ObjectGetPropertiesForInterface` and calling `installExtensionHandlers()` silently got no handler installed.

This PR extends the interface→setter dispatch in `installExtensionHandlers()` with the three missing entries, following the exact pattern already used for `ObjectReadPropertyInterface`/`ObjectWritePropertyInterface`:

| Interface | Magic method | Setter |
|---|---|---|
| `ObjectHasPropertyInterface` | `__fieldIsset` | `setHasPropertyHandler()` |
| `ObjectUnsetPropertyInterface` | `__fieldUnset` | `setUnsetPropertyHandler()` |
| `ObjectGetPropertiesForInterface` | `__getFields` | `setGetPropertiesForHandler()` |

## Changes

- `src/Reflection/ReflectionClass.php` — three new dispatch blocks in `installExtensionHandlers()` (only file changed in `src/`, per the issue's implementation sketch; no new symbols, no header regeneration).
- `tests/Stub/TestPropertyHandlers.php` — new stub implementing `ObjectCreateInterface` + the three interfaces. Its `__init` mirrors `ObjectCreateTrait::__init()` but is typed strictly so the stub stays clean at PHPStan level max without a baseline entry.
- `tests/Reflection/ReflectionClassTest.php` — three new `#[Group('internal')]` + `#[RunInSeparateProcess]` tests, one per interface, each asserting end-to-end behavior after `installExtensionHandlers()`:
  - `isset($obj->property)` proceeds normally while a null-valued field is reported as existing by the hook (has_property);
  - `unset($obj->property)` is swallowed by the hook and the property survives (unset_property);
  - `(array) $obj` returns the hook-provided map instead of the real fields (get_properties_for).

## Test evidence

- `composer test` — OK, 158 tests, 2677 assertions (4 skipped / 4 incomplete, all pre-existing).
- `composer phpstan` — OK, no errors, **no new baseline entries**.
- `composer cs:check` — OK, 0 of 103 files need fixing.
- New internal tests (informational, run locally on the release build): `vendor/bin/phpunit --group internal --process-isolation --filter testInstallExtensionHandlersWires` — OK (3 tests, 9 assertions).
- Standalone smoke script (plain `php`, `Core::init()` bootstrap, `ZENGINE_STRICT_LAYOUT_CHECK=1`, not committed) output:

```
has_property: isset(property)=true isset(absent)=true
unset_property: property after unset=42
get_properties_for: (array)$obj={"a":1,"b":true,"c":42}
object(ZEngine\Stub\TestPropertyHandlers)#48 (3) {
  ["a"]=> int(1)
  ["b"]=> bool(true)
  ["c"]=> float(42)
}
hook log: isset:property, isset:absent, unset:property, fields:ZEngine\Stub\TestPropertyHandlers, fields:ZEngine\Stub\TestPropertyHandlers
SMOKE OK: all three interfaces are wired by installExtensionHandlers()
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_