### PR TITLE
feat(system): integrate user opcode handlers with the hook lifecycle

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -20,7 +20,7 @@ use FFI\CType;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
-use ZEngine\Hook\AbstractHook;
+use ZEngine\Hook\HookInterface;
 use ZEngine\System\Compiler;
 use ZEngine\System\Executor;
 use ZEngine\System\Hook\AstProcessHook;
@@ -207,7 +207,7 @@ class Core
      * Strong references: an installed hook (and its libffi trampoline) can never be collected
      * while the engine still points at it. Chains unwind in reverse installation order.
      *
-     * @var array<string, array<int, AbstractHook>>
+     * @var array<string, array<int, HookInterface>>
      */
     private static array $installedHooks = [];
 
@@ -518,9 +518,9 @@ class Core
     /**
      * Records a freshly installed hook at the top of its field chain
      *
-     * @internal called by AbstractHook::install()
+     * @internal called by AbstractHook::install() and OpCodeHook::install()
      */
-    public static function registerHook(AbstractHook $hook): void
+    public static function registerHook(HookInterface $hook): void
     {
         self::$installedHooks[$hook->getHookFieldKey()][] = $hook;
     }
@@ -528,9 +528,9 @@ class Core
     /**
      * Removes an uninstalled hook from the top of its field chain
      *
-     * @internal called by AbstractHook::uninstall()
+     * @internal called by AbstractHook::uninstall() and OpCodeHook::uninstall()
      */
