### PR TITLE
feat(reflection): get_debug_info + clone_obj object handlers (custom var_dump and clone interception)

### DIFF
--- a/src/ClassExtension/Hook/CloneObjectHook.php
+++ b/src/ClassExtension/Hook/CloneObjectHook.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Type\ObjectEntry;
+
+/**
+ * Receiving hook for intercepting `clone $object` (deep clone, copy-on-write, clone bans)
+ *
+ * Memory ownership contract (see docs/long-running.md for the full model):
+ *
+ *  - handle() returns the zend_object* of the object produced by the user handler with
+ *    exactly one reference transferred to the engine: the CLONE opcode stores the returned
+ *    pointer into its result operand without an addref, so the reference taken here is
+ *    consumed by the VM. The temporary zval container is freed right away.
+ *  - proceed() invokes the original clone_obj handler, which hands back a fresh clone
+ *    carrying one reference. That reference is exchanged for a PHP-level one owned by the
+ *    returned object value, so returning the clone from the user handler (or dropping it)
+ *    keeps the refcount balanced either way.
+ *  - The user handler must not let exceptions escape: handle() is entered by the engine
+ *    through an FFI trampoline with no PHP frame around it to catch them (see issue #50).
+ */
+class CloneObjectHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'clone_obj';
+
+    /**
+     * Object instance being cloned
+     */
+    protected CData $object;
+
+    /**
+     * typedef zend_object* (*zend_object_clone_obj_t)(zend_object *object);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): CData
+    {
+        [$object] = $rawArguments;
+        assert($object instanceof CData);
+        $this->object = $object;
+
+        $result = ($this->userHandler)($this);
+
+        // The engine stores the returned zend_object* into the result operand without an
+        // addref, so the reference this temporary wrapper took is transferred to the VM;
+        // the temporary zval container is freed right away
+        $refValue  = new ReflectionValue($result);
+        $rawObject = $refValue->getRawObject();
+        $refValue->transferReferenceOwnership();
+        $refValue->release();
+
+        return $rawObject;
+    }
+
+    /**
+     * Returns the object instance being cloned
+     */
+    public function getObject(): object
+    {
+        $objectInstance = ObjectEntry::fromCData($this->object)->getNativeValue();
+
+        return $objectInstance;
+    }
+
+    /**
+     * Proceeds with the default field-copy clone from the original handler
+     */
+    public function proceed(): object
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+        $originalHandler = $this->getOriginalCallable();
+
+        $rawClone = ($originalHandler)($this->object);
+        assert($rawClone instanceof CData);
+
+        // The original handler handed us a clone with one reference. Materializing the
+        // PHP object takes an own reference, so the handler's one is released afterwards:
+        // the only remaining reference is owned by the returned PHP value
+        $cloneEntry = ObjectEntry::fromCData($rawClone);
+        $clone      = $cloneEntry->getNativeValue();
+        $cloneEntry->releaseReference();
+
+        return $clone;
+    }
+}

