### PR TITLE
fix(reflection): complete removeParentClass() detachment and refactor addMethod() off raw structs

### DIFF
--- a/src/Reflection/FunctionLikeTrait.php
+++ b/src/Reflection/FunctionLikeTrait.php
@@ -16,10 +16,50 @@ namespace ZEngine\Reflection;
 use FFI\CData;
 use ZEngine\Core;
 use ZEngine\Type\OpLine;
+use ZEngine\Type\StringEntry;
 
 trait FunctionLikeTrait
 {
     private CData $pointer;
+
+    /**
+     * Changes the name of this function/method
+     *
+     * The function structure releases its previous name (if any) and takes over one owned
+     * reference on the new one, following engine assignment semantics.
+     *
+     * @internal
+     */
+    public function setFunctionName(string $newName): void
+    {
+        $commonPointer = $this->getCommonPointer();
+        $previousName  = $commonPointer->function_name;
+        if ($previousName !== null) {
+            assert($previousName instanceof CData);
+            StringEntry::fromCData($previousName)->releaseReference();
+        }
+        $commonPointer->function_name = StringEntry::fromString($newName)
+            ->transferReferenceOwnership()
+            ->getRawValue();
+    }
+
+    /**
+     * Marks this function as a closure or converts a closure-backed entry into a regular
+     * function/method (toggles the ZEND_ACC_CLOSURE flag)
+     *
+     * @internal
+     */
+    public function setClosureFlag(bool $isClosure = true): void
+    {
+        $commonPointer = $this->getCommonPointer();
+        $flags         = $commonPointer->fn_flags;
+        assert(is_int($flags));
+        if ($isClosure) {
+            $commonPointer->fn_flags = $flags | Core::ZEND_ACC_CLOSURE;
+        } else {
+            $commonPointer->fn_flags = $flags & (~Core::ZEND_ACC_CLOSURE);
+        }
+    }
 
     /**
     * Declares method as deprecated/non-deprecated
@@ -64,6 +104,24 @@ trait FunctionLikeTrait
     }
 
     /**
+     * Function flags that describe the body of the function (as opposed to its declaration):
+     * they must always travel together with the op_array they were compiled for.
+     *
+     * ZEND_ACC_HEAP_RT_CACHE and the run_time_cache/T fields live in zend_function.common
+     * since PHP 8.2, so a whole-common copy from the previous entry would graft a run-time
+     * cache and a temporaries count sized for the OLD opcodes onto the new body - the VM
+     * then reads cache slots out of bounds and crashes.
+     */
+    private const BODY_LEVEL_FUNCTION_FLAGS = Core::ZEND_ACC_HEAP_RT_CACHE
+        | Core::ZEND_ACC_GENERATOR
+        | Core::ZEND_ACC_VARIADIC
+        | Core::ZEND_ACC_RETURN_REFERENCE
+        | Core::ZEND_ACC_HAS_RETURN_TYPE
+        | Core::ZEND_ACC_HAS_TYPE_HINTS
+        | Core::ZEND_ACC_STRICT_TYPES
+        | Core::ZEND_ACC_IMMUTABLE;
+
+    /**
      * Redefines an existing method in the class with closure
      * @internal
      */
@@ -76,11 +134,33 @@ trait FunctionLikeTrait
             $newCodeEntry       = $selfExecutionState->getArgument(0)->getRawObject();
             $newCodeEntry       = Core::cast('zend_closure *', $newCodeEntry);
 
-            // Copy only common op_array part from original one to keep name, scope, etc
-            Core::memcpy($newCodeEntry->func, $this->pointer[0], Core::sizeof($newCodeEntry->func->common));
+            // Remember the declaration identity of the redefined entry: it survives the
+            // body replacement, while everything executor-related (opcodes, literals,
+            // run-time cache, temporaries count) comes from the new closure body
+            $targetCommon  = $this->getCommonPointer();
+            $previousName  = $targetCommon->function_name;
+            $previousScope = $targetCommon->scope;
+            $previousProto = $targetCommon->prototype;
+            $previousFlags = $targetCommon->fn_flags;
+            $newFunction   = $newCodeEntry->func;
+            assert(is_int($previousFlags) && $newFunction instanceof CData);
+            $newFunctionCommon = $newFunction->common;
+            assert($newFunctionCommon instanceof CData);
+            $newBodyFlags = $newFunctionCommon->fn_flags;
+            assert(is_int($newBodyFlags));
 
-            // Replace original method with redefined closure
-            Core::memcpy($this->pointer, Core::addr($newCodeEntry->func), Core::sizeof($newCodeEntry->func));
+            // Replace the whole function with the closure-backed one (the donor closure
+            // object itself stays untouched - it keeps sole ownership of its own fields)
+            Core::memcpy($this->pointer, Core::addr($newFunction), Core::sizeof($newFunction));
+
+            // Restore the declaration identity: the single owned reference on the previous
+            // name stays with this entry, declaration-level flags (visibility, static,
+            // final, closure bit) are kept while body-level flags follow the new op_array
+            $targetCommon->function_name = $previousName;
+            $targetCommon->scope         = $previousScope;
+            $targetCommon->prototype     = $previousProto;
+            $targetCommon->fn_flags      = ($previousFlags & ~self::BODY_LEVEL_FUNCTION_FLAGS)
+                | ($newBodyFlags & self::BODY_LEVEL_FUNCTION_FLAGS);
         } else {
             // For internal function we can simply adjust a handler
             $this->pointer->handler = function (CData $executeData, CData $returnValue) use ($newCode): void {
@@ -247,8 +327,10 @@ trait FunctionLikeTrait
      */
     private function getCommonPointer(): CData
     {
-        // For zend_internal_function we have same fields directly in current structure
-        if ($this->isInternal()) {
+        // For zend_internal_function we have same fields directly in current structure.
+        // The check goes through the low-level structure (not native isInternal()) so it
+        // also works on wrappers whose native reflection state is not initialized yet
+        if (!$this->isUserDefined()) {
             $pointer = $this->pointer;
         } else {
             // zend_function uses "common" struct to store all important fields

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -75,6 +75,38 @@ class ReflectionClass extends NativeReflectionClass
     private CData $pointer;
 
     /**
+     * Function pointers in zend_class_entry that are grafted from the parent during inheritance
+     * and therefore must be detached together with the parent methods
+     */
+    private const INHERITED_FUNCTION_POINTERS = [
+        'constructor',
+        'destructor',
+        'clone',
+        '__get',
+        '__set',
+        '__unset',
+        '__isset',
+        '__call',
+        '__callstatic',
+        '__tostring',
+        '__debugInfo',
+        '__serialize',
+        '__unserialize',
+    ];
+
+    /**
+     * Remembers the slot capacity of the engine-allocated properties_info_table per class
+     *
+     * The table is arena-allocated by the engine during linking, so it can only be compacted
+     * or refilled in place, never grown. removeParentClass() records the capacity here and
+     * setParent() consults it to refuse a re-link that would not fit (keyed by
+     * zend_class_entry address, like the object handlers cache below).
+     *
+     * @var array<int, int>
+     */
+    private static array $propertyTableCapacity = [];
+
+    /**
      * Stores all allocated zend_object_handler pointers, keyed by zend_class_entry address
      *
      * Keying by address (and not by class name) keeps the cache bounded: anonymous classes
@@ -516,6 +548,17 @@ class ReflectionClass extends NativeReflectionClass
 
     /**
      * Removes the linked parent class from the existing class
+     *
+     * Besides interfaces and methods, this detaches everything the engine grafted from the
+     * parent during linking: class constants, property definitions (including the default
+     * property/static member tables and the property slot offsets) and the inherited
+     * constructor/destructor/magic-method pointers.
+     *
+     * <span style="color:red; font-weight:bold">Danger!</span> No instance of this class may
+     * be alive across this call: existing objects keep the old property slot layout, and
+     * destroying them after the slot count changed reads memory out of bounds. The same
+     * applies to opcodes with warmed-up property inline caches.
+     *
      * @internal
      */
     public function removeParentClass(): void
@@ -546,12 +589,348 @@ class ReflectionClass extends NativeReflectionClass
         } catch (\ReflectionException $e) {
             // This can happen during the class-loading (parent not loaded yet). But we ignore this error
         }
-        // TODO: Detach all related constants, properties, etc...
+        if ($this->isParentStateDetachable()) {
+            $this->detachParentState();
+        }
         $this->pointer->parent = null;
     }
 
     /**
+     * Checks if the grafted parent state (constants, properties, statics) can be detached safely
+     *
+     * Only linked user-defined classes are detachable: unlinked classes have nothing grafted
+     * yet, internal classes store their tables with persistent destructors that would free
+     * the parent's shared entries, and immutable (opcache-shared) classes must not be
+     * modified in place at all.
+     */
+    private function isParentStateDetachable(): bool
+    {
+        $classFlags = $this->pointer->ce_flags;
+        assert(is_int($classFlags));
+        $isLinked  = ($classFlags & Core::ZEND_ACC_LINKED) !== 0;
+        $isMutable = ($classFlags & Core::ZEND_ACC_IMMUTABLE) === 0;
+
+        return $isLinked && $isMutable && $this->isUserDefined();
+    }
+
+    /**
+     * Detaches all class state grafted from the (former) parent class
+     *
+     * Every entry whose declaring class is not this class itself is removed, symmetric with
+     * the method detachment loop in removeParentClass().
+     */
+    private function detachParentState(): void
+    {
+        $selfAddress = Core::addressOf($this->pointer);
+
+        $this->detachParentConstants($selfAddress);
+        $this->detachParentFunctionPointers($selfAddress);
+        $hookedProperties = $this->pointer->num_hooked_props;
+        assert(is_int($hookedProperties));
+        if ($hookedProperties === 0) {
+            $this->detachParentProperties($selfAddress);
+        }
+        // TODO: classes with property hooks (num_hooked_props > 0) keep the parent property
+        // state attached: hooked properties add extra properties_info_table entries whose
+        // layout cannot be compacted with plain slot arithmetic
+    }
+
+    /**
+     * Removes constants declared by the (former) parent class chain
+     *
+     * The constants_table of a user-defined class has no payload destructor: deleting a
+     * bucket only drops the pointer to the zend_class_constant that is still owned (and
+     * later freed) by its declaring class.
+     */
+    private function detachParentConstants(int $selfAddress): void
+    {
+        $inheritedKeys = [];
+        foreach ($this->constantsTable as $constantName => $constantValue) {
+            $rawConstant    = Core::cast('zend_class_constant *', $constantValue->getRawPointer());
+            $declaringClass = $rawConstant->ce;
+            assert(is_string($constantName) && $declaringClass instanceof CData);
+            if (Core::addressOf($declaringClass) !== $selfAddress) {
+                $inheritedKeys[] = $constantName;
+            }
+        }
+        foreach ($inheritedKeys as $constantKey) {
+            $this->constantsTable->delete($constantKey);
+        }
+    }
+
+    /**
+     * Clears constructor/destructor/magic-method shortcuts pointing into the detached parent
+     *
+     * The zend_function entries themselves stay owned by their declaring class; only the
+     * cached pointers inside this class entry are dropped, otherwise `new`, object
+     * destruction or magic-method dispatch would still call into the detached parent.
+     */
+    private function detachParentFunctionPointers(int $selfAddress): void
+    {
+        foreach (self::INHERITED_FUNCTION_POINTERS as $fieldName) {
+            $function = $this->pointer->{$fieldName};
+            if ($function === null) {
+                continue;
+            }
+            assert($function instanceof CData);
+            $functionCommon = $function->common;
+            assert($functionCommon instanceof CData);
+            $functionScope = $functionCommon->scope;
+            assert($functionScope instanceof CData);
+            if (Core::addressOf($functionScope) !== $selfAddress) {
+                $this->pointer->{$fieldName} = null;
+            }
+        }
+    }
+
+    /**
+     * Removes parent-declared properties and compacts all property storages in place
+     *
+     * Instance properties: the default_properties_table is indexed by the slot number encoded
+     * in zend_property_info.offset (OBJ_PROP_TO_NUM math: slot = (offset - base) / sizeof(zval)).
+     * Parent-declared slots - including shadow slots of parent private properties that have no
+     * properties_info entry, and dead slots left behind by property overrides - are released
+     * and the surviving own slots are re-numbered consecutively. The engine-allocated buffers
+     * are compacted in place: they stay owned by the engine, which frees them with the class.
+     *
+     * Static members: same compaction by table index, applied to default_static_members_table
+     * and, when the class statics were already materialized (CE_STATIC_MEMBERS), to the live
+     * table as well. Slots inherited from a userland parent are IS_INDIRECT views into the
+     * parent storage and are dropped without releasing anything.
+     */
+    private function detachParentProperties(int $selfAddress): void
+    {
+        $zvalSize = Core::sizeof(Core::type('zval'));
+        $slotBase = Core::type('zend_object')->getStructFieldOffset('properties_table');
+
+        // Partition properties_info into inherited entries and own instance/static definitions
+        $inheritedKeys  = [];
+        $ownSlotInfos   = [];
+        $ownStaticInfos = [];
+        foreach ($this->propertiesTable as $propertyName => $propertyValue) {
+            $rawInfo        = Core::cast('zend_property_info *', $propertyValue->getRawPointer());
+            $flags          = $rawInfo->flags;
+            $offset         = $rawInfo->offset;
+            $declaringClass = $rawInfo->ce;
+            assert(is_string($propertyName) && is_int($flags) && is_int($offset));
+            assert($declaringClass instanceof CData);
+            if (Core::addressOf($declaringClass) !== $selfAddress) {
+                $inheritedKeys[] = $propertyName;
+            } elseif (($flags & Core::ZEND_ACC_STATIC) !== 0) {
+                $ownStaticInfos[$offset] = $rawInfo;
+            } elseif (($flags & Core::ZEND_ACC_VIRTUAL) === 0) {
+                $ownSlotInfos[intdiv($offset - $slotBase, $zvalSize)] = $rawInfo;
+            }
+        }
+        foreach ($inheritedKeys as $propertyKey) {
+            $this->propertiesTable->delete($propertyKey);
+        }
+
+        $this->compactDefaultPropertiesTable($ownSlotInfos, $slotBase, $zvalSize);
+        $this->compactStaticMembersTables($ownStaticInfos, $zvalSize);
+    }
+
+    /**
+     * Compacts default_properties_table and properties_info_table down to the own slots
+     *
+     * @param array<int, CData> $ownSlotInfos zend_property_info entries of own properties, by old slot
+     */
+    private function compactDefaultPropertiesTable(array $ownSlotInfos, int $slotBase, int $zvalSize): void
+    {
+        $totalSlots = $this->pointer->default_properties_count;
+        assert(is_int($totalSlots));
+        if ($totalSlots === 0) {
+            return;
+        }
+        // The engine-allocated slot table can be refilled in place but never grown: remember
+        // its capacity so setParent() can check whether a new parent still fits
+        self::$propertyTableCapacity[Core::addressOf($this->pointer)] = $totalSlots;
+
+        // Renumber the surviving slots consecutively, keeping their relative order
+        ksort($ownSlotInfos);
+        $newSlotByOldSlot = [];
+        $nextSlot         = 0;
+        foreach ($ownSlotInfos as $oldSlot => $rawInfo) {
+            $newSlotByOldSlot[$oldSlot] = $nextSlot;
+            $rawInfo->offset            = $slotBase + $nextSlot * $zvalSize;
+            $nextSlot++;
+        }
+
+        $defaultTable = $this->pointer->default_properties_table;
+        assert($defaultTable instanceof CData);
+        $this->compactZvalTable($defaultTable, $totalSlots, $newSlotByOldSlot, $zvalSize);
+
+        // The slot-indexed property info table (used by GC, foreach and var_dump) must mirror
+        // the new slot numbering; it is compacted in place for the same ownership reason
+        $infoTable = $this->pointer->properties_info_table;
+        if ($infoTable !== null) {
+            assert($infoTable instanceof CData);
+            foreach ($ownSlotInfos as $oldSlot => $rawInfo) {
+                self::storePropertyInfoSlot($infoTable, $newSlotByOldSlot[$oldSlot], $rawInfo);
+            }
+            for ($slot = $nextSlot; $slot < $totalSlots; $slot++) {
+                self::storePropertyInfoSlot($infoTable, $slot, null);
+            }
+        }
+
+        $this->pointer->default_properties_count = $nextSlot;
+    }
+
+    /**
+     * Compacts one zval slot table in place according to the old-to-new slot mapping
+     *
+     * Dropped slots are released with engine semantics - except IS_INDIRECT views into
+     * foreign storage (inherited static member slots), which are dropped without touching
+     * the value they point to. Surviving slots move down to their new position and the
+     * vacated tail is neutralized to IS_UNDEF so no stale zval bytes can ever be
+     * interpreted - or double-released - again.
+     *
+     * @param array<int, int> $newSlotByOldSlot Surviving slots, old slot => new slot (ascending)
+     */
+    private function compactZvalTable(CData $table, int $totalSlots, array $newSlotByOldSlot, int $zvalSize): void
+    {
+        $nextSlot = count($newSlotByOldSlot);
+        for ($slot = 0; $slot < $totalSlots; $slot++) {
+            $slotValue = self::zvalTableSlot($table, $slot);
+            if (!isset($newSlotByOldSlot[$slot])) {
+                if (!self::isIndirectZval($slotValue)) {
+                    Core::call('zval_ptr_dtor', Core::addr($slotValue));
+                }
+            } elseif ($newSlotByOldSlot[$slot] !== $slot) {
+                Core::memcpy(self::zvalTableSlot($table, $newSlotByOldSlot[$slot]), $slotValue, $zvalSize);
+            }
+        }
+        for ($slot = $nextSlot; $slot < $totalSlots; $slot++) {
+            self::markZvalUndef(self::zvalTableSlot($table, $slot));
+        }
+    }
+
+    /**
+     * Returns the zval stored in the given slot of an engine zval table
+     */
+    private static function zvalTableSlot(CData $table, int $slot): CData
+    {
+        $slotValue = $table[$slot];
+        assert($slotValue instanceof CData);
+
+        return $slotValue;
+    }
+
+    /**
+     * Checks if the given zval is an IS_INDIRECT view into another storage location
+     */
+    private static function isIndirectZval(CData $zvalEntry): bool
+    {
+        $typeUnion = $zvalEntry->u1;
+        assert($typeUnion instanceof CData);
+        $typeInfo = $typeUnion->v;
+        assert($typeInfo instanceof CData);
+
+        return $typeInfo->type === ReflectionValue::IS_INDIRECT;
+    }
+
+    /**
+     * Overwrites the type of the given zval with IS_UNDEF (without releasing anything)
+     */
+    private static function markZvalUndef(CData $zvalEntry): void
+    {
+        $typeUnion = $zvalEntry->u1;
+        assert($typeUnion instanceof CData);
+        $typeUnion->type_info = ReflectionValue::IS_UNDEF;
+    }
+
+    /**
+     * Stores a zend_property_info pointer (or null for an empty slot) into the slot-indexed
+     * properties_info_table
+     *
+     * The offset write mutates engine memory behind the FFI pointer, which static analysis
+     * cannot see - hence the explicit impurity marker.
+     *
+     * @phpstan-impure
+     */
+    private static function storePropertyInfoSlot(CData $infoTable, int $slot, ?CData $propertyInfo): void
+    {
+        $infoTable[$slot] = $propertyInfo;
+    }
+
+    /**
+     * Compacts the default (and, if materialized, the live) static member tables
+     *
+     * @param array<int, CData> $ownStaticInfos zend_property_info entries of own statics, by old index
+     */
+    private function compactStaticMembersTables(array $ownStaticInfos, int $zvalSize): void
+    {
+        $totalSlots = $this->pointer->default_static_members_count;
+        assert(is_int($totalSlots));
+        if ($totalSlots === 0) {
+            return;
+        }
+
+        ksort($ownStaticInfos);
+        $newSlotByOldSlot = [];
+        $nextSlot         = 0;
+        foreach ($ownStaticInfos as $oldSlot => $rawInfo) {
+            $newSlotByOldSlot[$oldSlot] = $nextSlot;
+            $rawInfo->offset            = $nextSlot;
+            $nextSlot++;
+        }
+
+        $tables       = [];
+        $defaultTable = $this->pointer->default_static_members_table;
+        if ($defaultTable !== null) {
+            assert($defaultTable instanceof CData);
+            $tables[] = $defaultTable;
+        }
+        // Inherited slots (IS_INDIRECT views into the parent storage) are dropped without
+        // releasing the parent's value - both in the default table and in the live one
+        $materialized = $this->getMaterializedStaticMembersTable();
+        if ($materialized !== null) {
+            $tables[] = $materialized;
+        }
+        foreach ($tables as $table) {
+            $this->compactZvalTable($table, $totalSlots, $newSlotByOldSlot, $zvalSize);
+        }
+
+        $this->pointer->default_static_members_count = $nextSlot;
+    }
+
+    /**
+     * Returns the materialized CE_STATIC_MEMBERS table if it is a plain separate pointer
+     *
+     * Once any static member is touched, the engine materializes a live copy of the static
+     * table (zend_class_init_statics) and every further access goes through it. Map-ptr
+     * offsets (low bit set, opcache-shared classes) and the legacy case where the map ptr
+     * aliases default_static_members_table are reported as null - nothing extra to fix then.
+     */
+    private function getMaterializedStaticMembersTable(): ?CData
+    {
+        $materialized = $this->pointer->static_members_table__ptr;
+        if ($materialized === null) {
+            return null;
+        }
+        assert($materialized instanceof CData);
+        $materializedAddress = Core::addressOf($materialized);
+        if (($materializedAddress & 1) !== 0) {
+            return null;
+        }
+        $defaultTable = $this->pointer->default_static_members_table;
+        if ($defaultTable !== null) {
+            assert($defaultTable instanceof CData);
+            if ($materializedAddress === Core::addressOf($defaultTable)) {
+                return null;
+            }
+        }
+
+        return $materialized;
+    }
+
+    /**
      * Configures a new parent class for this one
+     *
+     * <span style="color:red; font-weight:bold">Danger!</span> Like removeParentClass(), this
+     * changes the property slot layout: no instance of this class may be alive across the
+     * call, and a parent that declares more properties than the original one cannot be
+     * attached to an already-linked class (the engine-allocated slot tables cannot grow).
      *
      * @param string $newParent New parent class name
      * @internal
@@ -568,9 +947,160 @@ class ReflectionClass extends NativeReflectionClass
         if ($parentClassValue === null) {
             throw new \ReflectionException("Class {$newParent} was not found");
         }
+        $parentEntry = $parentClassValue->getRawClass();
+
+        $isDetachable = $this->isParentStateDetachable();
+        if ($isDetachable) {
+            // Refuse re-linking that would overflow the fixed-capacity slot tables before
+            // any engine state is modified
+            $this->assertParentFitsPropertyTables($parentEntry);
+            // The materialized static members table (if any) matches the pre-inheritance
+            // layout and cannot be resized: fold the live values back into the default
+            // table and let the engine materialize a fresh one lazily
+            $this->foldMaterializedStaticMembersTable();
+        }
 
         // Call API to reduce the boilerplate code
-        Core::call('zend_do_inheritance_ex', $this->pointer, $parentClassValue->getRawClass(), 0);
+        Core::call('zend_do_inheritance_ex', $this->pointer, $parentEntry, 0);
+
+        if ($isDetachable) {
+            // zend_do_inheritance_ex() does not rebuild the slot-indexed property info
+            // table for an already-linked class, so mirror the new layout ourselves
+            $this->refillPropertiesInfoTable($parentEntry);
+        }
+    }
+
+    /**
+     * Ensures the slot tables of this class can hold the properties of the new parent
+     *
+     * @param CData $parentEntry zend_class_entry of the new parent
+     */
+    private function assertParentFitsPropertyTables(CData $parentEntry): void
+    {
+        if ($this->pointer->properties_info_table === null) {
+            return;
+        }
+        $parentHookedProperties = $parentEntry->num_hooked_props;
+        assert(is_int($parentHookedProperties));
+        if ($parentHookedProperties > 0) {
+            throw new \ReflectionException('Cannot inherit a class with property hooks in runtime');
+        }
+        $ownSlots    = $this->pointer->default_properties_count;
+        $parentSlots = $parentEntry->default_properties_count;
+        assert(is_int($ownSlots) && is_int($parentSlots));
+        $capacity = self::$propertyTableCapacity[Core::addressOf($this->pointer)] ?? null;
+        if ($capacity === null || $ownSlots + $parentSlots > $capacity) {
+            throw new \ReflectionException(
+                'Cannot set a parent class with more properties than the original parent: '
+                . 'the engine-allocated property slot tables cannot grow after linking',
+            );
+        }
+    }
+
+    /**
+     * Folds the live (materialized) static member values back into the default table
+     *
+     * The materialized table cannot be reused after inheritance changes the static member
+     * count, and it cannot be freed through FFI (it belongs to the request allocator, the
+     * engine releases it at shutdown only through the map pointer). Transferring the values
+     * into default_static_members_table keeps them alive and leak-free; only the bare table
+     * block stays allocated until the end of the request.
+     */
+    private function foldMaterializedStaticMembersTable(): void
+    {
+        $mapPointer = $this->pointer->static_members_table__ptr;
+        if ($mapPointer === null) {
+            return;
+        }
+        assert($mapPointer instanceof CData);
+        if ((Core::addressOf($mapPointer) & 1) !== 0) {
+            // Map-ptr offset form (opcache-shared class): not ours to manage
+            return;
+        }
+        $materialized = $this->getMaterializedStaticMembersTable();
+        if ($materialized !== null) {
+            $zvalSize     = Core::sizeof(Core::type('zval'));
+            $defaultTable = $this->pointer->default_static_members_table;
+            $totalSlots   = $this->pointer->default_static_members_count;
+            assert($defaultTable instanceof CData && is_int($totalSlots));
+            for ($slot = 0; $slot < $totalSlots; $slot++) {
+                $liveValue = self::zvalTableSlot($materialized, $slot);
+                if (self::isIndirectZval($liveValue) || self::isUndefZval($liveValue)) {
+                    continue;
+                }
+                // The default slot hands its old value over and adopts the live one
+                $defaultValue = self::zvalTableSlot($defaultTable, $slot);
+                Core::call('zval_ptr_dtor', Core::addr($defaultValue));
+                Core::memcpy($defaultValue, $liveValue, $zvalSize);
+                self::markZvalUndef($liveValue);
+            }
+        }
+        // Detach the map pointer: zend_do_inheritance_ex() reallocates the default table, so
+        // a stale alias or an undersized materialized table would dangle after re-linking;
+        // the engine re-materializes the statics lazily on next access
+        $this->pointer->static_members_table__ptr = null;
+    }
+
+    /**
+     * Checks if the given zval slot is IS_UNDEF
+     */
+    private static function isUndefZval(CData $zvalEntry): bool
+    {
+        $typeUnion = $zvalEntry->u1;
+        assert($typeUnion instanceof CData);
+        $typeInfo = $typeUnion->v;
+        assert($typeInfo instanceof CData);
+
+        return $typeInfo->type === ReflectionValue::IS_UNDEF;
+    }
+
+    /**
+     * Refills the slot-indexed properties_info_table after a manual re-link
+     *
+     * Mirrors zend_build_properties_info_table(): parent slots are copied from the parent's
+     * table, own non-static non-virtual properties are placed by their (already re-based)
+     * slot offsets, dead override slots stay empty.
+     *
+     * @param CData $parentEntry zend_class_entry of the freshly attached parent
+     */
+    private function refillPropertiesInfoTable(CData $parentEntry): void
+    {
+        $infoTable = $this->pointer->properties_info_table;
+        if ($infoTable === null) {
+            return;
+        }
+        assert($infoTable instanceof CData);
+        $selfAddress = Core::addressOf($this->pointer);
+        $zvalSize    = Core::sizeof(Core::type('zval'));
+        $slotBase    = Core::type('zend_object')->getStructFieldOffset('properties_table');
+        $totalSlots  = $this->pointer->default_properties_count;
+        assert(is_int($totalSlots));
+
+        for ($slot = 0; $slot < $totalSlots; $slot++) {
+            self::storePropertyInfoSlot($infoTable, $slot, null);
+        }
+        $parentTable = $parentEntry->properties_info_table;
+        if ($parentTable !== null) {
+            assert($parentTable instanceof CData);
+            $parentSlots = $parentEntry->default_properties_count;
+            assert(is_int($parentSlots));
+            for ($slot = 0; $slot < $parentSlots; $slot++) {
+                $parentInfo = $parentTable[$slot];
+                assert($parentInfo === null || $parentInfo instanceof CData);
+                self::storePropertyInfoSlot($infoTable, $slot, $parentInfo);
+            }
+        }
+        foreach ($this->propertiesTable as $propertyValue) {
+            $rawInfo        = Core::cast('zend_property_info *', $propertyValue->getRawPointer());
+            $flags          = $rawInfo->flags;
+            $offset         = $rawInfo->offset;
+            $declaringClass = $rawInfo->ce;
+            assert(is_int($flags) && is_int($offset) && $declaringClass instanceof CData);
+            $isOwn = Core::addressOf($declaringClass) === $selfAddress;
+            if ($isOwn && ($flags & (Core::ZEND_ACC_STATIC | Core::ZEND_ACC_VIRTUAL)) === 0) {
+                self::storePropertyInfoSlot($infoTable, intdiv($offset - $slotBase, $zvalSize), $rawInfo);
+            }
+        }
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -985,13 +985,14 @@ class ReflectionClass extends NativeReflectionClass
     }
 
     /**
-     * Folds the live (materialized) static member values back into the default table
+     * Folds the live (materialized) static member values back into the default table and
+     * releases the materialized table itself
      *
      * The materialized table cannot be reused after inheritance changes the static member
-     * count, and it cannot be freed through FFI (it belongs to the request allocator, the
-     * engine releases it at shutdown only through the map pointer). Transferring the values
-     * into default_static_members_table keeps them alive and leak-free; only the bare table
-     * block stays allocated until the end of the request.
+     * count. Its values are transferred into default_static_members_table (so they survive
+     * the re-link) and the emalloc'd table block from zend_class_init_statics() is handed
+     * back to the request allocator: FFI::free() on a pointer CData performs an engine
+     * efree() of the pointed block, which matches the original allocation exactly.
      */
     private function foldMaterializedStaticMembersTable(): void
     {
@@ -1021,10 +1022,14 @@ class ReflectionClass extends NativeReflectionClass
                 Core::memcpy($defaultValue, $liveValue, $zvalSize);
                 self::markZvalUndef($liveValue);
             }
+            // Every value has been moved out (or is an indirect view): return the bare
+            // zval[] block to the request allocator, exactly reversing the engine's
+            // emalloc in zend_class_init_statics()
+            Core::free($materialized);
         }
         // Detach the map pointer: zend_do_inheritance_ex() reallocates the default table, so
-        // a stale alias or an undersized materialized table would dangle after re-linking;
-        // the engine re-materializes the statics lazily on next access
+        // a stale alias would dangle after re-linking; the engine re-materializes the
+        // statics lazily on next access
         $this->pointer->static_members_table__ptr = null;
     }
 

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -344,28 +344,15 @@ class ReflectionClass extends NativeReflectionClass
         $closureEntry->getClosureObjectEntry()->incrementReferenceCount();
         $closureEntry->setCalledScope($this->name);
 
-        // TODO: replace with ReflectionFunction instead of low-level structures
-        $rawFunction  = $closureEntry->getRawFunction();
-        $previousName = $rawFunction->common->function_name;
-        if ($previousName !== null) {
-            StringEntry::fromCData($previousName)->releaseReference();
-        }
-        // The function structure takes over one owned reference on its new name
-        $rawFunction->common->function_name = StringEntry::fromString($methodName)
-            ->transferReferenceOwnership()
-            ->getRawValue();
+        // Bind the closure-backed zend_function to this class through the reflection
+        // wrappers: renaming, scope binding and closure-flag surgery live in the
+        // ReflectionMethod/FunctionLikeTrait API instead of hand-written field writes
+        $boundMethod = ReflectionMethod::fromClosureEntry($closureEntry, $this->name, $methodName);
+        $boundMethod->setPublic();
 
-        // Adjust the scope of our function to our class
-        $classScopeValue            = Core::$executor->classTable->find(strtolower($this->name));
-        $rawFunction->common->scope = $classScopeValue->getRawClass();
-
-        // Clean closure flag
-        $rawFunction->common->fn_flags &= (~Core::ZEND_ACC_CLOSURE);
-
-        $refMethod = $this->addRawMethod($methodName, $rawFunction);
-        $refMethod->setPublic();
-
-        return $refMethod;
+        // Publish the function in the method table and re-wrap it so the returned
+        // reflection is backed by fully-initialized native reflection state
+        return $this->addRawMethod($methodName, $closureEntry->getRawFunction());
     }
 
     #[\ReturnTypeWillChange]
