### PR TITLE
feat(system): expose executor error, exception and runtime state

### DIFF
--- a/src/System/Executor.php
+++ b/src/System/Executor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ZEngine\System;
 
 use FFI\CData;
+use ZEngine\Core;
 use ZEngine\Reflection\ReflectionValue;
 use ZEngine\Type\HashTable;
 use ZEngine\Type\ObjectEntry;
@@ -76,5 +77,200 @@ class Executor
         $this->pointer->fake_scope = $newScope;
 
         return $oldScope;
+    }
+
+    /**
+     * Checks if the engine carries an exception in flight (EG(exception) != NULL)
+     *
+     * Memory contract: pure pointer comparison, no refcount changes.
+     */
+    public function hasException(): bool
+    {
+        return $this->pointer->exception !== null;
+    }
+
+    /**
+     * Returns the exception the engine currently carries in EG(exception), if any
+     *
+     * Memory contract (see docs/long-running.md): EG(exception) stays engine-owned. The
+     * zend_object pointer is wrapped with a BORROWED ObjectEntry behind a null guard (no
+     * addref on the engine slot), and materializing the returned Throwable takes a regular
+     * reference for the returned PHP variable only. The slot itself is left untouched, so
+     * a propagating exception keeps propagating exactly as before (refcount-neutral).
+     *
+     * The engine also parks non-Throwable sentinel objects in this slot (unwind-exit and
+     * graceful-exit markers); those are reported as null.
+     */
+    public function getCurrentException(): ?\Throwable
+    {
+        $exception = $this->pointer->exception;
+        if ($exception === null) {
+            return null;
+        }
+        \assert($exception instanceof CData);
+        $entry     = ObjectEntry::fromCData($exception);
+        $throwable = $entry->getNativeValue();
+
+        return $throwable instanceof \Throwable ? $throwable : null;
+    }
+
+    /**
+     * Returns the current error_reporting level (EG(error_reporting))
+     */
+    public function getErrorReporting(): int
+    {
+        $level = $this->pointer->error_reporting;
+        \assert(\is_int($level));
+
+        return $level;
+    }
+
+    /**
+     * Sets a new error_reporting level and returns the previous one, like error_reporting()
+     *
+     * Note: this writes the runtime EG(error_reporting) field directly, bypassing the INI
+     * subsystem - ini_get('error_reporting') will not observe the change, exactly as with
+     * an engine-level modification.
+     */
+    public function setErrorReporting(int $level): int
+    {
+        $previous = $this->getErrorReporting();
+
+        $this->pointer->error_reporting = $level;
+
+        return $previous;
+    }
+
+    /**
+     * Returns the user error handler installed via set_error_handler(), or null if none is set
+     *
+     * Memory contract: EG(user_error_handler) is an engine-owned embedded zval; it is read
+     * through a BORROWED ReflectionValue view and materialized into a PHP callable that
+     * holds its own reference. The engine slot is left untouched (refcount-neutral).
+     */
+    public function getUserErrorHandler(): ?callable
+    {
+        $handlerValue = $this->pointer->user_error_handler;
+        \assert($handlerValue instanceof CData);
+
+        return $this->materializeHandler($handlerValue);
+    }
+
+    /**
+     * Returns the user exception handler installed via set_exception_handler(), or null if none is set
+     *
+     * Memory contract: same BORROWED, refcount-neutral read as getUserErrorHandler().
+     */
+    public function getUserExceptionHandler(): ?callable
+    {
+        $handlerValue = $this->pointer->user_exception_handler;
+        \assert($handlerValue instanceof CData);
+
+        return $this->materializeHandler($handlerValue);
+    }
+
+    /**
+     * Returns the process exit status (EG(exit_status)), the code exit() was called with
+     */
+    public function getExitStatus(): int
+    {
+        $exitStatus = $this->pointer->exit_status;
+        \assert(\is_int($exitStatus));
+
+        return $exitStatus;
+    }
+
+    /**
+     * Returns the float-to-string conversion precision (EG(precision), the "precision" ini)
+     */
+    public function getPrecision(): int
+    {
+        $precision = $this->pointer->precision;
+        \assert(\is_int($precision));
+
+        return $precision;
+    }
+
+    /**
+     * Returns the script timeout in seconds (EG(timeout_seconds), the "max_execution_time" ini)
+     */
+    public function getTimeoutSeconds(): int
+    {
+        $timeoutSeconds = $this->pointer->timeout_seconds;
+        \assert(\is_int($timeoutSeconds));
+
+        return $timeoutSeconds;
+    }
+
+    /**
+     * Checks if the engine has hit the execution timeout (EG(timed_out))
+     *
+     * The underlying field is a zend_atomic_bool written by the timeout signal handler;
+     * this accessor is strictly read-only.
+     */
+    public function isTimedOut(): bool
+    {
+        $timedOut = $this->pointer->timed_out;
+        \assert($timedOut instanceof CData);
+        // FFI surfaces the atomic _Bool storage as an integer scalar
+        $value = $timedOut->value;
+        \assert(\is_int($value) || \is_bool($value));
+
+        return (bool) $value;
+    }
+
+    /**
+     * Returns the global symbol table (EG(symbol_table)) - the true global variable scope
+     *
+     * Memory contract (see docs/long-running.md): EG(symbol_table) is a zend_array value
+     * embedded into executor globals, so its address is taken to build the wrapper. The
+     * returned HashTable is a BORROWED view over engine-owned storage: no ownership is
+     * transferred, nothing on the PHP side may destroy it, and it stays valid for the
+     * whole request lifetime.
+     *
+     * @return HashTable&iterable<int|string|null, ReflectionValue>
+     */
+    public function getGlobalSymbolTable(): HashTable
+    {
+        $symbolTable = $this->pointer->symbol_table;
+        \assert($symbolTable instanceof CData);
+
+        return new HashTable(Core::addr($symbolTable));
+    }
+
+    /**
+     * Returns the table of included/required files (EG(included_files)), keyed by realpath
+     *
+     * Memory contract (see docs/long-running.md): EG(included_files) is a HashTable value
+     * embedded into executor globals, so its address is taken to build the wrapper. The
+     * returned HashTable is a BORROWED view over engine-owned storage: no ownership is
+     * transferred and nothing on the PHP side may destroy it.
+     *
+     * @return HashTable&iterable<int|string|null, ReflectionValue>
+     */
+    public function getIncludedFiles(): HashTable
+    {
+        $includedFiles = $this->pointer->included_files;
+        \assert($includedFiles instanceof CData);
+
+        return new HashTable(Core::addr($includedFiles));
+    }
+
+    /**
+     * Materializes a user handler slot (an engine-owned embedded zval) into a PHP callable
+     *
+     * Memory contract: the slot is read through a BORROWED ReflectionValue view; an unset
+     * handler (IS_UNDEF) yields null, otherwise the returned callable holds its own regular
+     * reference while the engine slot stays untouched (refcount-neutral).
+     */
+    private function materializeHandler(CData $handlerValue): ?callable
+    {
+        $reflectionValue = ReflectionValue::fromValueEntry($handlerValue);
+        if ($reflectionValue->getType() === ReflectionValue::IS_UNDEF) {
+            return null;
+        }
+        $reflectionValue->getNativeValue($handler);
+
+        return \is_callable($handler) ? $handler : null;
     }
 }