--- a/src/ClassExtension/Hook/GetDebugInfoHook.php
+++ b/src/ClassExtension/Hook/GetDebugInfoHook.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Type\HashTable;
+use ZEngine\Type\ObjectEntry;
+
+/**
+ * Receiving hook for providing custom debug info (what var_dump() and debuggers see)
+ *
+ * Memory ownership contract (see docs/long-running.md for the full model):
+ *
+ *  - handle() converts the PHP array returned by the user handler into a HashTable* and
+ *    reports it with *is_temp = 1: exactly one payload reference is handed over to the
+ *    engine caller, which releases it after dumping (zend_release_properties). The
+ *    temporary zval container is freed here; nothing on the PHP side may release the
+ *    handed-over reference again.
+ *  - proceed() materializes the table produced by the original get_debug_info handler as
+ *    a fresh PHP array of plain values (IS_INDIRECT property slots are followed, every
+ *    value gets its own reference). When the original handler reported its table as
+ *    temporary, the only reference it handed over is released here with full engine
+ *    semantics (mirroring zend_release_properties); a non-temporary table stays borrowed
+ *    from the object and is left untouched.
+ *  - The user handler must not let exceptions escape: handle() is entered by the engine
+ *    through an FFI trampoline with no PHP frame around it to catch them (see issue #50).
+ */
+class GetDebugInfoHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'get_debug_info';
+
+    /**
+     * Object instance to provide debug info for
+     */
+    protected CData $object;
+
+    /**
+     * Engine-provided output flag (int *): whether the returned table is temporary
+     */
+    protected CData $isTemp;
+
+    /**
+     * typedef HashTable *(*zend_object_get_debug_info_t)(zend_object *object, int *is_temp);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): CData
+    {
+        [$object, $isTemp] = $rawArguments;
+        assert($object instanceof CData && $isTemp instanceof CData);
+        $this->object = $object;
+        $this->isTemp = $isTemp;
+
+        $result   = ($this->userHandler)($this);
+        $refValue = new ReflectionValue($result);
+        $rawArray = $refValue->getRawArray();
+
+        // With *is_temp = 1 the engine caller releases the returned table itself, so
+        // exactly one payload reference is handed over; the temporary zval container
+        // is freed right away
+        $this->isTemp[0] = 1;
+        $refValue->transferReferenceOwnership();
+        $refValue->release();
+
+        return $rawArray;
+    }
+
+    /**
+     * Returns an object instance
+     */
+    public function getObject(): object
+    {
+        $objectInstance = ObjectEntry::fromCData($this->object)->getNativeValue();
+
+        return $objectInstance;
+    }
+
+    /**
+     * Proceeds with the default engine debug info from the original handler
+     *
+     * @return array<array-key, mixed>
+     */
+    public function proceed(): array
+    {
+        if (!$this->hasOriginalHandler()) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        $originalHandler = $this->getOriginalCallable();
+
+        $object = $this->object;
+        $scope  = $object->ce;
+        assert($scope instanceof CData);
+        // Use an own is_temp output slot: the engine-provided one must stay untouched
+        // until handle() reports its final verdict
+        $isTemp = Core::new('int');
+
+        // As we will play with EG(fake_scope), we won't be able to access private or protected members
+        $previousScope = Core::$executor->setFakeScope($scope);
+        $rawArray      = ($originalHandler)($object, Core::addr($isTemp));
+        Core::$executor->setFakeScope($previousScope);
+
+        if ($rawArray === null) {
+            return [];
+        }
+        assert($rawArray instanceof CData);
+
+        $table     = new HashTable($rawArray);
+        $debugInfo = [];
+        foreach ($table as $key => $refValue) {
+            assert($refValue instanceof ReflectionValue);
+            // Property tables store declared properties as IS_INDIRECT slots pointing into
+            // the object: follow them (skipping uninitialized ones), because a userland
+            // array must contain only plain values
+            if ($refValue->getType() === ReflectionValue::IS_INDIRECT) {
+                $refValue = $refValue->getIndirectValue();
+                if ($refValue->getType() === ReflectionValue::IS_UNDEF) {
+                    continue;
+                }
+            }
+            // Each value is materialized with its own reference owned by the built array
+            $refValue->getNativeValue($value);
+            if (is_string($key) || is_int($key)) {
+                $debugInfo[$key] = $value;
+            } else {
+                $debugInfo[] = $value;
+            }
+        }
+
+        // A temporary table comes with the only reference handed over to us: release it
+        // exactly like zend_release_properties() would (immutable tables stay untouched)
+        if ($isTemp->cdata === 1) {
+            $table->releaseReference();
+        }
+
+        return $debugInfo;
+    }
+}

