### PR TITLE
feat(system): expose compiler globals accessors

### DIFF
--- a/src/System/Compiler.php
+++ b/src/System/Compiler.php
@@ -18,6 +18,7 @@ use ZEngine\AbstractSyntaxTree\AstOwnership;
 use ZEngine\AbstractSyntaxTree\NodeFactory;
 use ZEngine\AbstractSyntaxTree\NodeInterface;
 use ZEngine\Core;
+use ZEngine\Reflection\ReflectionClass;
 use ZEngine\Reflection\ReflectionValue;
 use ZEngine\Type\HashTable;
 use ZEngine\Type\StringEntry;
@@ -167,6 +168,98 @@ class Compiler
     public function setOptions(int $newOptions): void
     {
         $this->pointer->compiler_options = $newOptions;
+    }
+
+    /**
+     * Returns the class entry which is being compiled at the moment, or null outside class compilation
+     *
+     * Memory notes: the returned wrapper is a BORROWED view over CG(active_class_entry) (no addref,
+     * no ownership) - the engine resets the pointer once the class body compilation finishes, so use
+     * the value only while compilation of that class is still in progress (e.g. inside compiler hooks).
+     */
+    public function getActiveClassEntry(): ?ReflectionClass
+    {
+        $activeClassEntry = $this->pointer->active_class_entry;
+        if ($activeClassEntry === null) {
+            return null;
+        }
+        assert($activeClassEntry instanceof CData);
+
+        return ReflectionClass::fromCData($activeClassEntry);
+    }
+
+    /**
+     * Returns the op_array which is being compiled at the moment, or null outside compilation
+     *
+     * Memory notes: the returned `zend_op_array*` is a raw BORROWED engine pointer (no ownership) -
+     * it is only valid while the engine compiles that op_array, do not store it beyond the current
+     * compilation (e.g. beyond the `zend_ast_process` callback it was observed in).
+     */
+    public function getActiveOpArray(): ?CData
+    {
+        $activeOpArray = $this->pointer->active_op_array;
+        assert($activeOpArray === null || $activeOpArray instanceof CData);
+
+        return $activeOpArray;
+    }
+
+    /**
+     * Returns the line number which is compiled at the moment, aka CG(zend_lineno)
+     */
+    public function getCurrentLineNumber(): int
+    {
+        $lineNumber = $this->pointer->zend_lineno;
+        assert(is_int($lineNumber));
+
+        return $lineNumber;
+    }
+
+    /**
+     * Returns the hashtable with all registered auto-globals (_SERVER, GLOBALS, etc), aka CG(auto_globals)
+     *
+     * Memory notes: the wrapper is a BORROWED view over the engine-owned CG(auto_globals) table
+     * (no addref, no ownership). Values in this table are raw `zend_auto_global*` pointers, not
+     * ordinary zvals - inspect keys only, do not read them as native PHP values.
+     *
+     * @return HashTable|ReflectionValue[]
+     */
+    public function getAutoGlobals(): HashTable
+    {
+        $autoGlobals = $this->pointer->auto_globals;
+        assert($autoGlobals instanceof CData);
+
+        return new HashTable($autoGlobals);
+    }
+
+    /**
+     * Returns extra flags that will be applied to the next compiled function, aka CG(extra_fn_flags)
+     */
+    public function getExtraFnFlags(): int
+    {
+        $extraFnFlags = $this->pointer->extra_fn_flags;
+        assert(is_int($extraFnFlags));
+
+        return $extraFnFlags;
+    }
+
+    /**
+     * Configures extra flags (ZEND_ACC_xxx) that will be applied to the next compiled function
+     *
+     * This is an engine-documented pattern: for example, the engine itself uses it to mark
+     * fake closures and generators. The engine resets the value during compilation, so set
+     * it right before the compilation it should affect and restore the previous value after.
+     *
+     * @param int $flags New set of extra function flags
+     *
+     * @return int Previous value of CG(extra_fn_flags)
+     */
+    public function setExtraFnFlags(int $flags): int
+    {
+        $previousFlags = $this->getExtraFnFlags();
+
+        $this->pointer->extra_fn_flags = $flags;
+
+        return $previousFlags;
     }
 
     /**

--- a/tests/System/CompilerTest.php
+++ b/tests/System/CompilerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\System;
+
+use FFI\CData;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\System\Hook\AstProcessHook;
+
+class CompilerTest extends TestCase
+{
+    public function testGetCurrentLineNumberOutsideCompilation(): void
+    {
+        $lineNumber = Core::$compiler->getCurrentLineNumber();
+
+        // Outside of compilation CG(zend_lineno) just holds the last recorded value
+        $this->assertGreaterThanOrEqual(0, $lineNumber);
+    }
+
+    public function testGetAutoGlobalsContainsKnownAutoGlobals(): void
+    {
+        $autoGlobals = Core::$compiler->getAutoGlobals();
+
+        // Values in this table are raw zend_auto_global* pointers, only keys are inspected
+        $this->assertNotNull($autoGlobals->find('_SERVER'), 'CG(auto_globals) must contain _SERVER');
+        $this->assertNotNull($autoGlobals->find('GLOBALS'), 'CG(auto_globals) must contain GLOBALS');
+    }
+
+    public function testExtraFnFlagsRoundTrip(): void
+    {
+        $originalFlags = Core::$compiler->getExtraFnFlags();
+
+        $newFlags = $originalFlags | Core::ZEND_ACC_GENERATOR;
+        try {
+            $previousFlags = Core::$compiler->setExtraFnFlags($newFlags);
+            $this->assertSame($originalFlags, $previousFlags);
+            $this->assertSame($newFlags, Core::$compiler->getExtraFnFlags());
+
+            $this->assertSame($newFlags, Core::$compiler->setExtraFnFlags($originalFlags));
+        } finally {
+            Core::$compiler->setExtraFnFlags($originalFlags);
+        }
+        $this->assertSame($originalFlags, Core::$compiler->getExtraFnFlags());
+    }
+
+    public function testGetActiveClassEntryIsNullOutsideCompilation(): void
+    {
+        $this->assertNull(Core::$compiler->getActiveClassEntry());
+    }
+
+    public function testGetActiveOpArrayIsNullOutsideCompilation(): void
+    {
+        $this->assertNull(Core::$compiler->getActiveOpArray());
+    }
+
+    /**
+     * CG(active_op_array) must be observable while the engine compiles code: the
+     * `zend_ast_process` callback runs after the engine has allocated the op_array
+     * of the compile unit, but BEFORE zend_compile_top_stmt() walks the AST - so
+     * CG(active_class_entry) is intentionally still NULL at that point (it is only
+     * set while the class statement itself is being compiled).
+     */
+    #[Group('internal')]
+    #[RunInSeparateProcess]
+    public function testCompilationStateIsObservableFromAstProcessHook(): void
+    {
+        $hookFired     = false;
+        $inCompilation = null;
+        $hasOpArray    = null;
+        $lineNumber    = null;
+        $activeClass   = null;
+
+        $hook = Core::setASTProcessHandler(
+            function (AstProcessHook $hook) use (&$hookFired, &$inCompilation, &$hasOpArray, &$lineNumber, &$activeClass): void {
+                $compiler = Core::$compiler;
+                // Only scalar observations escape the hook: the op_array pointer is
+                // borrowed and valid only while this compilation is running
+                $hookFired     = true;
+                $inCompilation = $compiler->isInCompilation();
+                $hasOpArray    = $compiler->getActiveOpArray() instanceof CData;
+                $lineNumber    = $compiler->getCurrentLineNumber();
+                $activeClass   = $compiler->getActiveClassEntry();
+            },
+        );
+
+        try {
+            eval('class CompilerTestAstProbe { public function hello(): string { return "hi"; } }');
+        } finally {
+            $hook->uninstall();
+        }
+
+        $this->assertTrue(class_exists('CompilerTestAstProbe', false));
+        $this->assertTrue($hookFired, 'The zend_ast_process hook must fire during eval()');
+        $this->assertTrue($inCompilation);
+        $this->assertTrue($hasOpArray, 'CG(active_op_array) must be set during compilation');
+        $this->assertNotNull($lineNumber);
+        $this->assertGreaterThanOrEqual(1, $lineNumber);
+        // zend_ast_process fires before class statements are compiled, see the docblock
+        $this->assertNull($activeClass);
+
+        // Compilation is over: the engine has restored both pointers
+        $this->assertNull(Core::$compiler->getActiveOpArray());
+        $this->assertNull(Core::$compiler->getActiveClassEntry());
+    }
+
+    /**
+     * The non-null branch of getActiveClassEntry(): point CG(active_class_entry) at a
+     * real engine-owned zend_class_entry and read it back through the accessor. Mutates
+     * raw engine globals, hence the internal group + process isolation.
+     */
+    #[Group('internal')]
+    #[RunInSeparateProcess]
+    public function testGetActiveClassEntryWrapsEngineClassEntry(): void
+    {
+        $classEntryValue = Core::$executor->classTable->find(strtolower(\ArrayObject::class));
+        $this->assertNotNull($classEntryValue);
+        $classEntry = $classEntryValue->getRawClass();
+
+        $pointerProperty = new \ReflectionProperty(Compiler::class, 'pointer');
+        $compilerGlobals = $pointerProperty->getValue(Core::$compiler);
+        assert($compilerGlobals instanceof CData);
+
+        // While CG(active_class_entry) is set the engine believes it is compiling that
+        // class, so NOTHING may be compiled (no autoloading, hence no PHPUnit assertions)
+        // until the pointer is restored - only capture values inside this window
+        try {
+            $compilerGlobals->active_class_entry = $classEntry;
+
+            $activeClass     = Core::$compiler->getActiveClassEntry();
+            $activeClassName = $activeClass?->getName();
+        } finally {
+            $compilerGlobals->active_class_entry = null;
+        }
+
+        $this->assertNotNull($activeClass);
+        $this->assertSame(\ArrayObject::class, $activeClassName);
+        $this->assertNull(Core::$compiler->getActiveClassEntry());
+    }
+}