@@ -1536,9 +1523,14 @@ class ReflectionClass extends NativeReflectionClass
         $this->methodTable->add(strtolower($methodName), $valueEntry);
         $valueEntry->release();
 
-        $refMethod = ReflectionMethod::fromCData($rawFunction);
+        // Wrap the zend_function pointer stored in the method table (not the passed
+        // structure) so pointer-level wrapper APIs like redefine() work on the result
+        $storedEntry = $this->methodTable->find(strtolower($methodName));
+        if ($storedEntry === null) {
+            throw new \ReflectionException("Method {$methodName} was not published in the class");
+        }
 
-        return $refMethod;
+        return ReflectionMethod::fromCData($storedEntry->getRawFunction());
     }
 
     /**

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -16,6 +16,7 @@ namespace ZEngine\Reflection;
 use FFI\CData;
 use ReflectionMethod as NativeReflectionMethod;
 use ZEngine\Core;
+use ZEngine\Type\ClosureEntry;
 use ZEngine\Type\HashTable;
 use ZEngine\Type\StringEntry;
 
@@ -70,6 +71,37 @@ class ReflectionMethod extends NativeReflectionMethod
             $functionName->getStringValue(),
         );
         $reflectionMethod->pointer = $functionEntry;
+
+        return $reflectionMethod;
+    }
+
+    /**
+     * Binds the zend_function embedded into a closure to the given class as a method
+     *
+     * All function surgery goes through the wrapper API: the entry is renamed, attached to
+     * the class scope and stripped of its ZEND_ACC_CLOSURE flag. The caller stays responsible
+     * for the closure lifetime (the embedded zend_function lives inside the closure object)
+     * and for publishing the function in the class method table.
+     *
+     * Note: the native reflection state of the returned wrapper is not initialized (the
+     * method is not registered in the class yet), so only the low-level API is usable on it.
+     * Re-wrap the function after publishing to get a fully functional reflection, like
+     * ReflectionClass::addMethod() does.
+     *
+     * @internal
+     */
+    public static function fromClosureEntry(
+        ClosureEntry $closureEntry,
+        string $className,
+        string $methodName,
+    ): ReflectionMethod {
+        /** @var ReflectionMethod $reflectionMethod */
+        $reflectionMethod          = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionMethod->pointer = Core::cast('zend_function *', Core::addr($closureEntry->getRawFunction()));
+
+        $reflectionMethod->setFunctionName($methodName);
+        $reflectionMethod->setDeclaringClass($className);
+        $reflectionMethod->setClosureFlag(false);
 
         return $reflectionMethod;
     }