--- a/src/ClassExtension/ObjectCloneInterface.php
+++ b/src/ClassExtension/ObjectCloneInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use ZEngine\ClassExtension\Hook\CloneObjectHook;
+
+/**
+ * Interface ObjectCloneInterface allows to intercept `clone $object` at the engine level
+ */
+interface ObjectCloneInterface
+{
+    /**
+     * Produces the clone of the object accessible via $hook->getObject()
+     *
+     * The handler must not throw: it is called by the engine across the FFI boundary
+     * where escaping exceptions cannot be handled (see issue #50). Call
+     * $hook->proceed() to get the default field-copy clone.
+     *
+     * @return object The object to return as the clone result
+     */
+    public static function __cloneObject(CloneObjectHook $hook): object;
+}

--- a/src/ClassExtension/ObjectGetDebugInfoInterface.php
+++ b/src/ClassExtension/ObjectGetDebugInfoInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension;
+
+use ZEngine\ClassExtension\Hook\GetDebugInfoHook;
+
+/**
+ * Interface ObjectGetDebugInfoInterface allows to control what var_dump() and debuggers see
+ */
+interface ObjectGetDebugInfoInterface
+{
+    /**
+     * Returns the debug info for the given object, replacing the default engine output
+     *
+     * The handler must not throw: it is called by the engine across the FFI boundary
+     * where escaping exceptions cannot be handled (see issue #50). Call
+     * $hook->proceed() to get the default engine debug info.
+     *
+     * @return array<array-key, mixed> Debug info to show
+     */
+    public static function __getDebugInfo(GetDebugInfoHook $hook): array;
+}

