### PR TITLE
feat(reflection): expose raw backed-enum table on ReflectionClass

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -361,6 +361,44 @@ class ReflectionClass extends NativeReflectionClass
     }
 
     /**
+     * Returns the raw backed-enum table of a backed enum (backing value => case name)
+     *
+     * The engine stores one entry per case: the key is the case backing value (a string
+     * key for string-backed enums, an integer key for int-backed enums) and the value is
+     * an IS_STRING zval holding the case name, exactly as zend_enum.c stored it.
+     *
+     * The engine materializes this table lazily: until the first Enum::from()/tryFrom()
+     * call on the enum, ce->backed_enum_table stays NULL and this method returns null.
+     * This is a raw read - it never triggers the materialization itself.
+     *
+     * Memory ownership contract (see docs/long-running.md): the returned HashTable is a
+     * BORROWED view over the engine-owned ce->backed_enum_table - no addref is taken and
+     * no ownership is transferred. The view and every ReflectionValue read from it stay
+     * valid only while the class entry is alive; reading never changes refcounts, and
+     * nothing on the PHP side may release the table or its buckets.
+     *
+     * @see zend_enum.c:zend_enum_build_backed_enum_table() for the table layout and laziness
+     *
+     * @return (HashTable&iterable<int|string|null, ReflectionValue>)|null Borrowed table for backed enums
+     *         (once materialized), null for pure enums, non-enum classes and unmaterialized tables
+     */
+    public function getBackedEnumTable(): ?HashTable
+    {
+        $ceFlags = $this->pointer->ce_flags;
+        if (!\is_int($ceFlags) || ($ceFlags & Core::ZEND_ACC_ENUM) === 0) {
+            return null;
+        }
+
+        // Pure enums have no backing values: the engine leaves the table pointer NULL
+        $rawTable = $this->pointer->backed_enum_table;
+        if (!$rawTable instanceof CData) {
+            return null;
+        }
+
+        return new HashTable($rawTable);
+    }
+
+    /**
      * Removes given methods from the class
      *
      * @param string ...$methodNames Name of methods to remove

--- a/tests/Reflection/ReflectionClassEnumTest.php
+++ b/tests/Reflection/ReflectionClassEnumTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Reflection;
+
+use PHPUnit\Framework\TestCase;
+use ZEngine\Stub\TestClass;
+use ZEngine\Stub\TestIntBackedEnum;
+use ZEngine\Stub\TestPureEnum;
+use ZEngine\Stub\TestStringBackedEnum;
+use ZEngine\Type\HashTable;
+
+/**
+ * Pure-read introspection of enum class entries: nothing here mutates engine state,
+ * so the whole class belongs to the default suite (no "internal" group required)
+ */
+class ReflectionClassEnumTest extends TestCase
+{
+    public function testStringBackedEnumExposesBackedEnumTable(): void
+    {
+        $refClass = new ReflectionClass(TestStringBackedEnum::class);
+
+        // The engine builds the backed-enum table lazily on the first from()/tryFrom()
+        // call: before that the raw accessor sees a NULL pointer and reports null
+        $tableBeforeUse = $refClass->getBackedEnumTable();
+        $this->assertNull($tableBeforeUse, 'Table should not be materialized yet');
+
+        $this->assertNotNull(TestStringBackedEnum::tryFrom('left'));
+        $table = $refClass->getBackedEnumTable();
+        if ($table === null) {
+            self::fail('Backed string enum should expose the backed-enum table');
+        }
+
+        // The engine maps each backing value to an IS_STRING zval with the case name
+        $caseEntry = $table->find('left');
+        if ($caseEntry === null) {
+            self::fail('Backing value "left" should be present in the table');
+        }
+        $this->assertSame(ReflectionValue::IS_STRING, $caseEntry->getType());
+        $caseEntry->getNativeValue($caseName);
+        $this->assertSame('Left', $caseName);
+
+        $this->assertNull($table->find('unknown'), 'Unknown backing value should not be found');
+
+        // Full iteration: backing value => case name, one entry per case
+        $this->assertSame(['left' => 'Left', 'right' => 'Right'], $this->collectTable($table));
+    }
+
+    public function testIntBackedEnumExposesBackedEnumTable(): void
+    {
+        $refClass = new ReflectionClass(TestIntBackedEnum::class);
+
+        // Materialize the lazily-built table through the ordinary engine path
+        TestIntBackedEnum::from(1);
+        $table = $refClass->getBackedEnumTable();
+        if ($table === null) {
+            self::fail('Backed int enum should expose the backed-enum table');
+        }
+
+        // Int-backed tables are keyed by the integer backing values, so the
+        // string-keyed find() does not apply: assert the whole table via iteration
+        $this->assertSame([1 => 'One', 2 => 'Two'], $this->collectTable($table));
+    }
+
+    public function testPureEnumHasNoBackedEnumTable(): void
+    {
+        $refClass = new ReflectionClass(TestPureEnum::class);
+
+        $this->assertTrue($refClass->isEnum(), 'Pure enum should still be an enum');
+        // Touch the cases so the null cannot be confused with a not-yet-materialized table
+        $this->assertCount(2, TestPureEnum::cases());
+        $this->assertNull($refClass->getBackedEnumTable(), 'Pure enum has no backed-enum table');
+    }
+
+    public function testPlainClassHasNoBackedEnumTable(): void
+    {
+        $refClass = new ReflectionClass(TestClass::class);
+
+        $this->assertFalse($refClass->isEnum(), 'Plain class is not an enum');
+        $this->assertNull($refClass->getBackedEnumTable(), 'Plain class has no backed-enum table');
+    }
+
+    public function testInternalBackedEnumExposesBackedEnumTable(): void
+    {
+        // \PropertyHookType is a string-backed enum registered by the engine itself;
+        // internal enums build their backed-enum table lazily as well
+        $refClass = new ReflectionClass(\PropertyHookType::class);
+        $this->assertNotNull(\PropertyHookType::tryFrom('get'));
+        $table = $refClass->getBackedEnumTable();
+        if ($table === null) {
+            self::fail('Internal backed enum should expose the backed-enum table');
+        }
+
+        $caseEntry = $table->find('get');
+        if ($caseEntry === null) {
+            self::fail('Backing value "get" should be present in the table');
+        }
+        $caseEntry->getNativeValue($caseName);
+        $this->assertSame('Get', $caseName);
+    }
+
+    /**
+     * Collects a borrowed backed-enum table into a plain [backing value => case name] array
+     *
+     * @param HashTable&iterable<int|string|null, ReflectionValue> $table
+     *
+     * @return array<int|string, string>
+     */
+    private function collectTable(HashTable $table): array
+    {
+        $cases = [];
+        foreach ($table as $backingValue => $entry) {
+            if (!is_int($backingValue) && !is_string($backingValue)) {
+                self::fail('Backed-enum table keys should be backing values');
+            }
+            $entry->getNativeValue($caseName);
+            if (!is_string($caseName)) {
+                self::fail('Backed-enum table values should hold the case name');
+            }
+            $cases[$backingValue] = $caseName;
+        }
+
+        return $cases;
+    }
+}