-    public static function unregisterHook(AbstractHook $hook): void
+    public static function unregisterHook(HookInterface $hook): void
     {
         $fieldKey = $hook->getHookFieldKey();
         if (self::isTopHook($hook)) {
@@ -544,11 +544,23 @@ class Core
     /**
      * Checks if the given hook is the most recently installed one on its engine field
      */
-    public static function isTopHook(AbstractHook $hook): bool
+    public static function isTopHook(HookInterface $hook): bool
     {
         $chain = self::$installedHooks[$hook->getHookFieldKey()] ?? [];
 
         return $chain !== [] && end($chain) === $hook;
+    }
+
+    /**
+     * Returns the most recently installed hook on the given engine slot (null if none)
+     *
+     * @internal used by OpCode::restoreHandler() to resolve the active user opcode hook
+     */
+    public static function topHook(string $fieldKey): ?HookInterface
+    {
+        $chain = self::$installedHooks[$fieldKey] ?? [];
+
+        return $chain === [] ? null : end($chain);
     }
 
     /**

--- a/src/Hook/HookInterface.php
+++ b/src/Hook/HookInterface.php
@@ -41,4 +41,22 @@ interface HookInterface
      * Checks if original handler is present to call it later with proceed
      */
     public function hasOriginalHandler(): bool;
+
+    /**
+     * Returns the identity of the engine slot this hook targets
+     *
+     * For struct-field hooks this is "<container address>::<field>", for slots that live
+     * outside any struct (e.g. user opcode handlers) it is a synthetic key. Hooks with the
+     * same key form one chain that unwinds in reverse installation order.
+     *
+     * @internal used by the Core hook registry to build per-slot chains
+     */
+    public function getHookFieldKey(): string;
+
+    /**
+     * Writes this hook's trampoline into the engine slot again without touching the chain
+     *
+     * @internal escape hatch used by Core::reinstallHooks() for SAPIs that cycle FFI state
+     */
+    public function refreshTrampoline(): void;
 }

--- a/src/System/Hook/OpCodeHook.php
+++ b/src/System/Hook/OpCodeHook.php
@@ -1,0 +1,296 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\System\Hook;
+
+use Closure;
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Hook\HookInterface;
+use ZEngine\System\ExecutionData;
+
+/**
+ * OpCodeHook integrates user opcode handlers with the engine hook lifecycle
+ *
+ * Not an AbstractHook subclass: AbstractHook's final install() writes an engine struct
+ * field, while user opcode handlers are installed via zend_set_user_opcode_handler().
+ * This class implements HookInterface directly with the same chaining semantics:
+ * install() captures the previously installed handler via zend_get_user_opcode_handler()
+ * and registers itself in the Core hook registry under the synthetic per-opcode key
+ * "user-opcode::<opcode>", uninstall() restores the captured handler, and Core::shutdown()
+ * unwinds still-installed opcode hooks exactly like struct-field hooks.
+ *
+ * A user handler that returns Core::ZEND_USER_OPCODE_DISPATCH chains to the previously
+ * installed user handler (if any) before the engine falls back to the VM opcode handler.
+ */
+final class OpCodeHook implements HookInterface
+{
+    /**
+     * Prefix of the synthetic Core registry key: user opcode handlers live in the engine's
+     * zend_user_opcode_handlers table (not in a hookable struct field), and every opcode
+     * forms its own independent chain
+     */
+    private const FIELD_KEY_PREFIX = 'user-opcode';
+
+    /**
+     * How deep to look for the frame that executed the hooked opcode: frame 0 is this
+     * handler, then possibly a few delegation frames of stacked OpCodeHook instances
+     */
+    private const BACKTRACE_LIMIT = 10;
+
+    /**
+     * Custom user handler with signature function($scope): int
+     */
+    private Closure $userHandler;
+
+    /**
+     * Hooked operation code, one of OpCode::* constants
+     */
+    private int $opCode;
+
+    /**
+     * Previously installed user opcode handler (if present), captured at install() time
+     *
+     * typedef int (*user_opcode_handler_t)(zend_execute_data *execute_data);
+     */
+    private ?CData $originalHandler = null;
+
+    /**
+     * Whether this hook's trampoline is currently installed as the user opcode handler
+     */
+    private bool $installed = false;
+
+    public function __construct(int $opCode, Closure $userHandler)
+    {
+        self::ensureValidOpCodeHandler($userHandler);
+        $this->opCode      = $opCode;
+        $this->userHandler = $userHandler;
+    }
+
+    /**
+     * Performs installation of current hook (idempotent)
+     *
+     * The previous user opcode handler is captured here (not in the constructor), so
+     * stacking several hooks on the same opcode forms a well-defined chain where each hook
+     * restores its predecessor. The Core registry keeps a strong reference to the installed
+     * hook: the trampoline can never be collected while the engine still points at it.
+     */
+    public function install(): void
+    {
+        if ($this->installed) {
+            return;
+        }
+        if (Core::isShutdown()) {
+            throw new \LogicException('Cannot install an engine hook after Core::shutdown()');
+        }
+        $previousHandler = Core::call('zend_get_user_opcode_handler', $this->opCode);
+        assert($previousHandler === null || $previousHandler instanceof CData);
+        $this->originalHandler = $previousHandler;
+
+        $result = Core::call('zend_set_user_opcode_handler', $this->opCode, Closure::fromCallable([$this, 'handle']));
+        if ($result === Core::FAILURE) {
+            throw new \RuntimeException('Can not install user opcode handler');
+        }
+        $this->installed = true;
+        Core::registerHook($this);
+    }
+
+    /**
+     * Restores the previously captured user opcode handler (idempotent)
+     *
+     * Only the most recently installed hook of an opcode may be uninstalled: restoring an
+     * older hook first would clobber the newer trampoline with a stale pointer.
+     */
+    public function uninstall(): void
+    {
+        if (!$this->installed) {
+            return;
+        }
+        if (Core::isShutdown()) {
+            // The engine handler table was already restored/abandoned during shutdown
+            $this->installed = false;
+
+            return;
+        }
+        if (!Core::isTopHook($this)) {
+            throw new \LogicException(
+                'Another hook was installed over this one on the same engine field; uninstall it first',
+            );
+        }
+
+        $result = Core::call('zend_set_user_opcode_handler', $this->opCode, $this->originalHandler);
+        if ($result === Core::FAILURE) {
+            throw new \RuntimeException('Can not restore original opcode handler');
+        }
+        $this->installed = false;
+        Core::unregisterHook($this);
+    }
+
+    /**
+     * Re-installs the hook with a freshly minted trampoline (uninstall + install)
+     */
+    public function reinstall(): void
+    {
+        $this->uninstall();
+        $this->install();
+    }
+
+    /**
+     * Checks if this hook is currently installed as the user opcode handler
+     */
+    public function isInstalled(): bool
+    {
+        return $this->installed;
+    }
+
+    /**
+     * Checks if a previously installed user opcode handler was captured at install() time
+     */
+    public function hasOriginalHandler(): bool
+    {
+        return $this->originalHandler !== null;
+    }
+
+    /**
+     * Returns the hooked operation code (one of OpCode::* constants)
+     */
+    public function getOpCode(): int
+    {
+        return $this->opCode;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHookFieldKey(): string
+    {
+        return self::fieldKeyFor($this->opCode);
+    }
+
+    /**
+     * Returns the synthetic Core registry key for the given opcode
+     *
+     * @internal used by OpCode::restoreHandler() to look up the active chain
+     */
+    public static function fieldKeyFor(int $opCode): string
+    {
+        return self::FIELD_KEY_PREFIX . '::' . $opCode;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Core::reinstallHooks() refreshes chains in installation order, so for stacked hooks
+     * the top hook's trampoline is written last and stays the one the engine dispatches to.
+     */
+    public function refreshTrampoline(): void
+    {
+        if (!$this->installed) {
+            return;
+        }
+        Core::call('zend_set_user_opcode_handler', $this->opCode, Closure::fromCallable([$this, 'handle']));
+    }
+
+    /**
+     * Handles the hooked opcode and returns one of ZEND_USER_OPCODE_* codes
+     *
+     * typedef int (*user_opcode_handler_t)(zend_execute_data *execute_data);
+     *
+     * @param mixed ...$rawArguments Raw C arguments of this callback (zend_execute_data*)
+     */
+    public function handle(...$rawArguments): int
+    {
+        [$state] = $rawArguments;
+        assert($state instanceof CData);
+
+        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, self::BACKTRACE_LIMIT);
+        $class = '';
+        $total = count($trace);
+        for ($index = 1; $index < $total; $index++) {
+            $frameClass = $trace[$index]['class'] ?? '';
+            if ($frameClass === self::class) {
+                // Delegation frame of a stacked OpCodeHook: the executing frame is deeper
+                continue;
+            }
+            $class = $frameClass;
+            break;
+        }
+        if (strpos($class, 'ZEngine') === 0) {
+            // For all our internal classes just proceed with default opcode handler
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        }
+
+        $executionState = new ExecutionData($state);
+        $handleResult   = ($this->userHandler)($executionState);
+        assert(is_int($handleResult));
+
+        if ($handleResult === Core::ZEND_USER_OPCODE_DISPATCH && $this->originalHandler !== null) {
+            // Chain to the user handler that was installed on this opcode before this hook
+            $dispatchResult = ($this->originalHandler)($state); // @phpstan-ignore callable.nonCallable (CData function pointer is callable)
+            assert(is_int($dispatchResult));
+
+            return $dispatchResult;
+        }
+
+        return $handleResult;
+    }
+
+    /**
+     * Best-effort restore for hooks that were dropped without uninstall()
+     *
+     * The Core registry keeps installed hooks alive, so this destructor only runs for hooks
+     * that were never installed, already uninstalled, or after Core::shutdown() cleared the
+     * registry - in the last case no engine memory is touched anymore.
+     */
+    public function __destruct()
+    {
+        if (Core::isShutdown() || !$this->installed) {
+            return;
+        }
+        if (Core::isTopHook($this)) {
+            $this->uninstall();
+        }
+    }
+
+    /**
+     * Internal CData fields could result in segfaults, so let's hide everything
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'opCode'      => $this->opCode,
+            'userHandler' => $this->userHandler,
+            'installed'   => $this->installed,
+        ];
+    }
+
+    /**
+     * Ensures that given callback can be used as opcode handler, otherwise throws an error
+     *
+     * @param Closure $userHandler User-defined opcode handler
+     */
+    private static function ensureValidOpCodeHandler(Closure $userHandler): void
+    {
+        $reflection = new \ReflectionFunction($userHandler);
+
+        $hasOneArgument     = $reflection->getNumberOfParameters() === 1;
+        $returnType         = $reflection->getReturnType();
+        $hasValidReturnType = $returnType instanceof \ReflectionNamedType && $returnType->getName() === 'int';
+        if (!$hasValidReturnType || !$hasOneArgument) {
+            throw new \InvalidArgumentException('Opcode handler signature should be: function($scope): int {}');
+        }
+    }
+}

--- a/src/System/OpCode.php
+++ b/src/System/OpCode.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace ZEngine\System;
 
 use Closure;
-use FFI\CData;
 use ZEngine\Core;
+use ZEngine\System\Hook\OpCodeHook;
 
 /**
  * Hold all internal opcode constants and provide an API to hook any existing opcode
@@ -259,56 +259,35 @@ final class OpCode
     /**
      * Installs a user opcode handler that will be used to handle specific opcode
      *
+     * The handler participates in the engine hook lifecycle: it chains to a previously
+     * installed user handler on ZEND_USER_OPCODE_DISPATCH, unwinds automatically at
+     * Core::shutdown() and can be uninstalled explicitly via the returned hook.
+     *
      * @param int     $opCode  Operation code to hook
      * @param Closure $handler Callback that will receive a control for overloaded operation code
      */
-    public static function setHandler(int $opCode, Closure $handler): void
+    public static function setHandler(int $opCode, Closure $handler): OpCodeHook
     {
-        self::ensureValidOpCodeHandler($handler);
-        $result = Core::call('zend_set_user_opcode_handler', $opCode, function (CData $state) use ($handler) {
-            $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-            $class = $trace[1]['class'] ?? '';
-            if (strpos($class, 'ZEngine') === 0) {
-                // For all our internal classes just proceed with default opcode handler
+        $hook = new OpCodeHook($opCode, $handler);
+        $hook->install();
 
-                return Core::ZEND_USER_OPCODE_DISPATCH;
-            }
-            $executionState = new ExecutionData($state);
-            $handleResult   = $handler($executionState);
-
-            return $handleResult;
-        });
-        if ($result === Core::FAILURE) {
-            throw new \RuntimeException('Can not install user opcode handler');
-        }
+        return $hook;
     }
 
     /**
-     * Restores default opcode handler
+     * Restores the previous opcode handler by uninstalling the top hook for that opcode
+     *
+     * No-op when no user opcode handler is installed (keeps the historic idempotent
+     * contract of this method).
      *
      * @param int $opCode Operation code
      */
     public static function restoreHandler(int $opCode): void
     {
-        $result = Core::call('zend_set_user_opcode_handler', $opCode, null);
-        if ($result === Core::FAILURE) {
-            throw new \RuntimeException('Can not restore original opcode handler');
+        $topHook = Core::topHook(OpCodeHook::fieldKeyFor($opCode));
+        if ($topHook === null) {
+            return;
         }
-    }
-
-    /**
-     * Ensures that given callback can be used as opcode handler, otherwise throws an error
-     *
-     * @param Closure $handler User-defined opcode handler
-     */
-    private static function ensureValidOpCodeHandler(Closure $handler): void
-    {
-        $reflection = new \ReflectionFunction($handler);
-
-        $hasOneArgument     = $reflection->getNumberOfParameters() === 1;
-        $hasValidReturnType = $reflection->hasReturnType() && ($reflection->getReturnType()->getName() === 'int');
-        if (!$hasValidReturnType || !$hasOneArgument) {
-            throw new \InvalidArgumentException('Opcode handler signature should be: function($scope): int {}');
-        }
+        $topHook->uninstall();
     }
 }

--- a/tests/System/Hook/OpCodeHookTest.php
+++ b/tests/System/Hook/OpCodeHookTest.php
@@ -1,0 +1,251 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\System\Hook;
+
+use ArrayObject;
+use Closure;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\System\ExecutionData;
+use ZEngine\System\OpCode;
+
+/**
+ * Lifecycle of user opcode handlers: install, chaining, guarded uninstall and Core::shutdown
+ */
+#[Group('internal')]
+final class OpCodeHookTest extends TestCase
+{
+    public function testHandlerFiresAndCanDispatch(): void
+    {
+        $log  = new ArrayObject();
+        $hook = OpCode::setHandler(OpCode::ADD, function ($scope) use ($log): int {
+            $log->append($scope instanceof ExecutionData ? 'fired' : 'wrong-scope');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+
+        try {
+            $this->assertInstanceOf(OpCodeHook::class, $hook);
+            $this->assertTrue($hook->isInstalled());
+            $this->assertTrue(Core::isTopHook($hook));
+            $this->assertSame(OpCode::ADD, $hook->getOpCode());
+            $this->assertFalse($hook->hasOriginalHandler());
+
+            $probe = self::compileProbe('$a + $b');
+            $this->assertSame(5, $probe(2, 3));
+            $this->assertSame(['fired'], $log->getArrayCopy());
+        } finally {
+            $hook->uninstall();
+        }
+        $this->assertFalse($hook->isInstalled());
+    }
+
+    public function testInstallIsIdempotentAndReinstallKeepsHookActive(): void
+    {
+        $hook = OpCode::setHandler(OpCode::ADD, fn($scope): int => Core::ZEND_USER_OPCODE_DISPATCH);
+
+        try {
+            // A second install must be a no-op, not a self-referencing chain entry
+            $hook->install();
+            $this->assertTrue($hook->isInstalled());
+            $this->assertTrue(Core::isTopHook($hook));
+
+            $hook->reinstall();
+            $this->assertTrue($hook->isInstalled());
+            $this->assertTrue(Core::isTopHook($hook));
+        } finally {
+            $hook->uninstall();
+        }
+    }
+
+    public function testSecondHandlerChainsOnDispatch(): void
+    {
+        $log       = new ArrayObject();
+        $firstHook = OpCode::setHandler(OpCode::ADD, function ($scope) use ($log): int {
+            $log->append('first');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+        $secondHook = OpCode::setHandler(OpCode::ADD, function ($scope) use ($log): int {
+            $log->append('second');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+
+        try {
+            $this->assertFalse($firstHook->hasOriginalHandler());
+            $this->assertTrue($secondHook->hasOriginalHandler());
+            $this->assertTrue(Core::isTopHook($secondHook));
+
+            $probe = self::compileProbe('$a + $b');
+            $this->assertSame(30, $probe(10, 20));
+            // Top handler fires first, its dispatch reaches the previously installed one
+            $this->assertSame(['second', 'first'], $log->getArrayCopy());
+        } finally {
+            $secondHook->uninstall();
+            $firstHook->uninstall();
+        }
+    }
+
+    public function testUninstallTopReactivatesPreviousHandler(): void
+    {
+        $log       = new ArrayObject();
+        $firstHook = OpCode::setHandler(OpCode::ADD, function ($scope) use ($log): int {
+            $log->append('first');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+        $secondHook = OpCode::setHandler(OpCode::ADD, function ($scope) use ($log): int {
+            $log->append('second');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+
+        try {
+            $secondHook->uninstall();
+            $this->assertFalse($secondHook->isInstalled());
+            $this->assertTrue(Core::isTopHook($firstHook));
+
+            $probe = self::compileProbe('$a + $b');
+            $this->assertSame(15, $probe(7, 8));
+            $this->assertSame(['first'], $log->getArrayCopy());
+        } finally {
+            $secondHook->uninstall();
+            $firstHook->uninstall();
+        }
+
+        // With every hook uninstalled a freshly compiled probe runs without interception
+        $log->exchangeArray([]);
+        $probe = self::compileProbe('$a + $b');
+        $this->assertSame(2, $probe(1, 1));
+        $this->assertSame([], $log->getArrayCopy());
+    }
+
+    public function testOutOfOrderUninstallThrows(): void
+    {
+        $firstHook  = OpCode::setHandler(OpCode::ADD, fn($scope): int => Core::ZEND_USER_OPCODE_DISPATCH);
+        $secondHook = OpCode::setHandler(OpCode::ADD, fn($scope): int => Core::ZEND_USER_OPCODE_DISPATCH);
+
+        try {
+            $this->assertTrue(Core::isTopHook($secondHook));
+            $this->assertFalse(Core::isTopHook($firstHook));
+
+            $caught = null;
+            try {
+                $firstHook->uninstall();
+            } catch (\LogicException $exception) {
+                $caught = $exception;
+            }
+            $this->assertInstanceOf(\LogicException::class, $caught);
+            $this->assertTrue($firstHook->isInstalled());
+        } finally {
+            // Unwinding in reverse order is legal and restores the previous handlers
+            $secondHook->uninstall();
+            $firstHook->uninstall();
+        }
+    }
+
+    public function testIndependentOpCodesUnwindIndependently(): void
+    {
+        $log     = new ArrayObject();
+        $addHook = OpCode::setHandler(OpCode::ADD, function ($scope) use ($log): int {
+            $log->append('add');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+        $subHook = OpCode::setHandler(OpCode::SUB, function ($scope) use ($log): int {
+            $log->append('sub');
+
+            return Core::ZEND_USER_OPCODE_DISPATCH;
+        });
+
+        try {
+            $probe = self::compileProbe('($a + $a) - $b');
+            $this->assertSame(7, $probe(5, 3));
+            $this->assertSame(['add', 'sub'], $log->getArrayCopy());
+
+            // Uninstalling the SUB hook must not disturb the ADD chain
+            OpCode::restoreHandler(OpCode::SUB);
+            $this->assertFalse($subHook->isInstalled());
+            $this->assertTrue($addHook->isInstalled());
+
+            $log->exchangeArray([]);
+            $probe = self::compileProbe('($a + $a) - $b');
+            $this->assertSame(7, $probe(5, 3));
+            $this->assertSame(['add'], $log->getArrayCopy());
+
+            OpCode::restoreHandler(OpCode::ADD);
+            $this->assertFalse($addHook->isInstalled());
+            // Restoring an opcode without any installed hook is an idempotent no-op
+            OpCode::restoreHandler(OpCode::ADD);
+
+            $log->exchangeArray([]);
+            $probe = self::compileProbe('($a + $a) - $b');
+            $this->assertSame(7, $probe(5, 3));
+            $this->assertSame([], $log->getArrayCopy());
+        } finally {
+            $subHook->uninstall();
+            $addHook->uninstall();
+        }
+    }
+
+    public function testInvalidHandlerSignatureIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Opcode handler signature should be: function($scope): int {}');
+
+        OpCode::setHandler(OpCode::ADD, function () {});
+    }
+
+    #[RunInSeparateProcess]
+    public function testShutdownUninstallsOpCodeHooksAndBlocksNewInstalls(): void
+    {
+        $hook = OpCode::setHandler(OpCode::ADD, fn($scope): int => Core::ZEND_USER_OPCODE_DISPATCH);
+        $this->assertTrue($hook->isInstalled());
+
+        Core::shutdown();
+
+        $this->assertTrue(Core::isShutdown());
+        $this->assertFalse($hook->isInstalled());
+
+        // Idempotent second call
+        Core::shutdown();
+
+        // Installing after shutdown is forbidden: engine writes are no longer safe
+        $this->expectException(\LogicException::class);
+        OpCode::setHandler(OpCode::ADD, fn($scope): int => Core::ZEND_USER_OPCODE_DISPATCH);
+    }
+
+    /**
+     * Compiles a fresh two-argument probe function and returns it as a closure
+     *
+     * User opcode handlers only affect op_arrays compiled AFTER installation, so every
+     * probe must be compiled once the handler configuration under test is in place. The
+     * probe is a global function (not a method of this ZEngine\* test class) because
+     * opcodes executed inside ZEngine classes bypass user handlers by design. Every probe
+     * gets a unique name and is never called again after its handler chain changed:
+     * an op_array compiled against a user opcode keeps dispatching through the user
+     * handler table for its whole lifetime.
+     */
+    private static function compileProbe(string $expression): Closure
+    {
+        $name = str_replace('.', '_', uniqid('zengine_opcode_probe_', true));
+        eval("function {$name}(\$a, \$b) { return {$expression}; }");
+        assert(is_callable($name));
+
+        return Closure::fromCallable($name);
+    }
+}


### PR DESCRIPTION
Fixes #69

## Summary

`OpCode::setHandler()` was the only hook family outside the `Core::registerHook()` lifecycle: it blindly overwrote any existing user opcode handler, `restoreHandler()` wrote `NULL` instead of restoring the previous one, and installed handlers were never unwound by `Core::shutdown()`. This PR brings user opcode handlers into the hook lifecycle.

- **New `ZEngine\System\Hook\OpCodeHook`** — implements `HookInterface` directly (not `AbstractHook`: its final `install()` writes a struct field, while opcode handlers install via `zend_set_user_opcode_handler()`), with the same chaining semantics:
  - `install()` captures the previous handler via the previously unused `zend_get_user_opcode_handler()` and registers under the synthetic per-opcode registry key `user-opcode::<opcode>`, so independent opcodes unwind independently and `Core::shutdown()` restores the engine handler table exactly like struct-field hooks
  - `uninstall()` restores the captured previous handler; idempotent, out-of-order uninstall throws, install after shutdown throws
  - `handle()` keeps the ZEngine-internal-frame bypass and the `ZEND_USER_OPCODE_*` return contract, and chains: a handler returning `ZEND_USER_OPCODE_DISPATCH` now reaches the previously installed user handler before the VM handler
  - `reinstall()`, `isInstalled()`, `hasOriginalHandler()`, `getOpCode()`, plus `refreshTrampoline()` participation in `Core::reinstallHooks()`
- **`OpCode::setHandler()` returns the `OpCodeHook`** (behavior-compatible for callers ignoring the return); handler signature validation (`function($scope): int`) preserved, now in the `OpCodeHook` constructor
- **`OpCode::restoreHandler()`** uninstalls the top hook for the opcode instead of writing `NULL` (still an idempotent no-op when nothing is installed)
- **`HookInterface`** gained `getHookFieldKey()`/`refreshTrampoline()` (both already `final` in `AbstractHook`), so the Core registry types against the interface; new internal `Core::topHook()` resolves the top of a chain for `restoreHandler()`

No header regeneration needed — both engine functions were already declared in `engine.h`.

## Tests

New `#[Group('internal')]` `tests/System/Hook/OpCodeHookTest.php` (8 tests, 42 assertions): handler fires and dispatches, install idempotence + reinstall, second handler chains (top fires, dispatch reaches previous), uninstall of top reactivates previous, out-of-order uninstall throws, independent opcodes unwind independently via `restoreHandler()`, invalid handler signature rejected, `Core::shutdown()` uninstalls and blocks new installs.

Test probes are compiled via `eval()` after handler installation because `zend_set_user_opcode_handler()` only affects op_arrays compiled afterwards (and literal arithmetic is constant-folded at compile time).

## Test evidence

```
composer test          OK, 158 tests, 2679 assertions (4 skipped, 4 incomplete — pre-existing)
composer phpstan       [OK] No errors (level max, no new baseline entries)
composer cs:check      Found 0 of 104 files that can be fixed
internal group         OK, 37 tests, 79 assertions (process-isolated, incl. the 8 new tests)
```

Standalone smoke run (install → chain → uninstall on `ADD`/`SUB`, not committed):

```
2+3=5, log=A                       # single handler fires, DISPATCH keeps VM result
10+20=30, log=B,A                  # second handler chains: top fires, dispatch reaches previous
OK LogicException: Another hook was installed over this one on the same engine field; uninstall it first
7+8=15, log=A                      # uninstall top → previous active again
1+1=2, log=                        # full unwind → no user handler left
5+5-3=7, log=add,sub               # independent opcodes
after restore SUB: 5+5-3=7, log=add
after restore ADD: 5+5-3=7, log=
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_