--- a/src/Hook/AbstractHook.php
+++ b/src/Hook/AbstractHook.php
@@ -146,6 +146,32 @@ abstract class AbstractHook implements HookInterface
     }
 
     /**
+     * Returns the original engine handler as an invocable callable for proceed() implementations
+     *
+     * FFI\CData function pointers are invocable at runtime (FFI provides an engine-level
+     * get_closure handler for them), which static analysis cannot model on the CData type
+     * itself: the mixed-typed seam below erases the type so the callable check narrows
+     * instead of contradicting.
+     */
+    final protected function getOriginalCallable(): callable
+    {
+        $originalHandler = $this->getOriginalHandlerErased();
+        if (!is_callable($originalHandler)) {
+            throw new \LogicException('Original handler is not available');
+        }
+
+        return $originalHandler;
+    }
+
+    /**
+     * Type-erasing seam for getOriginalCallable()
+     */
+    private function getOriginalHandlerErased(): mixed
+    {
+        return $this->originalHandler;
+    }
+
+    /**
      * Returns the identity of the engine field this hook targets (container address + field)
      *
      * @internal used by the Core hook registry to build per-field chains

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -17,6 +17,7 @@ use Closure;
 use FFI\CData;
 use ReflectionClass as NativeReflectionClass;
 use ZEngine\ClassExtension\Hook\CastObjectHook;
+use ZEngine\ClassExtension\Hook\CloneObjectHook;
 use ZEngine\ClassExtension\Hook\CompareValuesHook;
 use ZEngine\ClassExtension\Hook\CreateObjectHook;
 use ZEngine\ClassExtension\Hook\DoOperationHook;
@@ -29,6 +30,7 @@ use ZEngine\ClassExtension\Hook\ReadPropertyHook;
 use ZEngine\ClassExtension\Hook\UnsetPropertyHook;
 use ZEngine\ClassExtension\Hook\WritePropertyHook;
 use ZEngine\ClassExtension\ObjectCastInterface;
+use ZEngine\ClassExtension\ObjectCloneInterface;
 use ZEngine\ClassExtension\ObjectCompareValuesInterface;
 use ZEngine\ClassExtension\ObjectCreateInterface;
 use ZEngine\ClassExtension\ObjectDoOperationInterface;
@@ -748,6 +750,11 @@ class ReflectionClass extends NativeReflectionClass
             $handler = parent::getMethod('__getDebugInfo')->getClosure();
             $this->setGetDebugInfoHandler($handler);
         }
+
+        if ($this->implementsInterface(ObjectCloneInterface::class)) {
+            $handler = parent::getMethod('__cloneObject')->getClosure();
+            $this->setCloneObjectHandler($handler);
+        }
     }
 
     public function __debugInfo()
@@ -905,6 +912,23 @@ class ReflectionClass extends NativeReflectionClass
         $handlers = self::getObjectHandlers($this->pointer);
 
         $hook = new GetDebugInfoHook($handler, $handlers);
+        $hook->install();
+
+        return $hook;
+    }
+
+    /**
+     * Installs the "clone_obj" handler for the current class
+     *
+     * @param Closure $handler Callback function (CloneObjectHook $hook): object;
+     *
+     * @see ObjectCloneInterface
+     */
+    public function setCloneObjectHandler(Closure $handler): CloneObjectHook
+    {
+        $handlers = self::getObjectHandlers($this->pointer);
+
+        $hook = new CloneObjectHook($handler, $handlers);
         $hook->install();
 
         return $hook;

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -20,6 +20,7 @@ use ZEngine\ClassExtension\Hook\CastObjectHook;
 use ZEngine\ClassExtension\Hook\CompareValuesHook;
 use ZEngine\ClassExtension\Hook\CreateObjectHook;
 use ZEngine\ClassExtension\Hook\DoOperationHook;
+use ZEngine\ClassExtension\Hook\GetDebugInfoHook;
 use ZEngine\ClassExtension\Hook\GetPropertiesForHook;
 use ZEngine\ClassExtension\Hook\GetPropertyPointerHook;
 use ZEngine\ClassExtension\Hook\HasPropertyHook;
@@ -31,6 +32,7 @@ use ZEngine\ClassExtension\ObjectCastInterface;
 use ZEngine\ClassExtension\ObjectCompareValuesInterface;
 use ZEngine\ClassExtension\ObjectCreateInterface;
 use ZEngine\ClassExtension\ObjectDoOperationInterface;
+use ZEngine\ClassExtension\ObjectGetDebugInfoInterface;
 use ZEngine\ClassExtension\ObjectGetPropertiesForInterface;
 use ZEngine\ClassExtension\ObjectGetPropertyPointerInterface;
 use ZEngine\ClassExtension\ObjectHasPropertyInterface;
@@ -741,6 +743,11 @@ class ReflectionClass extends NativeReflectionClass
             $handler = parent::getMethod('__fieldPointer')->getClosure();
             $this->setGetPropertyPointerHandler($handler);
         }
+
+        if ($this->implementsInterface(ObjectGetDebugInfoInterface::class)) {
+            $handler = parent::getMethod('__getDebugInfo')->getClosure();
+            $this->setGetDebugInfoHandler($handler);
+        }
     }
 
     public function __debugInfo()
@@ -881,6 +888,23 @@ class ReflectionClass extends NativeReflectionClass
         $handlers = self::getObjectHandlers($this->pointer);
 
         $hook = new GetPropertiesForHook($handler, $handlers);
