### PR TITLE
feat(module): module lifecycle callbacks, phpinfo output and dependency wiring for AbstractModule

### DIFF
--- a/docs/long-running.md
+++ b/docs/long-running.md
@@ -86,13 +86,45 @@ inactive during shutdown-phase object destructors, and installing a new hook thr
   engine field in such setups — stacked chains keep intermediate `proceed()` targets from
   the previous cycle.
 
+## Module lifecycle callbacks
+
+`AbstractModule::register()` wires FFI-closure trampolines into the module entry's
+`module_startup_func` / `module_shutdown_func` / `request_startup_func` /
+`request_shutdown_func` slots when the module class implements `ModuleLifecycleInterface`,
+and into `info_func` when it implements `ModuleInfoInterface`. Two hard rules shape the
+delivery semantics:
+
+1. **The trampolines follow the standard hook lifecycle.** `Core::shutdown()` restores the
+   NULL pointers while the trampolines are still alive, so the module entry — which the
+   persistent module registry references directly since PHP 8.4 — never points into freed
+   libffi memory (ext/ffi frees every callback trampoline at its own RSHUTDOWN). Every
+   trampoline additionally checks `Core::isShutdown()` and no-ops after shutdown.
+2. **Callbacks never throw across the FFI boundary** ([#50](https://github.com/lisachenko/z-engine/issues/50)):
+   ext/ffi aborts the process on an escaping exception, and a FAILURE result from MINIT
+   escalates to a fatal `E_CORE_ERROR`. Failures are contained and reported as
+   `E_USER_WARNING`; the engine always sees SUCCESS.
+
+Consequences — **only request-phase callbacks are guaranteed**:
+
+| Callback | Delivery |
+|----------|----------|
+| `moduleStartup()` | guaranteed: the engine calls the MINIT trampoline inside `AbstractModule::startup()` |
+| `requestStartup()` | guaranteed: delivered directly by `startup()` for the current request (dl() parity — the engine only activates modules at request start) |
+| `requestShutdown()` | guaranteed: delivered at request end by z-engine's own shutdown chain, immediately **after** `Core::shutdown()` (user shutdown functions run in registration order and `Core::init()` registered first). The engine's own RSHUTDOWN walk happens later, after the trampoline pointers were cleared. Engine writes are already forbidden inside this callback. |
+| `moduleShutdown()` | best-effort only: real MSHUTDOWN runs after the FFI bridge teardown (for temporary modules in `zend_post_deactivate_modules()`, for persistent ones at process shutdown), where no PHP callback can be reached. It fires only if the engine destroys the module while the request is still alive. |
+
+Runtime-registered modules are wired for the current request only: after `Core::shutdown()`
+the entry keeps no callback pointers, so subsequent requests of the same process (FPM,
+workers) see the module without lifecycle callbacks unless it is registered again.
+
 ## Immortal-by-design allocations
 
 The debug-build leak gate treats the following as expected, by design:
 
 | Allocation | Why it stays |
 |------------|--------------|
-| Module entries, module name/globals buffers (`AbstractModule`) | the engine module registry references them for the process lifetime |
+| Module entries, module name/globals buffers (`AbstractModule`) | since PHP 8.4 the engine module registry stores the registered `zend_module_entry` pointer directly (no copy), so the entry and its buffers must live for the process lifetime; all are malloc-backed |
+| Persistent `zend_module_dep[]` arrays and their name/rel/version strings (`AbstractModule::getModuleDependencies()`) | referenced from the registered module entry's `deps` field for the process lifetime; malloc-backed, bounded to one array per registered module |
 | One `zend_object_handlers` block per hooked class entry | objects still dereference `->handlers` after user shutdown functions ran, so freeing at shutdown would be a use-after-free; blocks are malloc-backed, keyed by class entry address, and bounded |
 | One live libffi trampoline per installed hook | owned by ext/ffi, freed by its RSHUTDOWN |
 | Closures immortalized by `ReflectionClass::addMethod()` | the method table references the closure body for the rest of the request |

--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -15,9 +15,30 @@ namespace ZEngine\EngineExtension;
 
 use FFI\CData;
 use ZEngine\Core;
+use ZEngine\EngineExtension\Hook\AbstractModuleLifecycleHook;
 use ZEngine\EngineExtension\Hook\ExtensionConstructorHook;
+use ZEngine\EngineExtension\Hook\ModuleInfoHook;
+use ZEngine\EngineExtension\Hook\ModuleShutdownHook;
+use ZEngine\EngineExtension\Hook\ModuleStartupHook;
+use ZEngine\EngineExtension\Hook\RequestShutdownHook;
+use ZEngine\EngineExtension\Hook\RequestStartupHook;
 use ZEngine\Reflection\ReflectionExtension;
 
+/**
+ * Base class for userland PHP extensions (engine modules)
+ *
+ * Memory model (docs/long-running.md): since PHP 8.4 zend_register_module_ex() stores the
+ * given zend_module_entry pointer directly in the module registry - it no longer copies the
+ * structure. The entry and every buffer it references (module name, globals, dependency
+ * array and its strings) are therefore allocated persistently and stay alive for the whole
+ * process: immortal-by-design allocations.
+ *
+ * Lifecycle callbacks (ModuleLifecycleInterface) and phpinfo() output (ModuleInfoInterface)
+ * are wired opt-in through FFI-closure trampolines that follow the standard hook lifecycle:
+ * Core::shutdown() restores the NULL pointers, so the persistent module entry never points
+ * into freed libffi memory. See the interfaces and docs/long-running.md ("Module lifecycle
+ * callbacks") for the delivery guarantees.
+ */
 abstract class AbstractModule extends ReflectionExtension implements ModuleInterface
 {
     /**
@@ -36,11 +57,16 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
     private string $moduleName;
 
     /**
+     * Whether the request-end delivery of requestShutdown() has already happened
+     */
+    private bool $requestShutdownDelivered = false;
+
+    /**
      * Module constructor.
      *
      * @param string|null $moduleName Module name (optional). If not set, class name will be used as module name
      */
-    final public function __construct(string $moduleName = null)
+    final public function __construct(?string $moduleName = null)
     {
         $this->moduleName = $moduleName ?? self::detectModuleName();
 
@@ -72,6 +98,17 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
     }
 
     /**
+     * Returns the list of dependencies of this module on other engine modules
+     *
+     * @inheritDoc
+     * @return list<ModuleDependency>
+     */
+    public function getModuleDependencies(): array
+    {
+        return [];
+    }
+
+    /**
      * Checks if this module loaded or not
      */
     final public function isModuleRegistered(): bool
@@ -88,37 +125,54 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
             throw new \RuntimeException('Module ' . $this->moduleName . ' was already registered.');
         }
 
-        // We don't need persistent memory here, as PHP copies structures into persistent memory itself
-        $module     = Core::new('zend_module_entry');
+        // Since PHP 8.4 the engine stores this entry pointer directly in the module registry
+        // (no copy anymore), so the entry and every buffer it references must stay valid for
+        // the rest of the process: persistent, immortal-by-design (docs/long-running.md)
+        $module     = Core::trackedNew('zend_module_entry', true);
         $moduleName = $this->moduleName;
-        $nameLength = strlen($moduleName) + 1;
-        /* extra zero-byte */;
-        $rawName = Core::new("char[$nameLength]", false, static::targetPersistent());
-        Core::memcpy($rawName, $moduleName, $nameLength - 1);
-        $rawName[$nameLength - 1] = "\0";
+        $moduleType = static::targetPersistent() ? self::MODULE_PERSISTENT : self::MODULE_TEMPORARY;
 
         $module->size       = Core::sizeof($module);
-        $module->type       = static::targetPersistent() ? self::MODULE_PERSISTENT : self::MODULE_TEMPORARY;
-        $module->name       = $rawName;
+        $module->type       = $moduleType;
+        $module->name       = self::newPersistentString($moduleName);
         $module->zend_api   = static::targetApiVersion();
         $module->zend_debug = (int) static::targetDebug();
         $module->zts        = (int) static::targetThreadSafe();
 
         $globalType = static::globalType();
         if ($globalType !== null) {
+            // The engine dereferences globals_ptr for the module's whole registry lifetime
             $module->globals_size = Core::sizeof(Core::type($globalType));
-            $memoryStructure      = Core::new($globalType, false, static::targetPersistent());
+            $memoryStructure      = Core::trackedNew($globalType, true);
             $module->globals_ptr  = Core::addr($memoryStructure);
         }
 
-        // $module pointer will be updated, as registration method returns a copy of memory.
+        $this->attachDependencies($module);
+
         // Since PHP 8.3 the module type is passed explicitly instead of being read from the entry.
-        $realModulePointer = Core::call('zend_register_module_ex', Core::addr($module), (int) $module->type);
+        $realModulePointer = Core::call('zend_register_module_ex', Core::addr($module), $moduleType);
+        if ($realModulePointer === null) {
+            // The engine refused the entry (conflicting dependency or duplicate name) and
+            // reported an E_CORE_WARNING; the persistent buffers above are bounded, error-path
+            // allocations that stay in the tracked-block registry
+            throw new \RuntimeException('Can not register module ' . $moduleName . ' in the engine');
+        }
+        \assert($realModulePointer instanceof CData);
 
         $this->moduleEntry = $realModulePointer;
 
-        $extensionConstructor = \ReflectionExtension::class . '::__construct';
-        call_user_func([$this, $extensionConstructor], $moduleName);
+        // dl() parity: a temporary module registered mid-request is only deactivated and
+        // destroyed at request shutdown when the engine walks the full module registry
+        // instead of the handler lists precomputed at process startup
+        if (!static::targetPersistent()) {
+            Core::$executor->enableFullTablesCleanup();
+        }
+
+        $this->wireOptInCallbacks();
+
+        // Initialize the native reflection state for the freshly registered module; the
+        // ['obj', 'Class::method'] callable form is deprecated since PHP 8.4
+        (new \ReflectionMethod(\ReflectionExtension::class, '__construct'))->invoke($this, $moduleName);
     }
 
     /**
@@ -138,6 +192,12 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
         if ($result !== Core::SUCCESS) {
             throw new \RuntimeException('Can not startup module ' . $this->moduleName);
         }
+
+        // dl() parity: a module started in the middle of a request receives the current
+        // request's RINIT immediately - the engine only activates modules at request start
+        if ($this instanceof ModuleLifecycleInterface) {
+            AbstractModuleLifecycleHook::invokeContained($this->requestStartup(...), 'requestStartup');
+        }
     }
 
     /**
@@ -153,6 +213,144 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
         }
 
         return $rawPointer;
+    }
+
+    /**
+     * Renders a phpinfo()-style table for this module's information section
+     *
+     * Used as the default rendering of ModuleInfoInterface::getDisplayInfo() rows: plain
+     * `label => value` lines in text mode, an HTML table otherwise. The engine's own
+     * text/HTML switch (sapi_module.phpinfo_as_text) is not exported, PHP_SAPI is a
+     * faithful proxy for it.
+     *
+     * @param array<string, scalar> $rows Map from row label to row value
+     */
+    final protected function printInfoTable(array $rows): void
+    {
+        if (in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+            foreach ($rows as $label => $value) {
+                echo $label, ' => ', (string) $value, "\n";
+            }
+
+            return;
+        }
+        echo "<table>\n";
+        foreach ($rows as $label => $value) {
+            $renderedLabel = htmlspecialchars($label);
+            $renderedValue = htmlspecialchars((string) $value);
+            echo '<tr><td class="e">', $renderedLabel, '</td><td class="v">', $renderedValue, "</td></tr>\n";
+        }
+        echo "</table>\n";
+    }
+
+    /**
+     * Wires the opt-in lifecycle and info trampolines into the registered module entry
+     *
+     * Installed hooks follow the standard hook lifecycle: Core::shutdown() restores the
+     * NULL pointers while the trampolines are still alive, so the persistent module entry
+     * never points into freed libffi memory.
+     */
+    private function wireOptInCallbacks(): void
+    {
+        if ($this instanceof ModuleLifecycleInterface) {
+            // The Core hook registry keeps every installed hook (and its trampoline) alive
+            $lifecycleHooks = [
+                new ModuleStartupHook($this->moduleStartup(...), $this->moduleEntry),
+                new ModuleShutdownHook($this->moduleShutdown(...), $this->moduleEntry),
+                new RequestStartupHook($this->requestStartup(...), $this->moduleEntry),
+                new RequestShutdownHook($this->requestShutdown(...), $this->moduleEntry),
+            ];
+            foreach ($lifecycleHooks as $hook) {
+                $hook->install();
+            }
+
+            // Guaranteed request-end delivery of requestShutdown(): the engine walks the
+            // module registry only after user shutdown functions have run, ie after
+            // Core::shutdown() has already cleared the trampoline pointers. User shutdown
+            // functions run in registration order and Core::init() registered
+            // Core::shutdown() before any module could register itself, so this callback
+            // always runs right after the engine pointers were restored.
+            register_shutdown_function(function (): void {
+                $this->deliverRequestShutdown();
+            });
+        }
+
+        if ($this instanceof ModuleInfoInterface) {
+            $moduleInfo = $this;
+            $infoHook   = new ModuleInfoHook(function () use ($moduleInfo): void {
+                $this->printInfoTable($moduleInfo->getDisplayInfo());
+            }, $this->moduleEntry);
+            $infoHook->install();
+        }
+    }
+
+    /**
+     * Delivers ModuleLifecycleInterface::requestShutdown() at request end (idempotent)
+     *
+     * Runs after Core::shutdown(): engine pointers are already restored, so the callback
+     * must not (and cannot) write into engine structures anymore.
+     */
+    private function deliverRequestShutdown(): void
+    {
+        if ($this->requestShutdownDelivered || !$this instanceof ModuleLifecycleInterface) {
+            return;
+        }
+        $this->requestShutdownDelivered = true;
+        // A module that was registered but never started does not take part in the request
+        // lifecycle (the engine skips RSHUTDOWN for non-started modules as well)
+        if (!$this->wasModuleStarted()) {
+            return;
+        }
+        AbstractModuleLifecycleHook::invokeContained($this->requestShutdown(...), 'requestShutdown');
+    }
+
+    /**
+     * Writes the declared dependencies into the entry as a NULL-terminated zend_module_dep[]
+     *
+     * The array and its strings are persistent: the module registry references them for the
+     * rest of the process (immortal-by-design, docs/long-running.md).
+     */
+    private function attachDependencies(CData $module): void
+    {
+        $dependencies = $this->getModuleDependencies();
+        if ($dependencies === []) {
+            return;
+        }
+
+        $count           = count($dependencies);
+        $rawDependencies = Core::trackedNew('zend_module_dep[' . ($count + 1) . ']', true);
+        $index           = 0;
+        foreach ($dependencies as $dependency) {
+            $rawDependency = $rawDependencies[$index];
+            \assert($rawDependency instanceof CData);
+            $rawDependency->name = self::newPersistentString($dependency->getName());
+            $relation            = $dependency->getRelation();
+            if ($relation !== null) {
+                $rawDependency->rel = self::newPersistentString($relation);
+            }
+            $version = $dependency->getVersion();
+            if ($version !== null) {
+                $rawDependency->version = self::newPersistentString($version);
+            }
+            $rawDependency->type = $dependency->getDependencyType();
+            $index++;
+        }
+        // The trailing element stays zero-initialized: the NULL terminator the engine
+        // iterates up to
+        $module->deps = Core::cast('zend_module_dep *', $rawDependencies);
+    }
+
+    /**
+     * Allocates a persistent NUL-terminated C string tracked in the z-engine block registry
+     */
+    private static function newPersistentString(string $value): CData
+    {
+        $length = strlen($value) + 1;
+        $buffer = Core::trackedNew("char[{$length}]", true);
+        // FFI zero-initializes the buffer, so the trailing NUL byte is already in place
+        Core::memcpy($buffer, $value, $length - 1);
+
+        return $buffer;
     }
 
     /**

--- a/src/EngineExtension/Hook/AbstractModuleLifecycleHook.php
+++ b/src/EngineExtension/Hook/AbstractModuleLifecycleHook.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension\Hook;
+
+use Closure;
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+
+/**
+ * Base for the module entry lifecycle trampolines (MINIT/MSHUTDOWN/RINIT/RSHUTDOWN)
+ *
+ * Safety contract (issue #75, see docs/long-running.md "Module lifecycle callbacks"):
+ *
+ *  - After Core::shutdown() every trampoline no-ops: the engine can reach module callbacks
+ *    at points where PHP re-entry is no longer safe (eg MSHUTDOWN after request teardown).
+ *  - User callbacks never throw across the FFI boundary (issue #50): ext/ffi aborts the
+ *    process on an escaping exception, and a FAILURE result from MINIT escalates to a fatal
+ *    E_CORE_ERROR. Failures are contained and reported as E_USER_WARNING instead, and the
+ *    trampoline always reports SUCCESS to the engine.
+ *  - The trampolines follow the standard hook lifecycle: Core::shutdown() restores the NULL
+ *    pointers in the module entry, so the entry - which stays in the persistent module
+ *    registry - never points into freed libffi memory (ext/ffi frees every callback
+ *    trampoline at its own RSHUTDOWN).
+ */
+abstract class AbstractModuleLifecycleHook extends AbstractHook
+{
+    /**
+     * zend_result (*callback)(int type, int module_number);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): int
+    {
+        if (Core::isShutdown()) {
+            return Core::SUCCESS;
+        }
+        self::invokeContained($this->userHandler, static::HOOK_FIELD);
+
+        return Core::SUCCESS;
+    }
+
+    /**
+     * Invokes a module lifecycle callback with full exception containment
+     *
+     * This frame can be entered by the engine through an FFI trampoline with no PHP frame
+     * around it, so nothing may escape: the failure itself is converted into E_USER_WARNING,
+     * and even a user error handler turning that warning into an exception is swallowed.
+     *
+     * @param Closure $callback     The user lifecycle callback to invoke
+     * @param string  $callbackName Name of the callback for the failure report
+     */
+    final public static function invokeContained(Closure $callback, string $callbackName): void
+    {
+        try {
+            $callback();
+        } catch (\Throwable $failure) {
+            try {
+                trigger_error(
+                    sprintf('Module lifecycle callback %s failed: %s', $callbackName, $failure->getMessage()),
+                    E_USER_WARNING,
+                );
+            } catch (\Throwable) {
+                // A user error handler converted the warning into an exception: it must not
+                // cross the FFI boundary either (issue #50)
+            }
+        }
+    }
+}

--- a/src/EngineExtension/Hook/ModuleInfoHook.php
+++ b/src/EngineExtension/Hook/ModuleInfoHook.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension\Hook;
+
+use ZEngine\Core;
+use ZEngine\Hook\AbstractHook;
+
+/**
+ * Receiving hook for the module info callback (phpinfo() section rendering)
+ *
+ * Follows the same safety contract as the lifecycle trampolines: no-op after
+ * Core::shutdown(), and the user callback never throws across the FFI boundary (#50).
+ */
+class ModuleInfoHook extends AbstractHook
+{
+    protected const HOOK_FIELD = 'info_func';
+
+    /**
+     * void (*info_func)(zend_module_entry *zend_module);
+     *
+     * @inheritDoc
+     */
+    public function handle(...$rawArguments): void
+    {
+        if (Core::isShutdown()) {
+            return;
+        }
+        AbstractModuleLifecycleHook::invokeContained($this->userHandler, static::HOOK_FIELD);
+    }
+}

--- a/src/EngineExtension/Hook/ModuleShutdownHook.php
+++ b/src/EngineExtension/Hook/ModuleShutdownHook.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension\Hook;
+
+/**
+ * Receiving hook for the module shutdown callback (MSHUTDOWN)
+ *
+ * Best-effort by design: the engine runs real MSHUTDOWN after the FFI bridge teardown,
+ * where the trampoline pointer has already been cleared by Core::shutdown(). It only fires
+ * if the engine destroys the module while the request (and ext/ffi) is still alive.
+ */
+class ModuleShutdownHook extends AbstractModuleLifecycleHook
+{
+    protected const HOOK_FIELD = 'module_shutdown_func';
+}

--- a/src/EngineExtension/Hook/ModuleStartupHook.php
+++ b/src/EngineExtension/Hook/ModuleStartupHook.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension\Hook;
+
+/**
+ * Receiving hook for the module startup callback (MINIT)
+ *
+ * The engine calls it from zend_startup_module_ex() during AbstractModule::startup().
+ */
+class ModuleStartupHook extends AbstractModuleLifecycleHook
+{
+    protected const HOOK_FIELD = 'module_startup_func';
+}

--- a/src/EngineExtension/Hook/RequestShutdownHook.php
+++ b/src/EngineExtension/Hook/RequestShutdownHook.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension\Hook;
+
+/**
+ * Receiving hook for the request shutdown callback (RSHUTDOWN)
+ *
+ * The engine walks the module registry only after user shutdown functions have run, ie
+ * after Core::shutdown() has already cleared this trampoline pointer. The guaranteed
+ * request-end delivery of ModuleLifecycleInterface::requestShutdown() therefore happens in
+ * z-engine's own shutdown chain (see AbstractModule), not through this trampoline.
+ */
+class RequestShutdownHook extends AbstractModuleLifecycleHook
+{
+    protected const HOOK_FIELD = 'request_shutdown_func';
+}

--- a/src/EngineExtension/Hook/RequestStartupHook.php
+++ b/src/EngineExtension/Hook/RequestStartupHook.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension\Hook;
+
+/**
+ * Receiving hook for the request startup callback (RINIT)
+ *
+ * The engine only activates modules at request start, so for a module registered in the
+ * middle of a request the current request's RINIT is delivered directly by
+ * AbstractModule::startup() (dl() parity) instead of through this trampoline.
+ */
+class RequestStartupHook extends AbstractModuleLifecycleHook
+{
+    protected const HOOK_FIELD = 'request_startup_func';
+}

--- a/src/EngineExtension/ModuleDependency.php
+++ b/src/EngineExtension/ModuleDependency.php
@@ -13,10 +13,14 @@ declare(strict_types=1);
 
 namespace ZEngine\EngineExtension;
 
-use FFI\CData;
-
 /**
- * Class ModuleDependency
+ * Declares a single dependency of a userland module on another engine module
+ *
+ * Dependencies returned from ModuleInterface::getModuleDependencies() are written into the
+ * module entry's `deps` field as a persistent NULL-terminated `zend_module_dep[]` during
+ * AbstractModule::register(). The engine consults them when the module is registered
+ * (conflicts) and started (required modules must already be started); they are also
+ * visible through the native ReflectionExtension::getDependencies().
  *
  * struct _zend_module_dep {
  *   const char *name;      // module name
@@ -25,27 +29,95 @@ use FFI\CData;
  *   unsigned char type;    // dependency type
  * };
  */
-class ModuleDependency
+final class ModuleDependency
 {
     public const MODULE_REQUIRED  = 1;
     public const MODULE_CONFLICTS = 2;
     public const MODULE_OPTIONAL  = 3;
 
     /**
-     * Holds a _zend_module_dep structure
+     * Version relationships understood by the engine (zend_modules.h)
      */
-    private CData $entry;
+    private const KNOWN_RELATIONS = ['lt', 'le', 'eq', 'ge', 'gt'];
 
+    /**
+     * @param string      $name           Name of the module this dependency points to (eg 'standard')
+     * @param int         $dependencyType One of the MODULE_REQUIRED/MODULE_CONFLICTS/MODULE_OPTIONAL constants
+     * @param string|null $relation       Version relationship: null (module just has to exist) or one of lt|le|eq|ge|gt
+     * @param string|null $version        Version to compare against; required when $relation is given
+     */
     public function __construct(
-        string $name,
-        int $relationType,
-        string $version,
-        int $dependencyType = self::MODULE_REQUIRED,
+        private readonly string $name,
+        private readonly int $dependencyType = self::MODULE_REQUIRED,
+        private readonly ?string $relation = null,
+        private readonly ?string $version = null,
     ) {
+        $knownTypes = [self::MODULE_REQUIRED, self::MODULE_CONFLICTS, self::MODULE_OPTIONAL];
+        if (!in_array($dependencyType, $knownTypes, true)) {
+            throw new \InvalidArgumentException("Unknown module dependency type {$dependencyType}");
+        }
+        if ($relation !== null && !in_array($relation, self::KNOWN_RELATIONS, true)) {
+            $known = implode('|', self::KNOWN_RELATIONS);
+            throw new \InvalidArgumentException("Unknown version relation '{$relation}', expected one of {$known}");
+        }
+        if (($relation === null) !== ($version === null)) {
+            throw new \InvalidArgumentException('Version relation and version must be provided together');
+        }
+    }
 
-        $this->name           = $name;
-        $this->relationType   = $relationType;
-        $this->version        = $version;
-        $this->dependencyType = $dependencyType;
+    /**
+     * Declares that the given module must be loaded and started before this one
+     */
+    public static function required(string $name, ?string $relation = null, ?string $version = null): self
+    {
+        return new self($name, self::MODULE_REQUIRED, $relation, $version);
+    }
+
+    /**
+     * Declares that this module cannot be loaded together with the given module
+     */
+    public static function conflicts(string $name): self
+    {
+        return new self($name, self::MODULE_CONFLICTS);
+    }
+
+    /**
+     * Declares an optional relationship (affects module startup ordering only)
+     */
+    public static function optional(string $name, ?string $relation = null, ?string $version = null): self
+    {
+        return new self($name, self::MODULE_OPTIONAL, $relation, $version);
+    }
+
+    /**
+     * Returns the name of the module this dependency points to
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns the dependency type (one of the MODULE_* constants)
+     */
+    public function getDependencyType(): int
+    {
+        return $this->dependencyType;
+    }
+
+    /**
+     * Returns the version relationship (null when the module just has to exist)
+     */
+    public function getRelation(): ?string
+    {
+        return $this->relation;
+    }
+
+    /**
+     * Returns the version to compare against (null when no relation is declared)
+     */
+    public function getVersion(): ?string
+    {
+        return $this->version;
     }
 }

--- a/src/EngineExtension/ModuleInfoInterface.php
+++ b/src/EngineExtension/ModuleInfoInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension;
+
+/**
+ * Opt-in phpinfo() output for userland modules
+ *
+ * When a module class implementing this interface is registered via AbstractModule::register(),
+ * an FFI-closure trampoline is written into the module entry's `info_func` slot. Whenever the
+ * engine renders module information (phpinfo(), phpinfo(INFO_MODULES), CLI `php -i`), the
+ * rows returned by getDisplayInfo() are rendered into the module's own section by
+ * AbstractModule::printInfoTable() - as `label => value` lines in text mode and as a table
+ * in HTML mode.
+ */
+interface ModuleInfoInterface
+{
+    /**
+     * Returns the rows to render into this module's phpinfo() section
+     *
+     * @return array<string, scalar> Map from row label to row value
+     */
+    public function getDisplayInfo(): array;
+}

--- a/src/EngineExtension/ModuleInterface.php
+++ b/src/EngineExtension/ModuleInterface.php
@@ -50,6 +50,21 @@ interface ModuleInterface
     public static function globalType(): ?string;
 
     /**
+     * Returns the list of dependencies of this module on other engine modules
+     *
+     * The dependencies are written into the module entry's `deps` field as a persistent
+     * NULL-terminated `zend_module_dep[]` during registration. AbstractModule provides a
+     * default implementation returning an empty list.
+     *
+     * Named getModuleDependencies() because AbstractModule inherits the native
+     * ReflectionExtension::getDependencies(), which reads the registered entry back in the
+     * engine's own `name => relationship` format.
+     *
+     * @return list<ModuleDependency>
+     */
+    public function getModuleDependencies(): array;
+
+    /**
      * Starts this module
      *
      * Startup includes calling callbacks for global memory allocation, checking deps, etc

--- a/src/EngineExtension/ModuleLifecycleInterface.php
+++ b/src/EngineExtension/ModuleLifecycleInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension;
+
+/**
+ * Opt-in lifecycle callbacks for userland modules
+ *
+ * When a module class implementing this interface is registered via AbstractModule::register(),
+ * FFI-closure trampolines are written into the module entry's `module_startup_func`,
+ * `module_shutdown_func`, `request_startup_func` and `request_shutdown_func` slots.
+ *
+ * Delivery guarantees (see docs/long-running.md, "Module lifecycle callbacks"):
+ *
+ *  - moduleStartup() and requestStartup() are delivered during AbstractModule::startup(),
+ *    inside the current request - guaranteed.
+ *  - requestShutdown() is delivered at request end by z-engine's own shutdown chain, right
+ *    after Core::shutdown() has restored the engine pointers - guaranteed. Engine writes
+ *    are already forbidden inside it.
+ *  - moduleShutdown() is best-effort only: the engine runs real MSHUTDOWN after the FFI
+ *    bridge is torn down, where no PHP callback can be reached anymore. It fires only if
+ *    the engine destroys the module while the request (and ext/ffi) is still alive.
+ *
+ * None of the callbacks may let an exception escape: they are entered by the engine through
+ * an FFI trampoline with no PHP frame around them (see issue #50). Escaping exceptions are
+ * contained by z-engine and reported as E_USER_WARNING.
+ */
+interface ModuleLifecycleInterface
+{
+    /**
+     * Module startup callback (MINIT), called by the engine during AbstractModule::startup()
+     */
+    public function moduleStartup(): void;
+
+    /**
+     * Module shutdown callback (MSHUTDOWN), best-effort: real MSHUTDOWN runs after the FFI
+     * bridge teardown and cannot be delivered (see the interface description)
+     */
+    public function moduleShutdown(): void;
+
+    /**
+     * Request startup callback (RINIT), delivered during AbstractModule::startup() for the
+     * current request (dl() parity: the engine only activates modules at request start)
+     */
+    public function requestStartup(): void;
+
+    /**
+     * Request shutdown callback (RSHUTDOWN), delivered at request end right after
+     * Core::shutdown()
+     */
+    public function requestShutdown(): void;
+}

--- a/src/Hook/AbstractHook.php
+++ b/src/Hook/AbstractHook.php
@@ -31,6 +31,8 @@ abstract class AbstractHook implements HookInterface
 {
     /**
      * This field should be updated in children class and accessed through LSB
+     *
+     * @var string
      */
     protected const HOOK_FIELD = 'unknown';
 

--- a/src/System/Executor.php
+++ b/src/System/Executor.php
@@ -257,6 +257,20 @@ class Executor
     }
 
     /**
+     * Requests the full-table cleanup mode for the current request shutdown
+     *
+     * Mirrors what dl() does when it loads a temporary extension mid-request: with
+     * EG(full_tables_cleanup) set the engine walks the complete module registry at request
+     * shutdown instead of the handler lists precomputed at process startup, so modules
+     * registered at runtime are properly deactivated and temporary ones destroyed at
+     * request end.
+     */
+    public function enableFullTablesCleanup(): void
+    {
+        $this->pointer->full_tables_cleanup = 1;
+    }
+
+    /**
      * Materializes a user handler slot (an engine-owned embedded zval) into a PHP callable
      *
      * Memory contract: the slot is read through a BORROWED ReflectionValue view; an unset

--- a/tests/EngineExtension/AbstractModuleTest.php
+++ b/tests/EngineExtension/AbstractModuleTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Stub\LifecycleModule;
+use ZEngine\Stub\ThrowingLifecycleModule;
+
+/**
+ * Module lifecycle callbacks, phpinfo output and dependency wiring (issue #75)
+ *
+ * Every test registers a module in the engine registry, which cannot be undone within the
+ * process - hence one process per test.
+ */
+#[Group('internal')]
+class AbstractModuleTest extends TestCase
+{
+    #[RunInSeparateProcess]
+    public function testLifecycleCallbacksFireOnStartup(): void
+    {
+        $module = new LifecycleModule();
+        $this->assertFalse($module->isModuleRegistered());
+
+        $module->register();
+        $this->assertTrue($module->isModuleRegistered());
+        $this->assertTrue(extension_loaded('lifecycle'));
+        $this->assertFalse($module->wasModuleStarted());
+        $this->assertSame([], LifecycleModule::$events);
+
+        $module->startup();
+        $this->assertTrue($module->wasModuleStarted());
+        // MINIT is delivered by the engine through the FFI trampoline, RINIT directly by
+        // startup() (dl() parity); request/module shutdown belong to the end of the request
+        $this->assertSame(['moduleStartup', 'requestStartup'], LifecycleModule::$events);
+    }
+
+    #[RunInSeparateProcess]
+    public function testPhpInfoRendersModuleSection(): void
+    {
+        $module = new LifecycleModule();
+        $module->register();
+        $module->startup();
+
+        ob_start();
+        phpinfo(INFO_MODULES);
+        $output = (string) ob_get_clean();
+
+        $this->assertStringContainsString('lifecycle', $output);
+        $this->assertStringContainsString('Lifecycle support => enabled', $output);
+        $this->assertStringContainsString('Module version => 1.0.0', $output);
+    }
+
+    #[RunInSeparateProcess]
+    public function testDependenciesAreVisibleViaReflection(): void
+    {
+        $module = new LifecycleModule();
+        $module->register();
+        $module->startup();
+
+        $dependencies = (new \ReflectionExtension('lifecycle'))->getDependencies();
+        $this->assertSame('Required', $dependencies['standard'] ?? null);
+        $this->assertSame('Optional', $dependencies['spl'] ?? null);
+    }
+
+    #[RunInSeparateProcess]
+    public function testCallbackExceptionsAreContainedAsWarnings(): void
+    {
+        $capturedWarnings = [];
+        set_error_handler(static function (int $severity, string $message) use (&$capturedWarnings): bool {
+            $capturedWarnings[] = $message;
+
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            $module = new ThrowingLifecycleModule();
+            $module->register();
+            // MINIT throws inside the engine-driven FFI trampoline and RINIT throws in the
+            // direct delivery: both must be contained (issue #50), the module still starts
+            $module->startup();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($module->wasModuleStarted());
+        $allWarnings = implode("\n", $capturedWarnings);
+        $this->assertStringContainsString('module_startup_func failed: MINIT boom', $allWarnings);
+        $this->assertStringContainsString('requestStartup failed: RINIT boom', $allWarnings);
+    }
+
+    #[RunInSeparateProcess]
+    public function testInvalidDependencyDeclarationsAreRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ModuleDependency::required('standard', 'unknown-relation', '1.0');
+    }
+
+    /**
+     * End-to-end shutdown ordering, observed from a child process:
+     *
+     *  1. moduleStartup/requestStartup during startup (before any shutdown)
+     *  2. Core::shutdown() (registered first) restores the engine pointers
+     *  3. requestShutdown() is delivered right after it (Core::isShutdown() is true)
+     *  4. later user shutdown functions run after the module delivery
+     *  5. moduleShutdown() is never delivered: real MSHUTDOWN runs after FFI teardown
+     *  6. the process exits cleanly through the engine's temporary-module destruction
+     */
+    #[RunInSeparateProcess]
+    public function testRequestShutdownIsDeliveredAfterCoreShutdownAtRequestEnd(): void
+    {
+        $command = [
+            PHP_BINARY,
+            '-d', 'ffi.enable=1',
+            '-d', 'zend.assertions=1',
+            '-d', 'assert.exception=1',
+            '-d', 'report_memleaks=1',
+            '-d', 'display_errors=on',
+            '-d', 'error_reporting=-1',
+            __DIR__ . '/fixture/module-lifecycle-order.php',
+        ];
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        $this->assertIsResource($process, 'Unable to spawn the fixture child process');
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        $report = "STDOUT:\n{$stdout}\nSTDERR:\n{$stderr}";
+        $this->assertSame(0, $exitCode, "Fixture exited with code {$exitCode}\n{$report}");
+
+        $expectedSequence = [
+            'moduleStartup(coreShutdown=false)',
+            'requestStartup(coreShutdown=false)',
+            'conflict-rejected',
+            'script-end',
+            'requestShutdown(coreShutdown=true)',
+            'late-user-shutdown(coreShutdown=true)',
+        ];
+        $offset = 0;
+        foreach ($expectedSequence as $marker) {
+            $position = strpos($stdout, $marker, $offset);
+            $this->assertNotFalse($position, "Marker '{$marker}' missing or out of order\n{$report}");
+            $offset = $position + strlen($marker);
+        }
+        // Real MSHUTDOWN runs after the FFI bridge teardown: never delivered
+        $this->assertStringNotContainsString('moduleShutdown', $stdout, $report);
+    }
+}

--- a/tests/EngineExtension/fixture/module-lifecycle-order.php
+++ b/tests/EngineExtension/fixture/module-lifecycle-order.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\EngineExtension\AbstractModule;
+use ZEngine\EngineExtension\ModuleDependency;
+use ZEngine\Stub\LifecycleModule;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+LifecycleModule::$echoEvents = true;
+$module                      = new LifecycleModule();
+$module->register();
+$module->startup();
+
+// Registered AFTER the module: must run after the module's requestShutdown() delivery
+register_shutdown_function(static function (): void {
+    echo 'late-user-shutdown(coreShutdown=', var_export(Core::isShutdown(), true), ')', PHP_EOL;
+});
+
+// The engine must reject an entry that conflicts with an already loaded module
+$conflicting = new class ('conflicting') extends AbstractModule {
+    public static function targetDebug(): bool
+    {
+        return ZEND_DEBUG_BUILD;
+    }
+
+    public static function targetPersistent(): bool
+    {
+        return false;
+    }
+
+    public static function targetThreadSafe(): bool
+    {
+        return ZEND_THREAD_SAFE;
+    }
+
+    public static function globalType(): ?string
+    {
+        return null;
+    }
+
+    public function getModuleDependencies(): array
+    {
+        return [ModuleDependency::conflicts('standard')];
+    }
+};
+try {
+    $conflicting->register();
+    echo 'conflict-not-rejected', PHP_EOL;
+} catch (RuntimeException) {
+    echo 'conflict-rejected', PHP_EOL;
+}
+if ($conflicting->isModuleRegistered()) {
+    throw new RuntimeException('Conflicting module must not appear in the registry');
+}
+
+echo 'script-end', PHP_EOL;

--- a/tests/Memory/scenarios/module-lifecycle.php
+++ b/tests/Memory/scenarios/module-lifecycle.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\Stub\LifecycleModule;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+$module = new LifecycleModule();
+$module->register();
+$module->startup();
+
+if (!extension_loaded('lifecycle')) {
+    throw new RuntimeException('Module was not registered');
+}
+if (LifecycleModule::$events !== ['moduleStartup', 'requestStartup']) {
+    throw new RuntimeException('Startup lifecycle callbacks were not delivered');
+}
+
+ob_start();
+phpinfo(INFO_MODULES);
+$info = (string) ob_get_clean();
+if (!str_contains($info, 'Lifecycle support => enabled')) {
+    throw new RuntimeException('phpinfo() output is missing the module section');
+}
+
+$dependencies = (new ReflectionExtension('lifecycle'))->getDependencies();
+if (($dependencies['standard'] ?? null) !== 'Required') {
+    throw new RuntimeException('Module dependencies were not written');
+}
+
+// Explicit shutdown clears every trampoline pointer from the persistent module entry
+// while the trampolines are still alive; a second call must be a no-op
+Core::shutdown();
+Core::shutdown();
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;
+
+// Immortal-by-design allocations left behind on purpose (documented exemptions, see
+// docs/long-running.md "Immortal-by-design allocations"):
+//  - the persistent zend_module_entry (the registry stores this pointer directly on 8.4+)
+//  - the module name buffer
+//  - the NULL-terminated zend_module_dep[] array and its dependency-name strings
+// All of them are malloc-backed (never ZendMM), so the debug leak gate stays silent about
+// them by construction. The libffi trampolines are owned by ext/ffi and freed by its
+// RSHUTDOWN. After SCENARIO OK the request shuts down through the engine's full-table
+// cleanup, destroying the temporary module with all its callback pointers already cleared.

--- a/tests/Stub/LifecycleModule.php
+++ b/tests/Stub/LifecycleModule.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use ZEngine\Core;
+use ZEngine\EngineExtension\AbstractModule;
+use ZEngine\EngineExtension\ModuleDependency;
+use ZEngine\EngineExtension\ModuleInfoInterface;
+use ZEngine\EngineExtension\ModuleLifecycleInterface;
+
+/**
+ * Test module (engine name "lifecycle") exercising lifecycle callbacks, phpinfo output
+ * and dependency wiring
+ */
+final class LifecycleModule extends AbstractModule implements ModuleLifecycleInterface, ModuleInfoInterface
+{
+    /**
+     * Recorded lifecycle events, in delivery order
+     *
+     * @var list<string>
+     */
+    public static array $events = [];
+
+    /**
+     * When enabled, every recorded event is echoed together with the Core::isShutdown()
+     * state at delivery time (used by child-process ordering tests)
+     */
+    public static bool $echoEvents = false;
+
+    public static function targetDebug(): bool
+    {
+        return ZEND_DEBUG_BUILD;
+    }
+
+    public static function targetPersistent(): bool
+    {
+        return false;
+    }
+
+    public static function targetThreadSafe(): bool
+    {
+        return ZEND_THREAD_SAFE;
+    }
+
+    public static function globalType(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getModuleDependencies(): array
+    {
+        return [
+            ModuleDependency::required('standard'),
+            ModuleDependency::optional('spl'),
+        ];
+    }
+
+    public function moduleStartup(): void
+    {
+        self::record('moduleStartup');
+    }
+
+    public function moduleShutdown(): void
+    {
+        self::record('moduleShutdown');
+    }
+
+    public function requestStartup(): void
+    {
+        self::record('requestStartup');
+    }
+
+    public function requestShutdown(): void
+    {
+        self::record('requestShutdown');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDisplayInfo(): array
+    {
+        return [
+            'Lifecycle support' => 'enabled',
+            'Module version'    => '1.0.0',
+        ];
+    }
+
+    private static function record(string $event): void
+    {
+        self::$events[] = $event;
+        if (self::$echoEvents) {
+            echo $event, '(coreShutdown=', var_export(Core::isShutdown(), true), ')', PHP_EOL;
+        }
+    }
+}

--- a/tests/Stub/ThrowingLifecycleModule.php
+++ b/tests/Stub/ThrowingLifecycleModule.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use ZEngine\EngineExtension\AbstractModule;
+use ZEngine\EngineExtension\ModuleLifecycleInterface;
+
+/**
+ * Test module (engine name "throwing_lifecycle") whose callbacks throw: exceptions must be
+ * contained by the lifecycle trampolines instead of crossing the FFI boundary (issue #50)
+ */
+final class ThrowingLifecycleModule extends AbstractModule implements ModuleLifecycleInterface
+{
+    public static function targetDebug(): bool
+    {
+        return ZEND_DEBUG_BUILD;
+    }
+
+    public static function targetPersistent(): bool
+    {
+        return false;
+    }
+
+    public static function targetThreadSafe(): bool
+    {
+        return ZEND_THREAD_SAFE;
+    }
+
+    public static function globalType(): ?string
+    {
+        return null;
+    }
+
+    public function moduleStartup(): void
+    {
+        throw new \RuntimeException('MINIT boom');
+    }
+
+    public function moduleShutdown(): void {}
+
+    public function requestStartup(): void
+    {
+        throw new \RuntimeException('RINIT boom');
+    }
+
+    public function requestShutdown(): void {}
+}


### PR DESCRIPTION
Fixes #75

## Summary

`EngineExtension\AbstractModule` now registers a functional extension instead of a bare globals allocator:

- **`ModuleLifecycleInterface`** (`moduleStartup` / `moduleShutdown` / `requestStartup` / `requestShutdown`) — wired opt-in by `register()` via FFI-closure trampolines into `module_startup_func` / `module_shutdown_func` / `request_startup_func` / `request_shutdown_func` (same approach as `ExtensionConstructorHook`/`globals_ctor`, one small `AbstractModuleLifecycleHook` family in `EngineExtension\Hook`).
- **`ModuleInfoInterface::getDisplayInfo(): array`** → `info_func` trampoline; `AbstractModule::printInfoTable()` renders the returned `label => value` rows into the module's phpinfo() section (text and HTML modes). Per your comment on the issue, the interface returns data and AbstractModule owns the rendering wiring, instead of a void `displayInfo()`.
- **`ModuleInterface::getModuleDependencies(): list<ModuleDependency>`** → persistent NULL-terminated `zend_module_dep[]` written into `->deps`; visible through the native `ReflectionExtension::getDependencies()` and enforced by the engine (conflicts at registration, required modules at startup). `ModuleDependency` was reworked into a working value object (the previous constructor assigned undeclared properties) with `required()`/`conflicts()`/`optional()` factories and relation validation.

## Safety design (mandatory part of the deliverable)

- Every trampoline checks `Core::isShutdown()` and no-ops after `Core::shutdown()`.
- Callbacks never throw across the FFI boundary (#50): ext/ffi fatals on escaping exceptions (`zend_error_noreturn(E_ERROR, "Throwing from FFI callbacks is not allowed")`), and a FAILURE from MINIT escalates to a fatal `E_CORE_ERROR` in `zend_startup_module_ex()`. Failures are contained, reported as `E_USER_WARNING`, and the engine always sees SUCCESS.
- The trampolines follow the standard hook lifecycle: `Core::shutdown()` restores the NULL pointers while the trampolines are still alive, keeping the existing invariant that no trampoline pointer survives into a structure that outlives the request — the module entry lives in the persistent module registry, and ext/ffi frees every callback trampoline at its own RSHUTDOWN (`FFI_G(callbacks)` teardown, verified against php-8.4.24 sources).
- **Only request-phase callbacks are guaranteed** (documented in `docs/long-running.md`, new "Module lifecycle callbacks" section + extended immortal-by-design table):
  - `moduleStartup()` — engine-driven MINIT trampoline during `startup()`;
  - `requestStartup()` — delivered directly by `startup()` (dl() parity; the engine only activates modules at request start);
  - `requestShutdown()` — delivered at request end by z-engine's own shutdown chain **immediately after `Core::shutdown()`** (user shutdown functions run in registration order; the engine's own RSHUTDOWN walk happens later, after the pointers were cleared);
  - `moduleShutdown()` — best-effort only: real MSHUTDOWN runs after the FFI bridge teardown (`zend_post_deactivate_modules()` for temporary modules, process shutdown for persistent ones).

## Correctness fixes required along the way

- **PHP 8.4 latent use-after-free**: `zend_register_module_ex()` stores the given `zend_module_entry` pointer directly in `module_registry` since 8.4 (`zend_hash_add_ptr`, no copy). The old code allocated the entry as owned request-lifetime FFI memory that died at the end of `register()`. The entry, module name, globals and dependency buffers are now persistent tracked allocations (immortal-by-design; all malloc-backed, invisible to the ZendMM leak gate by construction).
- **dl() parity**: registering a temporary module now sets `EG(full_tables_cleanup)` (new `Executor::enableFullTablesCleanup()`), exactly like `ext/standard/dl.c` — otherwise the engine never deactivates/destroys runtime-registered modules at request end (the precomputed handler lists are built at process startup only).
- Replaced the deprecated `['obj', 'Class::method']` callable form in `register()` and the implicitly nullable constructor parameter (removes two baseline-covered deprecations from this path).

## Deviations from the issue sketch (with reasons)

- `getDependencies()` → **`getModuleDependencies()`**: `AbstractModule` inherits the native `ReflectionExtension::getDependencies()`, which reads the registered deps back in the engine's `name => relationship` format (and is what the tests assert against). Overriding it with an incompatible return type would be an LSP violation flagged by PHPStan and would break reflection consumers.
- The issue sketch called the trampolines "process-lifetime / immortal". That is not physically possible: ext/ffi frees every callback trampoline at its RSHUTDOWN. Instead the trampolines follow the standard hook lifecycle (pointers cleared at `Core::shutdown()` — which is also why they're not listed as new immortal allocations), and the guaranteed `requestShutdown()` delivery moved into z-engine's shutdown chain; ordering vs `Core::shutdown()` is documented and asserted end-to-end.

## Out of scope (follow-ups in the epic)

- Native function registration (`zend_function_entry` array → `functions` field).
- Per-module INI (`ini_entry`).

Both need header regeneration and are flagged as follow-ups in the epic (#79). No header regeneration was needed here (`zend_module_entry`/`zend_module_dep` fully declared).

## Tests

- `tests/EngineExtension/AbstractModuleTest.php` (`#[Group('internal')]`, one process per test — module registration cannot be undone in-process): MINIT-via-trampoline + RINIT delivery, phpinfo(INFO_MODULES) section content via output buffering, deps via native `ReflectionExtension`, exception containment as warnings, dependency validation, and a child-process fixture asserting the full ordering (`moduleStartup` → `requestStartup` → conflict rejection → script end → `requestShutdown` with `Core::isShutdown() === true` → later user shutdown functions; `moduleShutdown` never delivered; exit code 0 through the engine's temporary-module destruction).
- `tests/Memory/scenarios/module-lifecycle.php` leak scenario with the immortal-by-design exemptions explicitly listed (persistent entry, name buffer, `zend_module_dep[]` + strings — malloc-backed, so the ZendMM gate stays silent by construction; trampolines freed by ext/ffi RSHUTDOWN).

## Evidence

**Debug build (PHP 8.4.24 NTS DEBUG, `--enable-debug --with-ffi`), internal group with process isolation:**

```
$ php-debug/bin/php -d ffi.enable=1 -d zend.assertions=1 -d assert.exception=1 \
    vendor/bin/phpunit --group internal --process-isolation
OK, but there were issues!
Tests: 81, Assertions: 314, Skipped: 2, Incomplete: 2.   (skips/incompletes pre-existing)
```

Leak scenarios alone (includes the new `module-lifecycle` scenario): `OK (12 tests, 72 assertions)`.

**Smoke script** (run under both the release 8.4.19 and debug 8.4.24 builds with `report_memleaks=1`, not committed):

```
moduleStartup(coreShutdown=false)
requestStartup(coreShutdown=false)
started=true
phpinfo-has-section=true
array ( 'standard' => 'Required', 'spl' => 'Optional', )
script-end
requestShutdown(coreShutdown=true)
late-user-shutdown(coreShutdown=true)
EXIT=0
```

**Gates:** `composer test` OK (180 tests, 2758 assertions), `composer phpstan` OK — no errors, **no baseline additions**, `composer cs:check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC

---
_Generated by [Claude Code](https://claude.ai/code/session_017fzpvLxVmyXjdbZYaCu1pC)_