--- a/tests/System/ExecutorTest.php
+++ b/tests/System/ExecutorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\System;
+
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Type\HashTable;
+
+class ExecutorTest extends TestCase
+{
+    public function testGetErrorReportingMatchesNativeFunction(): void
+    {
+        $this->assertSame(error_reporting(), Core::$executor->getErrorReporting());
+    }
+
+    public function testSetErrorReportingRoundTrip(): void
+    {
+        $original = error_reporting();
+        try {
+            $previous = Core::$executor->setErrorReporting(E_ERROR);
+            $this->assertSame($original, $previous, 'Previous level should be returned');
+            $this->assertSame(E_ERROR, Core::$executor->getErrorReporting());
+            // The native function reads EG(error_reporting) directly, so it observes the change
+            $this->assertSame(E_ERROR, error_reporting());
+
+            $restored = Core::$executor->setErrorReporting($previous);
+            $this->assertSame(E_ERROR, $restored);
+            $this->assertSame($original, Core::$executor->getErrorReporting());
+        } finally {
+            error_reporting($original);
+        }
+        $this->assertSame($original, error_reporting());
+    }
+
+    public function testHasExceptionIsFalseDuringNormalExecution(): void
+    {
+        $this->assertFalse(Core::$executor->hasException());
+    }
+
+    /**
+     * Only the null path is testable from userland: the engine never executes PHP code
+     * while EG(exception) is set (zend_call_function refuses with a pending exception and
+     * destructors run under zend_exception_save), so a live-exception assertion would
+     * require C-level instrumentation.
+     */
+    public function testGetCurrentExceptionIsNullDuringNormalExecution(): void
+    {
+        $this->assertNull(Core::$executor->getCurrentException());
+    }
+
+    public function testGetUserErrorHandlerReturnsInstalledHandler(): void
+    {
+        $handler = static function (int $code, string $message): bool {
+            return false;
+        };
+        set_error_handler($handler);
+        try {
+            $this->assertSame($handler, Core::$executor->getUserErrorHandler());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    public function testGetUserExceptionHandlerReturnsInstalledHandlerOrNull(): void
+    {
+        // Uninstall any current handler first to check the IS_UNDEF path deterministically
+        $previous = set_exception_handler(null);
+        try {
+            $this->assertNull(Core::$executor->getUserExceptionHandler());
+
+            $handler = static function (\Throwable $exception): void {};
+            set_exception_handler($handler);
+            $this->assertSame($handler, Core::$executor->getUserExceptionHandler());
+        } finally {
+            set_exception_handler($previous);
+        }
+    }
+
+    public function testGetExitStatusIsZeroWhileRunning(): void
+    {
+        $this->assertSame(0, Core::$executor->getExitStatus());
+    }
+
+    public function testGetPrecisionMatchesIniSetting(): void
+    {
+        $this->assertSame((int) ini_get('precision'), Core::$executor->getPrecision());
+    }
+
+    public function testGetTimeoutSecondsMatchesMaxExecutionTime(): void
+    {
+        $this->assertSame((int) ini_get('max_execution_time'), Core::$executor->getTimeoutSeconds());
+    }
+
+    public function testIsTimedOutIsFalseWhileRunning(): void
+    {
+        $this->assertFalse(Core::$executor->isTimedOut());
+    }
+
+    public function testGetGlobalSymbolTableSeesGlobalVariables(): void
+    {
+        $GLOBALS['zEngineExecutorTestGlobal'] = 'global-scope-value';
+        try {
+            $symbolTable = Core::$executor->getGlobalSymbolTable();
+            $this->assertInstanceOf(HashTable::class, $symbolTable);
+
+            $entry = $symbolTable->find('zEngineExecutorTestGlobal');
+            $this->assertNotNull($entry, 'Global variable should be present in EG(symbol_table)');
+            $entry->getNativeValue($value);
+            $this->assertSame('global-scope-value', $value);
+        } finally {
+            unset($GLOBALS['zEngineExecutorTestGlobal']);
+        }
+        $this->assertNull(Core::$executor->getGlobalSymbolTable()->find('zEngineExecutorTestGlobal'));
+    }
+
+    public function testGetIncludedFilesContainsThisTestFile(): void
+    {
+        $includedFiles = [];
+        foreach (Core::$executor->getIncludedFiles() as $fileName => $unused) {
+            $includedFiles[] = $fileName;
+        }
+        $this->assertContains(__FILE__, $includedFiles);
+        $this->assertNotEmpty($includedFiles);
+    }
+}


### PR DESCRIPTION
Fixes #68

## Summary

Adds read-mostly accessors over `zend_executor_globals` to `ZEngine\System\Executor`, all backed by fields already declared in the generated `engine.h` (no header regeneration, `include/` untouched):

| Accessor | Engine field | Notes |
|---|---|---|
| `hasException(): bool` | `EG(exception)` | pure pointer comparison, no refcount changes |
| `getCurrentException(): ?\Throwable` | `EG(exception)` | null-guarded borrowed `ObjectEntry` wrap, refcount-neutral on the slot; non-Throwable engine sentinels (unwind/graceful-exit markers) reported as `null` |
| `getErrorReporting(): int` / `setErrorReporting(int): int` | `EG(error_reporting)` | setter returns the previous level; the native `error_reporting()` observes the change (verified in tests) |
| `getUserErrorHandler(): ?callable` / `getUserExceptionHandler(): ?callable` | `EG(user_error_handler)` / `EG(user_exception_handler)` | borrowed `ReflectionValue` view over the embedded zvals, `null` when `IS_UNDEF`, materialized callable holds its own reference |
| `getExitStatus(): int`, `getPrecision(): int`, `getTimeoutSeconds(): int`, `isTimedOut(): bool` | `EG(exit_status)`, `EG(precision)`, `EG(timeout_seconds)`, `EG(timed_out)` | read-only; `timed_out` is the `zend_atomic_bool` |
| `getGlobalSymbolTable(): HashTable` / `getIncludedFiles(): HashTable` | `EG(symbol_table)` / `EG(included_files)` | embedded values, address taken; documented as BORROWED views with no ownership transfer per `docs/long-running.md` |

Every accessor carries a memory-contract docblock following the `docs/long-running.md` conventions. New code is clean at phpstan level max with **no new baseline entries** (mixed CData reads are narrowed via `assert()` instead).

## Live-exception test: why only the null path

The issue asks for a `#[Group('internal')]` test observing a live `EG(exception)`. This turned out to be **not feasible from userland, even with the hook machinery**:

- `zend_call_function` refuses to run any callable while `EG(exception)` is set ("we would result in an unstable executor otherwise") — and FFI callback trampolines (the basis of all z-engine hooks) go through `zend_call_function` too;
- destructors running during stack unwinding execute under `zend_exception_save()`/`zend_exception_restore()`, so `EG(exception)` is `NULL` inside them — **verified empirically** with a destructor probe firing during unwinding of a throwing frame: it observed `hasException() === false`;
- writing `EG(exception)` directly from a test would make the VM dispatch `HANDLE_EXCEPTION` with a stale `EG(opline_before_exception)` at the next exception check — a segfault, not a test.

So per the ticket's fallback, `getCurrentException()`/`hasException()` are covered on the null path in the default suite, and the wrapping logic itself is exercised by the accessor implementation shared with the guarded `ObjectEntry` path. A true live-path test needs C-level instrumentation (e.g. a probe extension) and is deferred.

## Test evidence

New `tests/System/ExecutorTest.php` (12 tests, 22 assertions, default suite): error_reporting match + round-trip/restore, exception null paths, user error/exception handler identity + `IS_UNDEF` path, exit status 0, precision vs ini, timeout seconds vs `max_execution_time`, `isTimedOut()` false, global symbol table sees (and stops seeing) a test-created global, included files contains the test file.

Gates on PHP 8.4.19 NTS:

```
composer test      OK — 170 tests, 2700 assertions (4 skipped / 4 incomplete pre-existing)
composer phpstan   [OK] No errors (no new baseline entries)
composer cs:check  0 of 103 files need fixing
```

Standalone smoke script (not committed) exercised every accessor against a plain `php` run: all values matched native counterparts, including `error_reporting()` observing `setErrorReporting()` and `$GLOBALS` visibility through `getGlobalSymbolTable()`.

Regarding the follow-up comment on the issue: mutation operations (`setCurrentException()`, `zend_clear_exception`) are deliberately left to the constant-table ticket as the issue body states, since clearing an exception safely needs the engine function (header regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_