+        $hook->install();
+
+        return $hook;
+    }
+
+    /**
+     * Installs the "get_debug_info" handler for the current class
+     *
+     * @param Closure $handler Callback function (GetDebugInfoHook $hook): array;
+     *
+     * @see ObjectGetDebugInfoInterface
+     */
+    public function setGetDebugInfoHandler(Closure $handler): GetDebugInfoHook
+    {
+        $handlers = self::getObjectHandlers($this->pointer);
+
+        $hook = new GetDebugInfoHook($handler, $handlers);
         $hook->install();
 
         return $hook;

--- a/tests/Memory/scenarios/clone-object-hook.php
+++ b/tests/Memory/scenarios/clone-object-hook.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\ClassExtension\Hook\CloneObjectHook;
+use ZEngine\ClassExtension\ObjectCreateTrait;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionClass;
+use ZEngine\Stub\TestClass;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+$refClass = new ReflectionClass(TestClass::class);
+$refClass->setCreateObjectHandler(Closure::fromCallable([ObjectCreateTrait::class, '__init']));
+$refClass->setCloneObjectHandler(function (CloneObjectHook $hook): object {
+    // proceed() exchanges the original handler's reference for a PHP-owned one, and
+    // handle() transfers exactly one reference back to the VM - the leak-sensitive part
+    return $hook->proceed();
+});
+
+$instance = new TestClass();
+for ($index = 0; $index < 1000; $index++) {
+    $clone = clone $instance;
+    if ($clone === $instance || $clone->property !== 42) {
+        throw new RuntimeException('Unexpected clone result');
+    }
+    unset($clone);
+}
+unset($instance);
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;

--- a/tests/Memory/scenarios/debug-info-hook.php
+++ b/tests/Memory/scenarios/debug-info-hook.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\ClassExtension\Hook\GetDebugInfoHook;
+use ZEngine\ClassExtension\ObjectCreateTrait;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionClass;
+use ZEngine\Stub\TestClass;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+/**
+ * Local target with a __debugInfo magic method: the engine's default handler reports its
+ * table as temporary (*is_temp = 1), so proceed() exercises the handed-over-reference
+ * release path in addition to the borrowed-table path of plain classes
+ */
+class DebugInfoMagicTarget
+{
+    public int $value = 7;
+
+    /**
+     * @return array<string, int>
+     */
+    public function __debugInfo(): array
+    {
+        return ['magic' => $this->value];
+    }
+}
+
+Core::init();
+
+$handler = function (GetDebugInfoHook $hook): array {
+    // proceed() materializes the default engine debug info (and releases a temporary
+    // table when the original handler hands one over)
+    $default = $hook->proceed();
+
+    // The returned array is converted to a HashTable* reported with *is_temp = 1:
+    // the engine caller owns and frees it after dumping - the leak-sensitive part
+    return ['marker' => 'debug-info-hook', 'default' => $default];
+};
+
+$refClass = new ReflectionClass(TestClass::class);
+$refClass->setCreateObjectHandler(Closure::fromCallable([ObjectCreateTrait::class, '__init']));
+$refClass->setGetDebugInfoHandler($handler);
+
+$refMagicClass = new ReflectionClass(DebugInfoMagicTarget::class);
+$refMagicClass->setCreateObjectHandler(Closure::fromCallable([ObjectCreateTrait::class, '__init']));
+$refMagicClass->setGetDebugInfoHandler($handler);
+
+$instance = new TestClass();
+$magic    = new DebugInfoMagicTarget();
+for ($index = 0; $index < 1000; $index++) {
+    ob_start();
+    var_dump($instance);
+    var_dump($magic);
+    $output = (string) ob_get_clean();
+    if (substr_count($output, 'debug-info-hook') !== 2) {
+        throw new RuntimeException('Unexpected debug info output');
+    }
+}
+unset($instance, $magic);
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -22,6 +22,7 @@ use ZEngine\ClassExtension\Hook\CastObjectHook;
 use ZEngine\ClassExtension\Hook\CompareValuesHook;
 use ZEngine\ClassExtension\Hook\CreateObjectHook;
 use ZEngine\ClassExtension\Hook\DoOperationHook;
+use ZEngine\ClassExtension\Hook\GetDebugInfoHook;
 use ZEngine\ClassExtension\Hook\GetPropertiesForHook;
 use ZEngine\ClassExtension\Hook\HasPropertyHook;
 use ZEngine\ClassExtension\Hook\InterfaceGetsImplementedHook;
@@ -470,6 +471,78 @@ class ReflectionClassTest extends TestCase
         $this->markTestIncomplete('Initialization object handler brings segfaults thus run it separately');
     }
 