### PR DESCRIPTION
Fixes #70

## Summary

Adds the six `_zend_compiler_globals` accessors to `ZEngine\System\Compiler` (struct declared in `engine.h:697-746`, no header changes):

| Method | Field | Semantics |
|---|---|---|
| `getActiveClassEntry(): ?ReflectionClass` | `CG(active_class_entry)` | borrowed, `null` outside class compilation, wrapped via `ReflectionClass::fromCData()` |
| `getActiveOpArray(): ?CData` | `CG(active_op_array)` | raw borrowed `zend_op_array*`, `null` outside compilation (typed wrapper is a follow-up) |
| `getCurrentLineNumber(): int` | `CG(zend_lineno)` | plain read |
| `getAutoGlobals(): HashTable` | `CG(auto_globals)` | borrowed view; values are raw `zend_auto_global*`, keys-only inspection documented |
| `getExtraFnFlags(): int` | `CG(extra_fn_flags)` | plain read |
| `setExtraFnFlags(int $flags): int` | `CG(extra_fn_flags)` | returns the previous value |

Every accessor carries a memory-contract docblock (borrowed pointers, no ownership, validity window) following the `docs/long-running.md` conventions. New code is clean at PHPStan level max — no baseline additions (narrowing uses the `assert()` pattern already established in `Hook\AbstractHook`).