--- a/tests/Memory/scenarios/remove-parent-class.php
+++ b/tests/Memory/scenarios/remove-parent-class.php
@@ -75,9 +75,15 @@ for ($index = 0; $index < $iterations; $index++) {
 }
 
 // Relink churn: removeParentClass() followed by setParent() must return the class to a
-// fully consistent state without leaking the per-relink table reallocations
-$refChild = new ReflectionClass(TestChildClass::class);
+// fully consistent state without leaking the per-relink table reallocations. Reading a
+// static member re-materializes the live statics table on every cycle, so the fold-back
+// in setParent() (values moved into the defaults, table block efree'd) is exercised too.
+$refChild       = new ReflectionClass(TestChildClass::class);
+$refChildNative = new \ReflectionClass(TestChildClass::class);
 for ($index = 0; $index < 50; $index++) {
+    if ($refChildNative->getStaticPropertyValue('childStaticProperty') !== ['child']) {
+        throw new RuntimeException('Own static member was corrupted during the relink churn');
+    }
     $refChild->removeParentClass();
     $refChild->setParent(TestParentClass::class);
 }

--- a/tests/Memory/scenarios/remove-parent-class.php
+++ b/tests/Memory/scenarios/remove-parent-class.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionClass;
+use ZEngine\Stub\TestChildClass;
+use ZEngine\Stub\TestParentClass;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+// Detach churn: every class goes through the full removal - constants, properties
+// (including the private parent shadow slot and the own override that adopted a parent
+// slot), materialized static members and methods - then instances are created, mutated
+// and destroyed. Instances never live across a parent transition (see the docblock of
+// removeParentClass(): existing objects keep the old property slot layout).
+$iterations = max(1, (int) (getenv('ZENGINE_SCENARIO_ITERATIONS') ?: 100));
+for ($index = 0; $index < $iterations; $index++) {
+    $childName       = 'ScenarioChild' . $index;
+    $classDefinition = "class {$childName} extends \\ZEngine\\Stub\\TestParentClass {"
+        . "    public const CHILD_CONST = 'child';"
+        . '    public int $childProperty = 20;'
+        . '    public int $parentProperty = 30;'
+        . "    public static array \$childStaticProperty = ['child'];"
+        // Real property opcodes compiled per class: mutating own properties after the
+        // detachment exercises the slot layout exactly like ordinary user code would
+        . '    public function mutateAndCount(): int {'
+        . '        $this->childProperty += 1;'
+        . '        $this->parentProperty += 1;'
+        . '        return count(get_object_vars($this));'
+        . '    }'
+        . '}';
+    eval($classDefinition);
+    assert(class_exists($childName));
+    $refNative = new \ReflectionClass($childName);
+
+    // Touch the static member so the engine materializes the live statics table: the
+    // detachment must then compact both the default and the materialized table
+    $liveStatic = $refNative->getStaticPropertyValue('childStaticProperty');
+    assert(is_array($liveStatic));
+    $liveStatic[] = 'live';
+    $refNative->setStaticPropertyValue('childStaticProperty', $liveStatic);
+
+    $refClass = new ReflectionClass($childName);
+    $refClass->removeParentClass();
+
+    if (defined($childName . '::PARENT_CONST')) {
+        throw new RuntimeException('Parent constant was not detached');
+    }
+    if (property_exists($childName, 'parentSecret')) {
+        throw new RuntimeException('Parent property was not detached');
+    }
+    if ($refNative->getStaticPropertyValue('childStaticProperty') !== ['child', 'live']) {
+        throw new RuntimeException('Own static member was corrupted');
+    }
+
+    $instance = new $childName();
+    // The runtime-resolved method name keeps static analysis away from the eval'd class
+    $mutator = $refNative->getMethod('mutateAndCount')->getName();
+    if ($instance->$mutator() !== 2) {
+        throw new RuntimeException('Own properties were corrupted');
+    }
+    unset($instance);
+}
+
+// Relink churn: removeParentClass() followed by setParent() must return the class to a
+// fully consistent state without leaking the per-relink table reallocations
+$refChild = new ReflectionClass(TestChildClass::class);
+for ($index = 0; $index < 50; $index++) {
+    $refChild->removeParentClass();
+    $refChild->setParent(TestParentClass::class);
+}
+if (get_parent_class(TestChildClass::class) !== TestParentClass::class) {
+    throw new RuntimeException('Parent was not restored after the relink churn');
+}
+$instance = new TestChildClass();
+if (get_object_vars($instance) !== ['parentProperty' => 30, 'childProperty' => 20]) {
+    throw new RuntimeException('Property state after the relink churn is corrupted');
+}
+unset($instance);
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;