+
+    #[Group('internal')]
+    public function testInstallGetDebugInfoHandler(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+        $this->refClass->setGetDebugInfoHandler(function (GetDebugInfoHook $hook): array {
+            $this->assertInstanceOf(TestClass::class, $hook->getObject());
+
+            return ['custom' => 'debug-info', 'answer' => 42];
+        });
+
+        $instance = new TestClass();
+        ob_start();
+        var_dump($instance);
+        $output = (string) ob_get_clean();
+
+        // The custom array fully replaces the default engine debug info
+        $this->assertStringContainsString('["custom"]', $output);
+        $this->assertStringContainsString('string(10) "debug-info"', $output);
+        $this->assertStringContainsString('["answer"]', $output);
+        $this->assertStringNotContainsString('["property"]', $output);
+    }
+
+    #[Group('internal')]
+    public function testGetDebugInfoHandlerProceedYieldsDefaultInfo(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+        $this->refClass->setGetDebugInfoHandler(function (GetDebugInfoHook $hook): array {
+            $default = $hook->proceed();
+            // The default engine debug info contains the declared properties
+            $this->assertSame(42, $default['property'] ?? null);
+
+            return $default + ['extra' => 'appended'];
+        });
+
+        $instance = new TestClass();
+        ob_start();
+        var_dump($instance);
+        $output = (string) ob_get_clean();
+
+        $this->assertStringContainsString('["property"]', $output);
+        $this->assertStringContainsString('int(42)', $output);
+        $this->assertStringContainsString('["extra"]', $output);
+        $this->assertStringContainsString('string(8) "appended"', $output);
+    }
+
+    #[Group('internal')]
+    public function testGetDebugInfoHandlerUninstallRestoresDefaultBehavior(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+        $hook = $this->refClass->setGetDebugInfoHandler(function (GetDebugInfoHook $hook): array {
+            return ['custom' => 'debug-info'];
+        });
+
+        $instance = new TestClass();
+        ob_start();
+        var_dump($instance);
+        $hookedOutput = (string) ob_get_clean();
+        $this->assertStringContainsString('["custom"]', $hookedOutput);
+
+        $hook->uninstall();
+
+        ob_start();
+        var_dump($instance);
+        $defaultOutput = (string) ob_get_clean();
+        $this->assertStringNotContainsString('["custom"]', $defaultOutput);
+        $this->assertStringContainsString('["property"]', $defaultOutput);
+        $this->assertStringContainsString('int(42)', $defaultOutput);
+    }
 
     public function testInstallExtensionHandlers(): void
     {

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use ZEngine\ClassExtension\Hook\CastObjectHook;
+use ZEngine\ClassExtension\Hook\CloneObjectHook;
 use ZEngine\ClassExtension\Hook\CompareValuesHook;
 use ZEngine\ClassExtension\Hook\CreateObjectHook;
 use ZEngine\ClassExtension\Hook\DoOperationHook;
@@ -31,6 +32,7 @@ use ZEngine\ClassExtension\Hook\UnsetPropertyHook;
 use ZEngine\ClassExtension\Hook\WritePropertyHook;
 use ZEngine\ClassExtension\ObjectCreateTrait;
 use ZEngine\Core;
+use ZEngine\Stub\DebuggableCloneable;
 use ZEngine\Stub\NativeNumber;
 use ZEngine\Stub\TestClass;
 use ZEngine\Stub\TestInterface;
@@ -542,6 +544,101 @@ class ReflectionClassTest extends TestCase
         $this->assertStringNotContainsString('["custom"]', $defaultOutput);
         $this->assertStringContainsString('["property"]', $defaultOutput);
         $this->assertStringContainsString('int(42)', $defaultOutput);
+    }
+
+    #[Group('internal')]
+    public function testInstallCloneObjectHandler(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+
+        $replacement = null;
+        $this->refClass->setCloneObjectHandler(function (CloneObjectHook $hook) use (&$replacement): object {
+            $this->assertInstanceOf(TestClass::class, $hook->getObject());
+            $replacement           = new TestClass();
+            $replacement->property = 4242;
+
+            return $replacement;
+        });
+
+        $instance = new TestClass();
+        $clone    = clone $instance;
+
+        // The clone result is exactly the object produced by the handler
+        $this->assertSame($replacement, $clone);
+        $this->assertNotSame($instance, $clone);
+        $this->assertSame(4242, $clone->property);
+        $this->assertSame(42, $instance->property);
+    }
+
+    #[Group('internal')]
+    public function testCloneObjectHandlerProceedYieldsDefaultClone(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+        $this->refClass->setCloneObjectHandler(function (CloneObjectHook $hook): object {
+            return $hook->proceed();
+        });
+
+        $instance           = new TestClass();
+        $instance->property = 100;
+        $clone              = clone $instance;
+
+        // proceed() produces the default field-copy clone: same state, distinct object
+        $this->assertInstanceOf(TestClass::class, $clone);
+        $this->assertNotSame($instance, $clone);
+        $this->assertSame(100, $clone->property);
+
+        $clone->property = 500;
+        $this->assertSame(100, $instance->property);
+    }
+
+    #[Group('internal')]
+    public function testCloneObjectHandlerUninstallRestoresDefaultBehavior(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+
+        $callsCount = 0;
+        $hook       = $this->refClass->setCloneObjectHandler(
+            function (CloneObjectHook $hook) use (&$callsCount): object {
+                $callsCount++;
+
+                return $hook->proceed();
+            },
+        );
+
+        $instance    = new TestClass();
+        $hookedClone = clone $instance;
+        $this->assertNotSame($instance, $hookedClone);
+        $this->assertSame(1, $callsCount);
+
+        $hook->uninstall();
+
+        $clone = clone $instance;
+        $this->assertSame(1, $callsCount, 'Uninstalled handler should not be called anymore');
+        $this->assertNotSame($instance, $clone);
+        $this->assertSame(42, $clone->property);
+    }
+
+    #[Group('internal')]
+    public function testInstallExtensionHandlersWiresGetDebugInfoAndCloneObject(): void
+    {
+        $refClass = new ReflectionClass(DebuggableCloneable::class);
+        $refClass->installExtensionHandlers();
+
+        $instance = new DebuggableCloneable();
+        ob_start();
+        var_dump($instance);
+        $output = (string) ob_get_clean();
+        $this->assertStringContainsString('["marker"]', $output);
+        $this->assertStringContainsString('string(17) "custom-debug-info"', $output);
+
+        $clone = clone $instance;
+        $this->assertInstanceOf(DebuggableCloneable::class, $clone);
+        $this->assertNotSame($instance, $clone);
+        $this->assertSame(0, $instance->generation);
+        $this->assertSame(1, $clone->generation);
     }
 
     public function testInstallExtensionHandlers(): void