## Tests

Default suite (`tests/System/CompilerTest.php`):
- `getCurrentLineNumber()` returns an int outside compilation
- `getAutoGlobals()` contains `_SERVER` and `GLOBALS`
- `getExtraFnFlags()`/`setExtraFnFlags()` round-trip with restore (previous value returned)
- `getActiveClassEntry()`/`getActiveOpArray()` are `null` outside compilation

`#[Group('internal')]` + `#[RunInSeparateProcess]`:
- `testCompilationStateIsObservableFromAstProcessHook` — `Core::setASTProcessHandler()` + `eval` of a class declaration observes `isInCompilation() === true`, a non-null `CG(active_op_array)` CData and a sane line number during compilation, and both pointers `null` afterwards.
- `testGetActiveClassEntryWrapsEngineClassEntry` — exercises the non-null `getActiveClassEntry()` branch by pointing `CG(active_class_entry)` at the engine-owned `ArrayObject` class entry and reading it back through the accessor (restored in `finally`).

### What the AST-process route can and cannot observe (as anticipated in the issue)

`zend_ast_process` fires after the engine has allocated the compile unit's op_array (`CG(active_op_array)` set) but **before** `zend_compile_top_stmt()` walks the AST, so `CG(active_class_entry)` is by design still `NULL` at that point — verified empirically and asserted in the test with an explanatory docblock. The populated `active_class_entry` state only exists while the class statement itself is being compiled, which no public hook currently reaches; the pointer-injection test covers the accessor's non-null branch instead.

Debugging note: while `CG(active_class_entry)` is artificially set, nothing may be compiled — PHPUnit's lazy autoloading of constraint classes inside that window crashed the child process until the test was restructured to capture values first and assert after restoring the pointer (documented in the test).

## Gate results

- `composer test` — OK, 163 tests, 2688 assertions (4 skipped / 4 incomplete, pre-existing)
- `composer test:internal` — OK, 31 tests (both new internal tests pass under process isolation on the release build)
- `composer phpstan` — no errors, no new baseline entries
- `composer cs:check` — clean

Standalone smoke script (not committed) output:

```
int(0)            // getCurrentLineNumber() outside compilation
NULL              // getActiveClassEntry() outside compilation
NULL              // getActiveOpArray() outside compilation
int(0)            // getExtraFnFlags()
auto_global _SERVER: present
auto_global GLOBALS: present
auto_global _GET: present
auto_global _ENV: present
previous flags: 0, now: 8388608
restored flags: 0
during compilation: in_compilation=true, op_array=CData, class_entry=NULL, lineno=1
after compilation: op_array=NULL, class_entry=NULL
class exists: true
wrapped active class: ArrayObject
after restore: NULL
SMOKE OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_