--- a/tests/Reflection/ReflectionClassParentTest.php
+++ b/tests/Reflection/ReflectionClassParentTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Reflection;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Stub\TestChildClass;
+use ZEngine\Stub\TestParentClass;
+
+/**
+ * Covers the full parent detachment performed by removeParentClass() and the re-linking
+ * via setParent(). Every test mutates the engine state of TestChildClass destructively and
+ * therefore runs in the process-isolated `internal` group.
+ */
+class ReflectionClassParentTest extends TestCase
+{
+    private ReflectionClass $refClass;
+
+    public function setUp(): void
+    {
+        $this->refClass = new ReflectionClass(TestChildClass::class);
+    }
+
+    #[Group('internal')]
+    public function testRemoveParentClassDetachesParentLink(): void
+    {
+        $this->refClass->removeParentClass();
+
+        // The engine-level class name breaks static analysis constant folding on purpose:
+        // these relations exist only at runtime after the surgery
+        $className = $this->refClass->getName();
+        $this->assertFalse(get_parent_class($className));
+        $this->assertFalse(is_subclass_of($className, TestParentClass::class));
+        // An instance created after the detachment does not pass the parent type check
+        $instance = new TestChildClass();
+        $this->assertFalse(is_subclass_of(get_class($instance) . '', TestParentClass::class));
+    }
+
+    #[Group('internal')]
+    public function testRemoveParentClassDetachesConstants(): void
+    {
+        $this->refClass->removeParentClass();
+
+        $this->assertFalse(defined(TestChildClass::class . '::PARENT_CONST'));
+        // Own constants stay reachable, also through the low-level constants table
+        $this->assertSame('child-const', TestChildClass::CHILD_CONST);
+        $refConstant = $this->refClass->getReflectionConstant('CHILD_CONST');
+        $this->assertSame(TestChildClass::class, $refConstant->getDeclaringClass()->getName());
+
+        // The parent class itself must keep its constant untouched
+        $this->assertSame('parent-const', TestParentClass::PARENT_CONST);
+
+        $this->expectException(\ReflectionException::class);
+        $this->expectExceptionMessage('Constant PARENT_CONST does not exist');
+        $this->refClass->getReflectionConstant('PARENT_CONST');
+    }
+
+    #[Group('internal')]
+    public function testRemoveParentClassDetachesProperties(): void
+    {
+        // Four slots before the detachment: parentProperty + private parentSecret from the
+        // parent, childProperty and the dead slot left by the parentProperty override
+        $this->assertCount(4, $this->refClass->getDefaultProperties());
+
+        $this->refClass->removeParentClass();
+
+        // Parent-declared properties (including the private shadow slot) are gone,
+        // own properties - including the override that adopted a parent slot - survive
+        $this->assertFalse(property_exists(TestChildClass::class, 'parentSecret'));
+        $this->assertTrue(property_exists(TestChildClass::class, 'childProperty'));
+        $this->assertTrue(property_exists(TestChildClass::class, 'parentProperty'));
+
+        // The compacted default properties table contains exactly the two own slots
+        $defaultProperties = $this->refClass->getDefaultProperties();
+        $this->assertCount(2, $defaultProperties);
+
+        $nativeDefaults = (new \ReflectionClass(TestChildClass::class))->getDefaultProperties();
+        $this->assertArrayNotHasKey('parentSecret', $nativeDefaults);
+        $this->assertSame(20, $nativeDefaults['childProperty']);
+        $this->assertSame(30, $nativeDefaults['parentProperty']);
+    }
+
+    #[Group('internal')]
+    public function testRemoveParentClassDetachesStaticMembers(): void
+    {
+        // Touch the statics first so the engine materializes the live static members table:
+        // the historically segfault-prone path goes through that second table
+        TestChildClass::$childStaticProperty[] = 'materialized';
+
+        $this->refClass->removeParentClass();
+
+        $staticMembers = (new \ReflectionClass(TestChildClass::class))->getStaticProperties();
+        $this->assertArrayNotHasKey('parentStaticProperty', $staticMembers);
+        // Own static keeps its live (materialized) value, stays readable and writable
+        $this->assertSame(['child', 'materialized'], $staticMembers['childStaticProperty']);
+        TestChildClass::$childStaticProperty[] = 'after-detach';
+        $this->assertSame(['child', 'materialized', 'after-detach'], TestChildClass::$childStaticProperty);
+
+        // The parent class keeps its own static member untouched
+        $this->assertSame(['parent'], TestParentClass::$parentStaticProperty);
+    }
+
+    #[Group('internal')]
+    public function testRemoveParentClassDetachesMethods(): void
+    {
+        $this->refClass->removeParentClass();
+
+        // The runtime class name avoids static analysis folding of method_exists()
+        $className = $this->refClass->getName();
+        $this->assertFalse(method_exists($className, 'parentMethod'));
+        $this->assertTrue(method_exists($className, 'childMethod'));
+        $this->assertSame('child', (new TestChildClass())->childMethod());
+    }
+
+    #[Group('internal')]
+    public function testDetachedClassInstancesAreFullyUsable(): void
+    {
+        $this->refClass->removeParentClass();
+
+        // Instances created after the detachment must construct, read/write their own
+        // properties, expose consistent property lists and destruct without crashing
+        $instance = new TestChildClass();
+        $this->assertSame(20, $instance->childProperty);
+        $this->assertSame(30, $instance->parentProperty);
+
+        $instance->childProperty = 21;
+        $instance->parentProperty += 100;
+        $this->assertSame(21, $instance->childProperty);
+        $this->assertSame(130, $instance->parentProperty);
+
+        $expectedState = ['parentProperty' => 130, 'childProperty' => 21];
+        $this->assertSame($expectedState, get_object_vars($instance));
+        $this->assertSame($expectedState, (array) $instance);
+
+        unset($instance);
+        gc_collect_cycles();
+        // Surviving the destruction of a detached-layout instance is the point here: a new
+        // instance must still come up with pristine defaults afterwards
+        $this->assertSame(20, (new TestChildClass())->childProperty);
+    }
+
+    #[Group('internal')]
+    public function testRemoveParentClassRequiresParent(): void
+    {
+        $this->refClass->removeParentClass();
+
+        $this->expectException(\ReflectionException::class);
+        $this->expectExceptionMessage('Could not remove non-existent parent class');
+        $this->refClass->removeParentClass();
+    }
+
+    #[Group('internal')]
+    public function testSetParentRestoresDetachedParent(): void
+    {
+        // Materialized statics exercise the fold-back path inside setParent()
+        TestChildClass::$childStaticProperty[] = 'live-value';
+
+        $this->refClass->removeParentClass();
+        $this->refClass->setParent(TestParentClass::class);
+
+        $this->assertSame(TestParentClass::class, get_parent_class(TestChildClass::class));
+        $this->assertSame('parent-const', TestChildClass::PARENT_CONST);
+        // All four property slots (incl. the private parent shadow and the dead override
+        // slot) are back after re-linking
+        $this->assertCount(4, $this->refClass->getDefaultProperties());
+        $this->assertSame('parent', (new TestChildClass())->parentMethod());
+
+        $staticMembers = (new \ReflectionClass(TestChildClass::class))->getStaticProperties();
+        // Inherited static is attached again and the own live value survived the round trip
+        $this->assertSame(['parent'], $staticMembers['parentStaticProperty']);
+        $this->assertSame(['child', 'live-value'], $staticMembers['childStaticProperty']);
+
+        $nativeDefaults = (new \ReflectionClass(TestChildClass::class))->getDefaultProperties();
+        $this->assertSame(20, $nativeDefaults['childProperty']);
+        $this->assertSame(30, $nativeDefaults['parentProperty'], 'Own override must win again');
+    }
+}

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -61,7 +61,7 @@ class ReflectionClassTest extends TestCase
         // so the debug-build shutdown report would flag it although nothing is wrong
         ini_set('report_memleaks', '0');
         $methodName = 'newMethod';