--- a/tests/Stub/DebuggableCloneable.php
+++ b/tests/Stub/DebuggableCloneable.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use FFI\CData;
+use ZEngine\ClassExtension\Hook\CloneObjectHook;
+use ZEngine\ClassExtension\Hook\CreateObjectHook;
+use ZEngine\ClassExtension\Hook\GetDebugInfoHook;
+use ZEngine\ClassExtension\ObjectCloneInterface;
+use ZEngine\ClassExtension\ObjectCreateInterface;
+use ZEngine\ClassExtension\ObjectGetDebugInfoInterface;
+
+class DebuggableCloneable implements ObjectCreateInterface, ObjectGetDebugInfoInterface, ObjectCloneInterface
+{
+    public int $generation = 0;
+
+    /**
+     * @inheritDoc
+     */
+    public static function __init(CreateObjectHook $hook): CData
+    {
+        $object = $hook->proceed();
+        assert($object instanceof CData);
+
+        return $object;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function __getDebugInfo(GetDebugInfoHook $hook): array
+    {
+        $default = $hook->proceed();
+
+        return ['marker' => 'custom-debug-info', 'default' => $default];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function __cloneObject(CloneObjectHook $hook): object
+    {
+        $clone = $hook->proceed();
+        assert($clone instanceof self);
+        $clone->generation++;
+
+        return $clone;
+    }
+}


### PR DESCRIPTION
Fixes #67

## Summary

Exposes two more `zend_object_handlers` fields (both already declared in `engine.h`, no header regeneration):

- **`get_debug_info`** — `GetDebugInfoHook` + `ObjectGetDebugInfoInterface::__getDebugInfo(GetDebugInfoHook $hook): array`
  - `handle()` converts the returned PHP array into a `HashTable*` reported with `*is_temp = 1`: exactly one payload reference is transferred to the engine caller, which releases it via `zend_release_properties()` after dumping.
  - `proceed()` materializes the original handler's table as a fresh PHP array of **plain values**: `IS_INDIRECT` property slots are followed (a userland array must not carry indirect zvals — they neither resolve on lookup nor survive the object), and the original handler's own `is_temp` verdict is honoured for the handed-over reference (temporary tables released with full engine semantics, borrowed ones left untouched).
- **`clone_obj`** — `CloneObjectHook` + `ObjectCloneInterface::__cloneObject(CloneObjectHook $hook): object`
  - `handle()` returns the `zend_object*` of the userland-produced object with one reference transferred to the engine (the CLONE opcode stores the pointer into its result operand without an addref).
  - `proceed()` invokes the original handler and exchanges the clone's handed-over reference for a PHP-owned one, so the user handler can return or drop the default field-copy clone without unbalancing refcounts.
- **`ReflectionClass`**: `setGetDebugInfoHandler(Closure): GetDebugInfoHook`, `setCloneObjectHandler(Closure): CloneObjectHook`, both interfaces auto-wired in `installExtensionHandlers()`.
- **`AbstractHook::getOriginalCallable()`**: a mixed-typed seam that lets `proceed()` implementations invoke the captured CData function pointer while staying clean under PHPStan level max (no new baseline entries) — FFI function pointers are invocable at runtime, which the `CData` type cannot express.

Memory ownership is documented in the class-level docblocks per the `docs/long-running.md` convention; both interfaces document the "no exceptions across the FFI boundary" constraint (#50).

## Tests

- `#[Group('internal')]` (7 new tests in `ReflectionClassTest`): custom `var_dump()` output, `proceed()` default debug info, uninstall restores default dump; clone returns the exact handler-produced object, `proceed()` yields a default field-copy clone, uninstall restores default clone; `installExtensionHandlers()` wiring of both interfaces via the new `DebuggableCloneable` stub.
- Leak scenarios `tests/Memory/scenarios/debug-info-hook.php` (covers the `is_temp` handover plus both `proceed()` ownership paths — borrowed table and temporary table via a `__debugInfo` class) and `tests/Memory/scenarios/clone-object-hook.php` (clone reference handover), auto-discovered by `MemoryLeakScenarioTest` on the debug build.

## Test evidence (local, PHP 8.4.19 NTS release build)

```
composer test        OK (158 tests, 2681 assertions, 4 skipped, 4 incomplete — pre-existing)
composer phpstan     [OK] No errors
composer cs:check    Found 0 of 109 files that can be fixed
phpunit --group internal --process-isolation   OK (38 tests, 71 assertions, 11 skipped, 2 incomplete)
```

Both leak scenarios print `SCENARIO OK` standalone; a standalone smoke script verified custom `var_dump` output, handler-produced clone identity, `proceed()` behavior and uninstall restoration end-to-end (not committed).

## Notes for review

- Implemented independently against `master` per the issue's merge-order note; overlap with #65/#66 in `ReflectionClass.php` resolves at merge time.
- The extra `clone-object-hook.php` scenario goes slightly beyond the issue text (which only names `debug-info-hook.php`): the clone refcount handover is equally leak-sensitive and the leak gate is its only automated check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_