--- a/tests/Stub/TestIntBackedEnum.php
+++ b/tests/Stub/TestIntBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+enum TestIntBackedEnum: int
+{
+    case One = 1;
+    case Two = 2;
+}

--- a/tests/Stub/TestPureEnum.php
+++ b/tests/Stub/TestPureEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+enum TestPureEnum
+{
+    case First;
+    case Second;
+}

--- a/tests/Stub/TestStringBackedEnum.php
+++ b/tests/Stub/TestStringBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+enum TestStringBackedEnum: string
+{
+    case Left  = 'left';
+    case Right = 'right';
+}


### PR DESCRIPTION
Fixes #71

## Summary

Adds `ReflectionClass::getBackedEnumTable(): ?HashTable` — raw, borrowed access to `ce->backed_enum_table` (backing value => case name, exactly as `zend_enum.c` stores it):

- Returns a **borrowed** `Type\HashTable` view (no addref, no ownership transfer), with a memory-contract docblock per `docs/long-running.md`.
- Returns `null` for non-enum classes and pure enums — no exception.
- Returns `null` while the table is unmaterialized: since PHP 8.2 the engine builds the backed-enum table **lazily** on the first `from()`/`tryFrom()` call (this holds for internal enums too, verified on 8.4). The accessor is a pure read and never triggers the build itself; the laziness is documented in the docblock and asserted in the tests.

Per the maintainer's comment on the issue, `isEnum()` and `getEnumBackingType()` are intentionally **not** added — native reflection (`ReflectionClass::isEnum()`, `ReflectionEnum::getBackingType()`) already covers them. Engine ground truth was verified during development: `ce_flags & ZEND_ACC_ENUM` and `ce->enum_backing_type` (`IS_STRING`=6 for the string-backed fixture) read correctly through the declared `engine.h` fields; no header changes.

## Tests

New default-suite test `tests/Reflection/ReflectionClassEnumTest.php` (pure reads, no `internal` group) with fixture enums `tests/Stub/TestStringBackedEnum` (string-backed), `TestIntBackedEnum` (int-backed), `TestPureEnum` (pure):

- string-backed: null before materialization; after `tryFrom()` — `find('left')` yields an `IS_STRING` zval `'Left'`, `find('unknown')` is null, full iteration equals `['left' => 'Left', 'right' => 'Right']`
- int-backed: integer-keyed table iterates to `[1 => 'One', 2 => 'Two']`
- pure enum: `isEnum()` true, table null (even after `cases()`)
- plain class: `isEnum()` false, table null
- internal string-backed enum (`\PropertyHookType`): `find('get')` => `'Get'`

### Gate results (PHP 8.4.19 NTS, linux-x64-nts)

- `composer test`: 163 tests, 2695 assertions, 0 failures (4 skipped / 4 incomplete, pre-existing)
- `composer phpstan`: OK, no errors, **no new baseline entries**
- `composer cs:check`: 0 of 106 files need fixing

### Standalone smoke run (not committed)

```
== string-backed enum (ZEngine\Stub\TestStringBackedEnum)
   isEnum (native): true
   getBackedEnumTable before from()/tryFrom(): null
   getBackedEnumTable:
     'left' => 'Left'
     'right' => 'Right'
== int-backed enum (ZEngine\Stub\TestIntBackedEnum)
   isEnum (native): true
   getBackedEnumTable before from()/tryFrom(): null
   getBackedEnumTable:
     1 => 'One'
     2 => 'Two'
== pure enum (ZEngine\Stub\TestPureEnum)
   isEnum (native): true
   getBackedEnumTable before from()/tryFrom(): null
   getBackedEnumTable: null
== plain class (ZEngine\Stub\TestClass)
   isEnum (native): false
   getBackedEnumTable before from()/tryFrom(): null
   getBackedEnumTable: null
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_