-        $this->refClass->addMethod($methodName, function (string $argument): string {
+        $refMethod  = $this->refClass->addMethod($methodName, function (string $argument): string {
             return $argument;
         });
         $isMethodExists = method_exists(TestClass::class, $methodName);
@@ -69,6 +69,24 @@ class ReflectionClassTest extends TestCase
         $instance = new TestClass();
         $result   = $instance->$methodName('Test');
         $this->assertSame('Test', $result);
+
+        // The returned reflection must be fully functional
+        $this->assertSame($methodName, $refMethod->getName());
+        $this->assertSame(TestClass::class, $refMethod->getDeclaringClass()->getName());
+        $this->assertTrue($refMethod->isPublic());
+        $this->assertFalse($refMethod->isClosure());
+        $this->assertSame('Invoked', $refMethod->invoke($instance, 'Invoked'));
+
+        // ...including the pointer-level API: redefine the fresh method and call it again
+        // (the redefining closure must stay alive while the method is callable - it owns
+        // the op_array the method now executes)
+        $newBody = function (string $argument): string {
+            return strrev($argument);
+        };
+        $refMethod->redefine($newBody);
+        // The runtime-resolved name keeps static analysis away from the dynamic method
+        $dynamicName = $refMethod->getName();
+        $this->assertSame('tseT', $instance->$dynamicName('Test'));
     }
 
     public function testSetAbstract()

--- a/tests/Stub/TestChildClass.php
+++ b/tests/Stub/TestChildClass.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+/**
+ * Child part of the inheritance pair used by the removeParentClass()/setParent() tests
+ */
+class TestChildClass extends TestParentClass
+{
+    public const CHILD_CONST = 'child-const';
+
+    public int $childProperty = 20;
+
+    /**
+     * Overrides the parent property: the child declaration adopts the parent's property
+     * slot during linking and leaves a dead slot behind - both must survive detachment
+     */
+    public int $parentProperty = 30;
+
+    /** @var list<string> */
+    public static array $childStaticProperty = ['child'];
+
+    public function childMethod(): string
+    {
+        return 'child';
+    }
+}

--- a/tests/Stub/TestParentClass.php
+++ b/tests/Stub/TestParentClass.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+/**
+ * Parent part of the inheritance pair used by the removeParentClass()/setParent() tests
+ */
+class TestParentClass
+{
+    public const PARENT_CONST = 'parent-const';
+
+    public int $parentProperty = 10;
+
+    /**
+     * Private parent properties occupy shadow slots in the child class that have no
+     * properties_info entry - the detachment logic must drop them by slot, not by name
+     */
+    private string $parentSecret = 'parent secret default value';
+
+    /** @var list<string> */
+    public static array $parentStaticProperty = ['parent'];
+
+    public function parentMethod(): string
+    {
+        return 'parent';
+    }
+
+    public function tellParentSecret(): string
+    {
+        return $this->parentSecret;
+    }
+}


### PR DESCRIPTION
Fixes #72

## Summary

Three commits — one per TODO, plus a debug-build leak fix found by CI:

### 1. `fix(reflection): detach parent constants, properties and statics in removeParentClass()`

`removeParentClass()` now performs the full detachment for **linked, mutable, user-defined** classes (in addition to the pre-existing interface + method removal):

- **Constants** — `constants_table` buckets whose `zend_class_constant.ce` is not the class itself are deleted. User-class constant tables carry no payload destructor, so the parent keeps sole ownership of its entries (verified: the parent's constants stay intact).
- **Instance properties** — inherited `properties_info` entries are removed and the surviving own slots are renumbered consecutively via `OBJ_PROP_TO_NUM` math on `zend_property_info.offset`. The compaction uses a general slot map rather than a "leading parent block" rule because two probe-verified layout facts demand it: parent **private** properties occupy shadow slots with no `properties_info` entry, and an own property that **overrides** a parent one adopts the *parent's* slot, leaving a dead `IS_UNDEF` hole in the own range. `default_properties_table` and the slot-indexed `properties_info_table` are compacted strictly **in place** — the engine keeps allocation ownership of both buffers (no allocator mismatch, `destroy_zend_class()`/arena free them exactly as before). Dropped defaults are released with `zval_ptr_dtor`; the vacated tail is neutralized to `IS_UNDEF`.
- **Static members** — same index-based compaction applied to `default_static_members_table` **and** to the lazily materialized `CE_STATIC_MEMBERS` table (on 8.4 the engine materializes a separate live table on first static access — the historically segfault-prone path). Inherited slots are `IS_INDIRECT` views into the parent's storage and are dropped without releasing anything; own live values survive the detachment.
- **Function shortcuts** — `ce->constructor`, `destructor`, `clone` and the magic-method pointers are cleared when their scope is the former parent chain, so `new`/dispatch cannot reach detached bodies.
- The original `// TODO: Detach all related constants, properties, etc...` is gone.

`setParent()` was taught to keep a previously-detached class consistent on re-link (it starts by calling `removeParentClass()`, so it inherits the new invariants):

- the materialized static table can never be resized to the post-inheritance layout, so its live values are folded back into the default table and the table is dropped — the engine re-materializes lazily (values survive the round trip, covered by a test);
- `properties_info_table` is refilled from the freshly inherited layout, mirroring `zend_build_properties_info_table()` (which `zend_do_inheritance_ex()` does **not** re-run for an already-linked class — this was the source of a reproducible re-link segfault in `zend_object_std_dtor`/`get_object_vars` before the fix);
- a parent that would overflow the fixed-capacity slot tables is refused with a `ReflectionException` **before** any engine state is mutated (the capacity is recorded at detach time; those arena/emalloc buffers cannot grow through FFI).

### 2. `refactor(reflection): build addMethod() on reflection wrappers`

- New wrapper API: `FunctionLikeTrait::setFunctionName()` (engine-semantics name replacement), `FunctionLikeTrait::setClosureFlag()`, and `ReflectionMethod::fromClosureEntry()` which binds a closure's embedded `zend_function` to a class/method through those wrappers.
- `addMethod()` shrinks to lifetime management + wrapper calls; public signature `addMethod(string, \Closure): ReflectionMethod` unchanged; flag semantics identical to the previous field writes (no behavior change re #41).
- `addRawMethod()` now re-wraps the *pointer* stored in the method table, so the returned reflection supports the pointer-level API — previously `->redefine()` on an `addMethod()` result died immediately with an FFI error.
- Bonus fix required to honor the "returned reflection is fully functional" criterion: `redefine()` performed a whole-`common` copy, which on PHP 8.2+ (where `run_time_cache__ptr` and `T` moved into `zend_function.common`) grafted a run-time cache and temporaries count sized for the **old** opcodes onto the new body — a reproducible segfault (VM jumps through garbage cache slots). `redefine()` now replaces the whole function and restores only the declaration identity (name reference, scope, prototype, declaration-level flags), leaving all body-level state with the op_array it was compiled for. The donor closure object is no longer written to.
- The original `// TODO: replace with ReflectionFunction instead of low-level structures` is gone.

### 3. `fix(reflection): release the materialized statics table in the setParent() fold-back`

The CI debug build flagged one leaked block per `removeParentClass()` → `setParent()` round trip: the emalloc'd `CE_STATIC_MEMBERS` table (`zend_object_handlers.c:2099`, `zend_class_init_statics()`) was orphaned by the fold-back on the assumption engine request memory cannot be freed through FFI. It can: `FFI::free()` on a pointer CData performs `pefree(*ptr, ...)` with `is_zend_ptr()` allocator detection — exactly the engine `efree()` matching the original allocation. The fold now transfers every live value into the defaults and returns the empty `zval[]` block to the request allocator; the leak scenario's relink churn re-materializes the statics table each cycle so the leak gate keeps this path covered. Verified leak-free on a local PHP 8.4.24 NTS **debug** build.

## What remains attached (narrowed TODO, and why)

- **Classes with property hooks** (`num_hooked_props > 0`): hooked properties add extra `properties_info_table` entries whose layout cannot be compacted with plain slot arithmetic; property/static detachment is skipped for them (constants/methods/interfaces still detach). Marked with a narrowed TODO in `detachParentState()`.
- **Internal classes**: their tables use persistent destructors that would free the parent's shared entries on bucket deletion; **immutable (opcache-shared) classes** must not be mutated in place at all. Both are excluded by the `isParentStateDetachable()` guard (behavior for them is unchanged from before this PR).
- **Instance lifecycle contract** (documented on both methods): no instance may live across a parent transition — objects freeze their slot layout at creation, and destroying an old-layout instance after the slot count changed reads out of bounds (probe-verified crash in `zend_object_std_dtor`). Same caveat applies to opcode inline caches warmed before the surgery. The tests and the leak scenario obey and document this contract.

## Tests

- New `tests/Reflection/ReflectionClassParentTest.php` (`#[Group('internal')]`, process-isolated): parent link/`instanceof`, constants (`getReflectionConstant()` throws; own + parent-side constants intact), default-properties compaction (4 slots → 2, private shadow + dead override slot dropped, own override survives), static members (materialized-table path: live values survive, remain writable, parent untouched), methods, instance usability (construct → mutate → `get_object_vars`/`(array)` → destroy → fresh instance pristine), double-remove error, and a full `removeParentClass()` → `setParent()` round trip.
- `testAddMethod` strengthened: returned `ReflectionMethod` asserts `getName()`, `getDeclaringClass()`, `isPublic()`, `isClosure()`, `invoke()`, and a `redefine()` round trip through the engine dispatcher.
- New leak scenario `tests/Memory/scenarios/remove-parent-class.php`: 100 eval'd child classes with full detach + per-class compiled property opcodes + materialized statics, plus a 50-iteration `removeParentClass()`/`setParent()` relink churn with per-cycle static re-materialization. Picked up automatically by the debug-build leak gate (`MemoryLeakScenarioTest`).
- The historically skipped `testRemoveTraits` (`ReflectionClassTest.php:141`) is **left skipped**: it covers `removeTraits()`, which this PR does not touch — un-skipping it would be unrelated to the parent-detachment fix.

## Test evidence

Local **PHP 8.4.24 NTS debug build** (`zend.assertions=1`, `report_memleaks=1`, mirrors CI's internal job):

```
phpunit --group internal --process-isolation --filter testSetParentRestoresDetachedParent
  OK (1 test, 8 assertions) — no leak report (previously: 1 x 32-byte block from zend_object_handlers.c:2099)
phpunit --group internal --process-isolation
  OK — 38 tests, 132 assertions, 0 errors (leak scenarios all green)
remove-parent-class scenario standalone: SCENARIO OK, exit 0, no "Freeing 0x..." lines
```

Local PHP 8.4.19 NTS release build:

```
composer test           OK — 158 tests, 2678 assertions (4 skipped, 4 incomplete — pre-existing)
composer test:internal  OK — stable across repeated runs
composer phpstan        OK — no errors, no new baseline entries
composer cs:check       OK — 0 fixable files
```

A standalone smoke script (not committed) exercised the full flow end-to-end: detach → constants/properties/statics/methods/ctor assertions → instance churn incl. `serialize()`/`(array)` → `addMethod` + `invoke` + `redefine` → `setParent` round trip with static values preserved. Output ends in `SMOKE OK`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC