### PR TITLE
feat: persistent object and hashtable primitives for request-surviving state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,32 @@ If you touch a struct the PHP code dereferences, add it to `layout_structs` in
 FFI-loads the header and asserts every offset against the C compiler, so a
 wrong header cannot be produced.
 
+### Regenerating without Docker (sandboxed/proxied environments)
+
+When Docker or the Debian package mirrors are unreachable (as in restricted CI
+sandboxes), the generator can run directly on the host — the Docker image is a
+convenience, not a requirement. `emit.php` derives everything from the
+*running* PHP build (`php-config --includes`, clang over the real headers, a C
+probe compiled with `cc`); the php-src tree is only needed to slice
+`Zend/zend_closures.c`. Verified recipe:
+
+1. Host needs: `clang`, `cc`, `php-config` + dev headers for the exact running
+   PHP version, ext-ffi. Fetch the matching `Zend/zend_closures.c` (and nothing
+   else) from `raw.githubusercontent.com/php/php-src/php-<version>/`.
+2. First run against the **committed** `symbols.php` into a scratch directory
+   and `diff` against `include/<minor>/<platform>/` — the output must be
+   byte-identical (it was, verified on Ubuntu clang-18 vs the trixie image:
+   the emitter normalizes declarations from the clang AST, so compiler
+   version does not leak into the artifacts). If the diff is clean, host
+   regeneration is equivalent to the Docker/CI pipeline for this host.
+3. Only then apply the `symbols.php` change and regenerate into `include/`
+   for real: `php -d memory_limit=2G tools/generator/emit.php
+   --php-src=<dir> [--out=...]`.
+
+The byte-identical pre-check is what makes this safe: the `header-drift` CI
+job re-runs the Docker pipeline and fails on any divergence, so never skip
+step 2.
+
 ## Running tests safely
 
 ```bash

--- a/docs/long-running.md
+++ b/docs/long-running.md
@@ -100,6 +100,10 @@ The debug-build leak gate treats the following as expected, by design:
 | Engine-chained arena blocks for >32 KiB parses | allocated by the engine; z-engine never frees memory it did not allocate |
 | Refcount-0 persistent strings | never freed with the request allocator; bounded, reclaimed at process end |
 | Engine-original interface/trait buffers replaced by z-engine | possibly shared or in opcache SHM, never freed by z-engine; at most one per touched class |
+| Persistent interned strings (`StringEntry::persistentInterned`) | interned-style (immutable, non-refcounted) blocks referenced by persistent tables and object properties; bounded by the number of persisted keys/values, reclaimed at process end |
+| Persistent hashtables and their engine-grown data blocks (`PersistentHashTable`) | registries that must outlive the request by design; the engine resizes their data with the persistent allocator, nothing may free them mid-process |
+| The shared `uninitialized_bucket` sentinel block | one `uint32_t[2]` per process backing every uninitialized persistent table, mirroring the engine's static |
+| Persistent object clones (`PersistentObjectFactory::persistentClone`) | refcount-pinned malloc objects designed to survive the request boundary; detached from the object store before teardown so no engine path ever frees them |
 
 Everything else is a bug: the test suite runs with `report_memleaks=1` on a debug build and
 fails on any leak report.

--- a/include/8.4/linux-x64-nts/constants.php
+++ b/include/8.4/linux-x64-nts/constants.php
@@ -118,6 +118,8 @@ return [
     'HASH_UPDATE_INDIRECT' => 4,
     'HASH_ADD_NEW' => 8,
     'HASH_ADD_NEXT' => 16,
+    'HT_MIN_MASK' => 4294967294,
+    'HT_MIN_SIZE' => 8,
     'ZEND_MODULE_API_NO' => 20240924,
     'MODULE_PERSISTENT' => 1,
     'MODULE_TEMPORARY' => 2,

--- a/include/8.4/linux-x64-nts/engine.h
+++ b/include/8.4/linux-x64-nts/engine.h
@@ -941,12 +941,15 @@ typedef struct _zend_closure {
 extern zend_result zend_hash_del(HashTable *, zend_string *);
 extern zval * zend_hash_find(const HashTable *, zend_string *);
 extern zval * zend_hash_add_or_update(HashTable *, zend_string *, zval *, uint32_t);
+extern zval * zend_hash_index_add_or_update(HashTable *, zend_ulong, zval *, uint32_t);
+extern zval * zend_hash_index_find(const HashTable *, zend_ulong);
 extern zend_result zend_set_user_opcode_handler(uint8_t, user_opcode_handler_t);
 extern user_opcode_handler_t zend_get_user_opcode_handler(uint8_t);
 extern void zend_do_inheritance_ex(zend_class_entry *, zend_class_entry *, _Bool);
 extern zend_object * zend_objects_new(zend_class_entry *);
 extern void zend_object_std_init(zend_object *, zend_class_entry *);
 extern void object_properties_init(zend_object *, zend_class_entry *);
+extern void zend_objects_store_put(zend_object *);
 extern void zend_save_lexical_state(zend_lex_state *);
 extern void zend_restore_lexical_state(zend_lex_state *);
 extern void zend_prepare_string_for_scanning(zval *, zend_string *);

--- a/include/8.4/linux-x64-nts/probe.c
+++ b/include/8.4/linux-x64-nts/probe.c
@@ -376,6 +376,12 @@ int main(void) {
 #ifdef HASH_ADD_NEXT
     fprintf(constants, "    'HASH_ADD_NEXT' => %lld,\n", (long long)(HASH_ADD_NEXT));
 #endif
+#ifdef HT_MIN_MASK
+    fprintf(constants, "    'HT_MIN_MASK' => %lld,\n", (long long)(HT_MIN_MASK));
+#endif
+#ifdef HT_MIN_SIZE
+    fprintf(constants, "    'HT_MIN_SIZE' => %lld,\n", (long long)(HT_MIN_SIZE));
+#endif
 #ifdef ZEND_MODULE_API_NO
     fprintf(constants, "    'ZEND_MODULE_API_NO' => %lld,\n", (long long)(ZEND_MODULE_API_NO));
 #endif

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -823,6 +823,12 @@ parameters:
 			path: src/Core.php
 
 		-
+			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/EngineExtension/AbstractModule.php
+
+		-
 			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$moduleName \(string\) is implicitly nullable via default value null\.$#'
 			identifier: parameter.implicitlyNullable
 			count: 1
@@ -835,7 +841,19 @@ parameters:
 			path: src/EngineExtension/AbstractModule.php
 
 		-
+			message: '#^Parameter \#1 \$stringPointer of static method ZEngine\\Type\\StringEntry\:\:fromCData\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/EngineExtension/AbstractModule.php
+
+		-
 			message: '#^Parameter \#1 \$type of static method ZEngine\\Core\:\:cast\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/EngineExtension/AbstractModule.php
+
+		-
+			message: '#^Parameter \#1 \$variable of static method ZEngine\\Core\:\:addr\(\) expects FFI\\CData, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/EngineExtension/AbstractModule.php
@@ -2217,7 +2235,7 @@ parameters:
 		-
 			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 4
+			count: 3
 			path: src/System/ObjectStore.php
 
 		-
@@ -2265,7 +2283,7 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$pointer of static method ZEngine\\Core\:\:cast\(\) expects FFI\\CData, mixed given\.$#'
 			identifier: argument.type
-			count: 1
+			count: 2
 			path: src/System/ObjectStore.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2199,13 +2199,19 @@ parameters:
 		-
 			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 3
+			count: 4
 			path: src/System/ObjectStore.php
 
 		-
 			message: '#^Binary operation "\-" between mixed and 2 results in an error\.$#'
 			identifier: binaryOp.invalid
-			count: 2
+			count: 3
+			path: src/System/ObjectStore.php
+
+		-
+			message: '#^Binary operation "\<\<" between mixed and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
 			path: src/System/ObjectStore.php
 
 		-
@@ -2217,7 +2223,7 @@ parameters:
 		-
 			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 3
+			count: 4
 			path: src/System/ObjectStore.php
 
 		-
@@ -2240,6 +2246,12 @@ parameters:
 
 		-
 			message: '#^Method ZEngine\\System\\ObjectStore\:\:nextHandle\(\) should return int but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/System/ObjectStore.php
+
+		-
+			message: '#^Method ZEngine\\System\\ObjectStore\:\:put\(\) should return int but returns mixed\.$#'
 			identifier: return.type
 			count: 1
 			path: src/System/ObjectStore.php
@@ -2407,30 +2419,6 @@ parameters:
 			path: src/Type/HashTable.php
 
 		-
-			message: '#^Constant ZEngine\\Type\\HashTable\:\:HASH_ADD is unused\.$#'
-			identifier: classConstant.unused
-			count: 1
-			path: src/Type/HashTable.php
-
-		-
-			message: '#^Constant ZEngine\\Type\\HashTable\:\:HASH_ADD_NEXT is unused\.$#'
-			identifier: classConstant.unused
-			count: 1
-			path: src/Type/HashTable.php
-
-		-
-			message: '#^Constant ZEngine\\Type\\HashTable\:\:HASH_UPDATE is unused\.$#'
-			identifier: classConstant.unused
-			count: 1
-			path: src/Type/HashTable.php
-
-		-
-			message: '#^Constant ZEngine\\Type\\HashTable\:\:HASH_UPDATE_INDIRECT is unused\.$#'
-			identifier: classConstant.unused
-			count: 1
-			path: src/Type/HashTable.php
-
-		-
 			message: '#^Method ZEngine\\Type\\HashTable\:\:getGC\(\) should return FFI\\CData but returns mixed\.$#'
 			identifier: return.type
 			count: 1
@@ -2457,7 +2445,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$valueEntry of static method ZEngine\\Reflection\\ReflectionValue\:\:fromValueEntry\(\) expects FFI\\CData, mixed given\.$#'
 			identifier: argument.type
-			count: 3
+			count: 4
 			path: src/Type/HashTable.php
 
 		-
@@ -2479,6 +2467,30 @@ parameters:
 			path: src/Type/ObjectEntry.php
 
 		-
+			message: '#^Binary operation "\-" between mixed and 1 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
+			message: '#^Cannot access offset 0 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
+			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
+			message: '#^Cannot access property \$default_properties_count on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
 			message: '#^Cannot access property \$type_info on mixed\.$#'
 			identifier: property.nonObject
 			count: 3
@@ -2493,6 +2505,18 @@ parameters:
 		-
 			message: '#^Cannot use \-\- on mixed\.$#'
 			identifier: preDec.type
+			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
+			message: '#^Method ZEngine\\Type\\ObjectEntry\:\:getDynamicPropertiesPointer\(\) should return FFI\\CData\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
+			message: '#^Method ZEngine\\Type\\ObjectEntry\:\:getExtraFlags\(\) should return int but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Type/ObjectEntry.php
 
@@ -2530,6 +2554,12 @@ parameters:
 			message: '#^Parameter \#1 \$hashInstance of class ZEngine\\Type\\HashTable constructor expects FFI\\CData, mixed given\.$#'
 			identifier: argument.type
 			count: 1
+			path: src/Type/ObjectEntry.php
+
+		-
+			message: '#^Parameter \#1 \$variable of static method ZEngine\\Core\:\:addr\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 2
 			path: src/Type/ObjectEntry.php
 
 		-
@@ -2651,6 +2681,114 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Type/OpLine.php
+
+		-
+			message: '#^Binary operation "\+" between FFI\\CData and 8 results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Binary operation "\|\=" between mixed and int results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Cannot access offset 1 on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Cannot access property \$flags on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Cannot access property \$refcount on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Cannot access property \$type_info on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Cannot access property \$u on mixed\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Method ZEngine\\Type\\PersistentHashTable\:\:create\(\) return type has no value type specified in iterable type ZEngine\\Type\\PersistentHashTable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Method ZEngine\\Type\\PersistentHashTable\:\:fromCData\(\) return type has no value type specified in iterable type ZEngine\\Type\\PersistentHashTable\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Parameter \#2 \$pointer of static method ZEngine\\Core\:\:cast\(\) expects FFI\\CData, FFI\\CData\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Parameter \#2 \$pointer of static method ZEngine\\Core\:\:cast\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Static property ZEngine\\Type\\PersistentHashTable\:\:\$uninitializedBucket \(FFI\\CData\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/Type/PersistentHashTable.php
+
+		-
+			message: '#^Binary operation "\|\=" between mixed and int results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: src/Type/PersistentObjectFactory.php
+
+		-
+			message: '#^Cannot access property \$refcount on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Type/PersistentObjectFactory.php
+
+		-
+			message: '#^Cannot access property \$type_info on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Type/PersistentObjectFactory.php
+
+		-
+			message: '#^Cannot access property \$u on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Type/PersistentObjectFactory.php
+
+		-
+			message: '#^Parameter \#1 \$classType of static method ZEngine\\Reflection\\ReflectionClass\:\:getObjectSize\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Type/PersistentObjectFactory.php
+
+		-
+			message: '#^Parameter \#1 \$pointer of static method ZEngine\\Core\:\:addressOf\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Type/PersistentObjectFactory.php
 
 		-
 			message: '#^Binary operation "&" between mixed and 128 results in an error\.$#'
@@ -2809,27 +2947,39 @@ parameters:
 			path: src/Type/StringEntry.php
 
 		-
+			message: '#^Binary operation "&" between mixed and int results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/Type/StringEntry.php
+
+		-
 			message: '#^Binary operation "\+" between FFI\\CData and int\<0, max\> results in an error\.$#'
 			identifier: binaryOp.invalid
 			count: 1
 			path: src/Type/StringEntry.php
 
 		-
+			message: '#^Binary operation "\|\=" between mixed and int results in an error\.$#'
+			identifier: assignOp.invalid
+			count: 1
+			path: src/Type/StringEntry.php
+
+		-
 			message: '#^Cannot access property \$refcount on mixed\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: src/Type/StringEntry.php
 
 		-
 			message: '#^Cannot access property \$type_info on mixed\.$#'
 			identifier: property.nonObject
-			count: 4
+			count: 6
 			path: src/Type/StringEntry.php
 
 		-
 			message: '#^Cannot access property \$u on mixed\.$#'
 			identifier: property.nonObject
-			count: 1
+			count: 2
 			path: src/Type/StringEntry.php
 
 		-
@@ -2939,6 +3089,36 @@ parameters:
 			identifier: binaryOp.invalid
 			count: 1
 			path: tests/Memory/scenarios/hook-install-uninstall.php
+
+		-
+			message: '#^Cannot access offset ''key\-1'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Memory/scenarios/persistent-hashtable-churn.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method ZEngine\\Reflection\\ReflectionValue\:\:newEntry\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Memory/scenarios/persistent-hashtable-churn.php
+
+		-
+			message: '#^Cannot access property \$counter on mixed\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: tests/Memory/scenarios/persistent-object-put-detach.php
+
+		-
+			message: '#^Parameter \#1 \$object of function spl_object_id expects object, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Memory/scenarios/persistent-object-put-detach.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method ZEngine\\Reflection\\ReflectionValue\:\:newEntry\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Memory/scenarios/persistent-object-put-detach.php
 
 		-
 			message: '#^Binary operation "\*" between mixed and 2 results in an error\.$#'
@@ -3641,6 +3821,24 @@ parameters:
 			identifier: isset.variable
 			count: 1
 			path: tests/Type/ClosureEntryTest.php
+
+		-
+			message: '#^Cannot call method getNativeValue\(\) on ZEngine\\Reflection\\ReflectionValue\|null\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: tests/Type/PersistentHashTableTest.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method ZEngine\\Reflection\\ReflectionValue\:\:newEntry\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Type/PersistentHashTableTest.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method ZEngine\\Reflection\\ReflectionValue\:\:newEntry\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Type/PersistentObjectFactoryTest.php
 
 		-
 			message: '#^Cannot cast mixed to string\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -829,12 +829,6 @@ parameters:
 			path: src/EngineExtension/AbstractModule.php
 
 		-
-			message: '#^Parameter \#1 \$callback of function call_user_func expects callable\(\)\: mixed, array\{\$this\(ZEngine\\EngineExtension\\AbstractModule\), ''ReflectionExtension…''\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/EngineExtension/AbstractModule.php
-
-		-
 			message: '#^Parameter \#1 \$string of function strtolower expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -2475,13 +2469,7 @@ parameters:
 		-
 			message: '#^Cannot access offset 0 on mixed\.$#'
 			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
-			path: src/Type/ObjectEntry.php
-
-		-
-			message: '#^Cannot access offset int\<0, max\> on mixed\.$#'
-			identifier: offsetAccess.nonOffsetAccessible
-			count: 1
+			count: 2
 			path: src/Type/ObjectEntry.php
 
 		-
@@ -2559,7 +2547,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$variable of static method ZEngine\\Core\:\:addr\(\) expects FFI\\CData, mixed given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 3
 			path: src/Type/ObjectEntry.php
 
 		-

--- a/src/Core.php
+++ b/src/Core.php
@@ -405,10 +405,11 @@ class Core
         // taking another reference to it leaks the owned FFI type structure (~116 bytes per
         // call), which made every buffer cast a slow leak in long-running processes.
         try {
-            // Only C arrays are countable; pointers, structs and scalars throw here
+            // Only C arrays are countable; pointers and structs throw FFI\Exception,
+            // scalar CData (eg uintptr_t) throws TypeError - both mean "not an array"
             \count($pointer);
             $pointer = FFI::addr($pointer[0]);
-        } catch (FFI\Exception) {
+        } catch (FFI\Exception | \TypeError) {
             // Not an array: cast directly
         }
 

--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -17,6 +17,7 @@ use FFI\CData;
 use ZEngine\Core;
 use ZEngine\EngineExtension\Hook\ExtensionConstructorHook;
 use ZEngine\Reflection\ReflectionExtension;
+use ZEngine\Type\StringEntry;
 
 abstract class AbstractModule extends ReflectionExtension implements ModuleInterface
 {
@@ -114,11 +115,14 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
             $module->globals_ptr  = Core::addr($memoryStructure);
         }
 
-        // $module pointer will be updated, as registration method returns a copy of memory.
         // Since PHP 8.3 the module type is passed explicitly instead of being read from the entry.
         $realModulePointer = Core::call('zend_register_module_ex', Core::addr($module), (int) $module->type);
 
         $this->moduleEntry = $realModulePointer;
+
+        if (static::targetPersistent()) {
+            $this->makeRegistryKeyPersistent();
+        }
 
         (new \ReflectionMethod(\ReflectionExtension::class, '__construct'))->invokeArgs($this, [$moduleName]);
     }
@@ -155,6 +159,40 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
         }
 
         return $rawPointer;
+    }
+
+    /**
+     * Swaps the module_registry bucket key for a persistent interned string
+     *
+     * Registering a module at runtime makes zend_register_module_ex intern the registry
+     * key as a REQUEST-lifetime string (zend_new_interned_string goes to the per-request
+     * interned table outside of engine startup), so a persistent module's bucket key
+     * would dangle after the first request and crash the registry teardown at process
+     * shutdown. A persistent interned replacement has the same content hash and is never
+     * released by the engine (interned strings are release no-ops).
+     */
+    private function makeRegistryKeyPersistent(): void
+    {
+        $registryTable = Core::$modules->getRawValue();
+        $lowerName     = strtolower($this->moduleName);
+
+        $numUsed = $registryTable->nNumUsed;
+        for ($index = 0; $index < $numUsed; $index++) {
+            $bucket = Core::addr($registryTable->arData[$index]);
+            if ($bucket->key === null) {
+                continue;
+            }
+            $key = StringEntry::fromCData($bucket->key);
+            if ($key->getStringValue() !== $lowerName) {
+                continue;
+            }
+            // A permanent interned key (registered during engine startup) is already safe
+            if (!$key->isPermanent()) {
+                $bucket->key = StringEntry::persistentInterned($lowerName)->getRawValue();
+            }
+
+            return;
+        }
     }
 
     /**

--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -88,8 +88,11 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
             throw new \RuntimeException('Module ' . $this->moduleName . ' was already registered.');
         }
 
-        // We don't need persistent memory here, as PHP copies structures into persistent memory itself
-        $module     = Core::new('zend_module_entry');
+        // Since PHP 8.4 zend_register_module_ex stores THIS pointer directly in the
+        // module registry (zend_hash_add_ptr - the old copying add_mem behaviour is
+        // gone), so the entry must be malloc-backed and never FFI-collected: the
+        // engine frees it itself with free() at module destruction
+        $module     = Core::trackedNew('zend_module_entry', true);
         $moduleName = $this->moduleName;
         $nameLength = strlen($moduleName) + 1;
         /* extra zero-byte */;
@@ -117,8 +120,7 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
 
         $this->moduleEntry = $realModulePointer;
 
-        $extensionConstructor = \ReflectionExtension::class . '::__construct';
-        call_user_func([$this, $extensionConstructor], $moduleName);
+        (new \ReflectionMethod(\ReflectionExtension::class, '__construct'))->invokeArgs($this, [$moduleName]);
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -982,6 +982,19 @@ class ReflectionClass extends NativeReflectionClass
     }
 
     /**
+     * Returns the full allocation size of an instance: zend_object plus the inline
+     * properties_table slots for a given class type
+     *
+     * @param CData $classType zend_class_entry type to measure
+     *
+     * @see zend_objects_API.h:zend_objects_store_put (callers size allocations this way)
+     */
+    public static function getObjectSize(CData $classType): int
+    {
+        return Core::sizeof(Core::type('zend_object')) + self::getObjectPropertiesSize($classType);
+    }
+
+    /**
      * Checks if the current class has a parent
      */
     private function hasParentClass(): bool

--- a/src/System/ObjectStore.php
+++ b/src/System/ObjectStore.php
@@ -108,6 +108,26 @@ final class ObjectStore implements Countable, ArrayAccess
     }
 
     /**
+     * Registers an object in the store, assigning it a fresh handle
+     *
+     * Wraps zend_objects_store_put: pops the free list or grows the bucket array with the
+     * engine's own request allocator, then writes the new handle into the object. Required
+     * for objects allocated outside zend_object_std_init (eg persistent clones) that must
+     * become visible to the engine for the current request.
+     *
+     * @param CData $object zend_object* to register
+     *
+     * @return int The handle assigned by the engine (== spl_object_id)
+     * @internal
+     */
+    public function put(CData $object): int
+    {
+        Core::call('zend_objects_store_put', $object);
+
+        return $object->handle;
+    }
+
+    /**
      * Detaches existing object from the object store
      *
      * <span style="color:red; font-weight: bold">Warning!</span> This call doesn't invokes object destructors,
@@ -127,6 +147,30 @@ final class ObjectStore implements Countable, ArrayAccess
         $rawPointer->cdata = $invalidPointer;
 
         $this->pointer->object_buckets[$offset] = Core::cast('zend_object *', $rawPointer);
+    }
+
+    /**
+     * Detaches an object from the store AND returns its slot to the free list
+     *
+     * Mirrors the slot bookkeeping of zend_objects_store_del: the bucket receives the
+     * tagged number of the previous free head and becomes the new head, so a later
+     * put() reuses the slot instead of growing the bucket array. Like detach(), this
+     * never invokes destructors or frees the object itself.
+     *
+     * @see zend_objects_API.h:SET_OBJ_BUCKET_NUMBER macro
+     * @internal
+     */
+    public function recycle(int $offset): void
+    {
+        if ($offset < 0 || $offset > $this->pointer->top - 1) {
+            // We use -2 because exception object also increments index by one
+            throw new \OutOfBoundsException("Index {$offset} is out of bounds 0.." . ($this->pointer->top - 2));
+        }
+        $taggedNumber        = Core::new('uintptr_t');
+        $taggedNumber->cdata = ($this->pointer->free_list_head << 1) | self::OBJ_BUCKET_INVALID;
+
+        $this->pointer->object_buckets[$offset] = Core::cast('zend_object *', $taggedNumber);
+        $this->pointer->free_list_head          = $offset;
     }
 
     /**

--- a/src/System/ObjectStore.php
+++ b/src/System/ObjectStore.php
@@ -166,11 +166,18 @@ final class ObjectStore implements Countable, ArrayAccess
             // We use -2 because exception object also increments index by one
             throw new \OutOfBoundsException("Index {$offset} is out of bounds 0.." . ($this->pointer->top - 2));
         }
-        $taggedNumber        = Core::new('uintptr_t');
-        $taggedNumber->cdata = ($this->pointer->free_list_head << 1) | self::OBJ_BUCKET_INVALID;
+        // Prepare every FFI temporary FIRST: each CData is itself a PHP object whose
+        // allocation pops this very free list, so creating one between reading and
+        // writing free_list_head would stale the captured head and orphan slots
+        $taggedNumber = Core::new('uintptr_t');
+        $bucketValue  = Core::cast('zend_object *', $taggedNumber);
+        $buckets      = Core::cast('zend_object **', $this->pointer->object_buckets);
 
-        $this->pointer->object_buckets[$offset] = Core::cast('zend_object *', $taggedNumber);
-        $this->pointer->free_list_head          = $offset;
+        // No CData allocations below this line (scalar reads/writes only)
+        $taggedNumber->cdata = ($this->pointer->free_list_head << 1) | self::OBJ_BUCKET_INVALID;
+        $buckets[$offset]    = $bucketValue;
+
+        $this->pointer->free_list_head = $offset;
     }
 
     /**

--- a/src/Type/HashTable.php
+++ b/src/Type/HashTable.php
@@ -201,6 +201,15 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
         }
     }
 
+    /**
+     * Returns raw C value entry (HashTable *)
+     * @internal
+     */
+    public function getRawValue(): CData
+    {
+        return $this->pointer;
+    }
+
     public function __debugInfo()
     {
         return iterator_to_array($this->getIterator());

--- a/src/Type/HashTable.php
+++ b/src/Type/HashTable.php
@@ -59,18 +59,18 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
 {
     use ReferenceCountedTrait;
 
-    private const HASH_UPDATE          = (1 << 0);
-    private const HASH_ADD             = (1 << 1);
-    private const HASH_UPDATE_INDIRECT = (1 << 2);
-    private const HASH_ADD_NEW         = (1 << 3);
-    private const HASH_ADD_NEXT        = (1 << 4);
+    protected const HASH_UPDATE          = (1 << 0);
+    protected const HASH_ADD             = (1 << 1);
+    protected const HASH_UPDATE_INDIRECT = (1 << 2);
+    protected const HASH_ADD_NEW         = (1 << 3);
+    protected const HASH_ADD_NEXT        = (1 << 4);
 
     /**
      * Corresponds to the HASH_FLAG_PACKED flag in zend_types.h
      */
-    private const HASH_FLAG_PACKED = (1 << 2);
+    protected const HASH_FLAG_PACKED = (1 << 2);
 
-    private CData $pointer;
+    protected CData $pointer;
 
     public function __construct(CData $hashInstance)
     {
@@ -159,6 +159,45 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
         );
         if ($result === Core::FAILURE) {
             throw new \RuntimeException("Can not add an item with key {$key}");
+        }
+    }
+
+    /**
+     * Performs search by integer key in the hashtable
+     *
+     * Same borrowing contract as find(): the returned wrapper is valid until the bucket
+     * is deleted or the table is rehashed, and reading it never changes refcounts.
+     *
+     * @return ReflectionValue|null Value or null if not found
+     */
+    public function findIndex(int $key): ?ReflectionValue
+    {
+        $pointer = Core::call('zend_hash_index_find', $this->pointer, $key);
+
+        if ($pointer !== null) {
+            $pointer = ReflectionValue::fromValueEntry($pointer);
+        }
+
+        return $pointer;
+    }
+
+    /**
+     * Adds new value with an integer key to the HashTable
+     *
+     * Same ownership contract as add(): the engine copies the source zval into its own
+     * bucket, the temporary container stays with the caller.
+     */
+    public function addIndex(int $key, ReflectionValue $value): void
+    {
+        $result = Core::call(
+            'zend_hash_index_add_or_update',
+            $this->pointer,
+            $key,
+            $value->getRawValue(),
+            self::HASH_ADD_NEW,
+        );
+        if ($result === null) {
+            throw new \RuntimeException("Can not add an item with index {$key}");
         }
     }
 

--- a/src/Type/ObjectEntry.php
+++ b/src/Type/ObjectEntry.php
@@ -159,6 +159,104 @@ class ObjectEntry implements ReferenceCountedInterface
     }
 
     /**
+     * Returns the object's extra_flags word (IS_OBJ_* engine flags)
+     */
+    public function getExtraFlags(): int
+    {
+        $this->assertObjectAlive();
+
+        return $this->pointer->extra_flags;
+    }
+
+    /**
+     * Replaces the object's extra_flags word
+     *
+     * <span style="color:red; font-weight:bold">Danger!</span> Low-level API, can bring a segmentation fault
+     * @internal
+     */
+    public function setExtraFlags(int $flags): void
+    {
+        $this->assertObjectAlive();
+        $this->pointer->extra_flags = $flags;
+    }
+
+    /**
+     * Returns a borrowed view of one inline property slot (properties_table[$index])
+     *
+     * The returned value owns neither the zval container nor a payload reference; it is
+     * valid only while the object itself is alive.
+     */
+    public function getPropertySlot(int $index): ReflectionValue
+    {
+        $this->assertObjectAlive();
+        $propertiesCount = $this->pointer->ce->default_properties_count;
+        if ($index < 0 || $index >= $propertiesCount) {
+            throw new \OutOfBoundsException("Property slot {$index} is out of bounds 0.." . ($propertiesCount - 1));
+        }
+
+        return ReflectionValue::fromValueEntry(Core::addr($this->pointer->properties_table[$index]));
+    }
+
+    /**
+     * Returns a raw pointer (zval *) to the first inline property slot, eg for snapshotting
+     * the whole properties_table with memcpy
+     * @internal
+     */
+    public function getPropertyTablePointer(): CData
+    {
+        $this->assertObjectAlive();
+
+        return Core::addr($this->pointer->properties_table[0]);
+    }
+
+    /**
+     * Returns the raw dynamic-properties HashTable pointer or null if it was never built
+     * @internal
+     */
+    public function getDynamicPropertiesPointer(): ?CData
+    {
+        $this->assertObjectAlive();
+
+        return $this->pointer->properties;
+    }
+
+    /**
+     * Replaces the raw dynamic-properties HashTable pointer
+     *
+     * No refcounting is performed on either the previous or the new table - the caller
+     * keeps ownership of both, exactly like setClass() does for class entries.
+     * @internal
+     */
+    public function setDynamicPropertiesPointer(?CData $hashTable): void
+    {
+        $this->assertObjectAlive();
+        $this->pointer->properties = $hashTable;
+    }
+
+    /**
+     * Points the object at another zend_object_handlers block
+     *
+     * Handler blocks are not refcounted engine structures, so replacing the pointer
+     * transfers no ownership (same contract as setClass()).
+     * @internal
+     */
+    public function setHandlers(CData $handlers): void
+    {
+        $this->assertObjectAlive();
+        $this->pointer->handlers = Core::cast('zend_object_handlers *', $handlers);
+    }
+
+    /**
+     * Returns raw C value entry
+     */
+    public function getRawValue(): CData
+    {
+        $this->assertObjectAlive();
+
+        return $this->pointer;
+    }
+
+    /**
      * Returns a PHP instance of object, associated with this entry
      */
     public function getNativeValue(): object

--- a/src/Type/ObjectEntry.php
+++ b/src/Type/ObjectEntry.php
@@ -193,8 +193,11 @@ class ObjectEntry implements ReferenceCountedInterface
         if ($index < 0 || $index >= $propertiesCount) {
             throw new \OutOfBoundsException("Property slot {$index} is out of bounds 0.." . ($propertiesCount - 1));
         }
+        // properties_table is a flexible array member declared zval[1]: FFI bounds-checks
+        // direct indexing, so slots past the first must go through pointer arithmetic
+        $tableBase = Core::cast('zval *', Core::addr($this->pointer->properties_table[0]));
 
-        return ReflectionValue::fromValueEntry(Core::addr($this->pointer->properties_table[$index]));
+        return ReflectionValue::fromValueEntry(Core::addr($tableBase[$index]));
     }
 
     /**

--- a/src/Type/PersistentHashTable.php
+++ b/src/Type/PersistentHashTable.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Type;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * A malloc-backed zend_array that outlives the request
+ *
+ * Emulates the engine's _zend_hash_init(ht, HT_MIN_SIZE, NULL, persistent = true) with
+ * FFI-allocated persistent memory: the struct starts HASH_FLAG_UNINITIALIZED and the
+ * first insert makes the engine real-init it. Because the GC header carries
+ * GC_PERSISTENT, every engine (re)allocation of the data block goes through
+ * pemalloc(..., 1) - plain malloc - and is therefore compatible with the FFI persistent
+ * allocator that minted the struct itself.
+ *
+ * Memory ownership contract (extends the HashTable one, see docs/long-running.md):
+ *
+ *  - create() mints an immortal-by-design block: nothing releases the struct or the
+ *    engine-grown data block before process end.
+ *  - pDestructor is NULL: deleting or overwriting a bucket never releases the payload;
+ *    the writer owns every value stored here and any replaced block stays allocated
+ *    (bounded, reclaimed at process end).
+ *  - add() interns every string key as a persistent interned string: the engine stores
+ *    interned keys without addref, so no request-lifetime key can leak into the table.
+ *  - add()/addIndex() are upserts here (HASH_UPDATE), unlike the add-new parent methods:
+ *    persistent registries are refreshed in place across requests.
+ *  - markImmutable() seals the table interned-style (GC_IMMUTABLE, refcount 2): the
+ *    engine copies it into zvals without refcounting and copy-on-writes into request
+ *    memory on mutation, which is the only safe shape for a persistent array reachable
+ *    from userland values.
+ *
+ * The per-process sentinel block stands in for the engine's non-exported
+ * uninitialized_bucket constant (two HT_INVALID_IDX slots); it is shared by every
+ * uninitialized persistent table and never freed.
+ */
+final class PersistentHashTable extends HashTable
+{
+    /**
+     * @see zend_hash.c:uninitialized_bucket - two uint32_t slots holding HT_INVALID_IDX
+     */
+    private const HT_INVALID_IDX = 0xFFFFFFFF;
+
+    /**
+     * Process-lifetime stand-in for the engine's static uninitialized_bucket
+     */
+    private static ?CData $uninitializedBucket = null;
+
+    /**
+     * Mints a new empty persistent hashtable (mutable, engine-compatible)
+     *
+     * Field-for-field port of zend_hash.c:_zend_hash_init_int(ht, HT_MIN_SIZE, NULL, true).
+     */
+    public static function create(): self
+    {
+        $table   = Core::trackedNew('HashTable', true);
+        $pointer = Core::cast('HashTable *', Core::addr($table));
+
+        $pointer->gc->refcount     = 1;
+        $pointer->gc->u->type_info = Core::engineConstant('GC_ARRAY')
+            | Core::engineConstant('GC_PERSISTENT')
+            | Core::engineConstant('GC_NOT_COLLECTABLE');
+        $pointer->u->flags         = Core::engineConstant('HASH_FLAG_UNINITIALIZED');
+        $pointer->nTableMask       = Core::engineConstant('HT_MIN_MASK');
+        $pointer->arData           = self::uninitializedBucketData();
+        $pointer->nNumUsed         = 0;
+        $pointer->nNumOfElements   = 0;
+        $pointer->nTableSize       = Core::engineConstant('HT_MIN_SIZE');
+        $pointer->nInternalPointer = 0;
+        $pointer->nNextFreeElement = PHP_INT_MIN;
+        $pointer->pDestructor      = null;
+
+        return new self($pointer);
+    }
+
+    /**
+     * Wraps an existing persistent hashtable, eg one recovered from module globals
+     */
+    public static function fromCData(CData $pointer): self
+    {
+        return new self($pointer);
+    }
+
+    /**
+     * Upserts a value under a persistent interned string key
+     *
+     * The key is minted as a persistent interned string so the engine stores it without
+     * addref and no request-lifetime string can leak into the table. The engine copies
+     * the source zval into its bucket; the container stays with the caller.
+     */
+    public function add(string $key, ReflectionValue $value): void
+    {
+        $stringEntry = StringEntry::persistentInterned($key);
+        $result      = Core::call(
+            'zend_hash_add_or_update',
+            $this->pointer,
+            $stringEntry->getRawValue(),
+            $value->getRawValue(),
+            self::HASH_UPDATE,
+        );
+        if ($result === null) {
+            throw new \RuntimeException("Can not store an item with key {$key}");
+        }
+    }
+
+    /**
+     * Upserts a value under an integer key
+     */
+    public function addIndex(int $key, ReflectionValue $value): void
+    {
+        $result = Core::call(
+            'zend_hash_index_add_or_update',
+            $this->pointer,
+            $key,
+            $value->getRawValue(),
+            self::HASH_UPDATE,
+        );
+        if ($result === null) {
+            throw new \RuntimeException("Can not store an item with index {$key}");
+        }
+    }
+
+    /**
+     * Seals the table interned-style: non-refcounted in zvals, copy-on-write on mutation
+     *
+     * After sealing, no further add()/addIndex() calls are allowed (the engine asserts
+     * on writes into immutable arrays); refcount 2 follows the immutable convention so
+     * engine separation paths always duplicate instead of mutating in place.
+     */
+    public function markImmutable(): void
+    {
+        $this->pointer->gc->u->type_info |= Core::engineConstant('GC_IMMUTABLE');
+        $this->pointer->gc->refcount = 2;
+    }
+
+    /**
+     * Returns raw C value entry (HashTable *)
+     */
+    public function getRawValue(): CData
+    {
+        return $this->pointer;
+    }
+
+    /**
+     * Returns arData pointing right past the shared sentinel, as HT_SET_DATA_ADDR does
+     *
+     * @see zend_types.h:HT_SET_DATA_ADDR/HT_HASH_SIZE - for HT_MIN_MASK the hash part
+     *      occupies two uint32_t slots, so arData points 8 bytes past the block start
+     */
+    private static function uninitializedBucketData(): CData
+    {
+        if (self::$uninitializedBucket === null) {
+            $sentinel    = Core::trackedNew('uint32_t[2]', true);
+            $sentinel[0] = self::HT_INVALID_IDX;
+            $sentinel[1] = self::HT_INVALID_IDX;
+
+            self::$uninitializedBucket = $sentinel;
+        }
+
+        return Core::cast('Bucket *', Core::cast('char *', self::$uninitializedBucket) + 8);
+    }
+}

--- a/src/Type/PersistentHashTable.php
+++ b/src/Type/PersistentHashTable.php
@@ -147,14 +147,6 @@ final class PersistentHashTable extends HashTable
     }
 
     /**
-     * Returns raw C value entry (HashTable *)
-     */
-    public function getRawValue(): CData
-    {
-        return $this->pointer;
-    }
-
-    /**
      * Returns arData pointing right past the shared sentinel, as HT_SET_DATA_ADDR does
      *
      * @see zend_types.h:HT_SET_DATA_ADDR/HT_HASH_SIZE - for HT_MIN_MASK the hash part

--- a/src/Type/PersistentObjectFactory.php
+++ b/src/Type/PersistentObjectFactory.php
@@ -76,7 +76,12 @@ final class PersistentObjectFactory
         $object->gc->u->type_info = Core::engineConstant('GC_OBJECT')
             | Core::engineConstant('GC_NOT_COLLECTABLE')
             | Core::engineConstant('GC_PERSISTENT');
-        $object->extra_flags |= Core::engineConstant('IS_OBJ_DESTRUCTOR_CALLED');
+        // Both shutdown passes over the object store must skip persistent clones: the
+        // destructor pass honors IS_OBJ_DESTRUCTOR_CALLED, the free-storage pass honors
+        // IS_OBJ_FREE_CALLED. Callers detach the object before teardown anyway - these
+        // flags are the belt-and-braces layer for buckets that leak past a missed detach.
+        $object->extra_flags |= Core::engineConstant('IS_OBJ_DESTRUCTOR_CALLED')
+            | Core::engineConstant('IS_OBJ_FREE_CALLED');
         $object->handlers   = Core::addr(Core::getStandardObjectHandlers());
         $object->properties = null;
 

--- a/src/Type/PersistentObjectFactory.php
+++ b/src/Type/PersistentObjectFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2019, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Type;
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionClass;
+
+/**
+ * Mints malloc-backed zend_object clones that can outlive the request
+ *
+ * A persistent clone is a byte copy of a live object with its GC header rewritten so no
+ * engine path ever reclaims it:
+ *
+ *  - refcount pinned at PIN_BASELINE: request-time addref/delref churn never reaches
+ *    zero, so rc_dtor_func/zend_object_release are never triggered;
+ *  - GC_NOT_COLLECTABLE: GC_TYPE_INFO no longer equals GC_OBJECT, so the cycle
+ *    collector neither buffers the object as a possible root nor writes gc_info bits
+ *    into the persistent header;
+ *  - GC_PERSISTENT: z-engine wrappers recognize the payload as malloc-backed and skip
+ *    engine destruction on release;
+ *  - IS_OBJ_DESTRUCTOR_CALLED in extra_flags: shutdown destructor passes over the
+ *    object store skip it (__destruct never runs for persistent clones, by design);
+ *  - handlers rewired to the engine's std_object_handlers global: the only handlers
+ *    block whose address is stable for the whole process lifetime. Callers must reject
+ *    source objects using any other handlers block (internal classes, hooked classes) -
+ *    a pointer to a request-lifetime handlers block would dangle on the next request.
+ *
+ * Deliberately does NOT go through zend_object_std_init: std_init registers the object
+ * in the request-scoped EG(objects_store) and writes request-normal GC flags. The clone
+ * leaves the copied handle in place; it is only valid after the caller re-registers the
+ * object for the current request via ObjectStore::put().
+ *
+ * The inline properties_table zvals are byte copies of the source: the caller (persister)
+ * owns converting every refcounted slot into a persistent/immutable payload - a byte
+ * copy of a request-allocated payload pointer would dangle after the request ends.
+ *
+ * Memory ownership: clones are immortal-by-design (docs/long-running.md); nothing frees
+ * them before process end.
+ */
+final class PersistentObjectFactory
+{
+    /**
+     * Refcount baseline for persistent objects: high enough that request-time release
+     * churn can never reach zero, low enough to stay far from the uint32 range
+     */
+    public const PIN_BASELINE = 1 << 29;
+
+    /**
+     * Creates a persistent byte-clone of a live zend_object
+     *
+     * @param CData $sourceObject zend_object* to clone (must use std_object_handlers)
+     *
+     * @return CData zend_object* in persistent memory, not yet registered in the store
+     */
+    public static function persistentClone(CData $sourceObject): CData
+    {
+        $totalSize = ReflectionClass::getObjectSize($sourceObject->ce);
+        $memory    = Core::trackedNew("char[{$totalSize}]", true);
+        $object    = Core::cast('zend_object *', $memory);
+
+        Core::memcpy($memory, Core::cast('char *', $sourceObject), $totalSize);
+
+        $object->gc->refcount     = self::PIN_BASELINE;
+        $object->gc->u->type_info = Core::engineConstant('GC_OBJECT')
+            | Core::engineConstant('GC_NOT_COLLECTABLE')
+            | Core::engineConstant('GC_PERSISTENT');
+        $object->extra_flags |= Core::engineConstant('IS_OBJ_DESTRUCTOR_CALLED');
+        $object->handlers   = Core::addr(Core::getStandardObjectHandlers());
+        $object->properties = null;
+
+        return $object;
+    }
+
+    /**
+     * Checks that an object uses the engine's std_object_handlers block, the only
+     * handlers pointer that stays valid across requests
+     */
+    public static function usesStandardHandlers(CData $object): bool
+    {
+        return Core::addressOf($object->handlers) === Core::addressOf(Core::addr(Core::getStandardObjectHandlers()));
+    }
+}

--- a/src/Type/StringEntry.php
+++ b/src/Type/StringEntry.php
@@ -137,6 +137,35 @@ class StringEntry implements ReferenceCountedInterface
     }
 
     /**
+     * Mints an owned persistent interned-style (malloc-backed, immutable) zend_string
+     *
+     * Unlike persistent(), the GC_IMMUTABLE flag makes every engine consumer treat the
+     * string exactly like an interned one: zvals hold it without refcounting and
+     * mutation paths copy-on-write into request memory instead of touching this block.
+     * Required for strings reachable from userland values that outlive the request
+     * (persistent object properties): a refcounted persistent string reaching refcount
+     * zero would be freed with the request allocator and corrupt the malloc heap.
+     *
+     * The string is never registered in the engine's interned tables, so equality
+     * against a real interned string falls back to a content compare - same contract
+     * as opcache SHM strings in processes that attach without the interning pass.
+     */
+    public static function persistentInterned(string $value): StringEntry
+    {
+        $stringEntry = static::persistent($value);
+        $pointer     = $stringEntry->pointer;
+
+        $pointer->gc->u->type_info |= Core::engineConstant('GC_IMMUTABLE');
+        // Interned strings live outside refcounting: the engine never addrefs or
+        // releases them, the conventional refcount value for such headers is 2
+        $pointer->gc->refcount = 2;
+        // The wrapper must not treat this as an owned engine reference either
+        $stringEntry->ownsReference = false;
+
+        return $stringEntry;
+    }
+
+    /**
      * Returns raw C value entry
      */
     public function getRawValue(): ?CData
@@ -208,6 +237,17 @@ class StringEntry implements ReferenceCountedInterface
     public function isInterned(): bool
     {
         return $this->isImmutable();
+    }
+
+    /**
+     * Checks if this string is a permanent interned string (lives for the process
+     * lifetime, eg opcache SHM or startup interning) rather than a request-interned one
+     *
+     * @see zend_string.h:IS_STR_PERMANENT
+     */
+    public function isPermanent(): bool
+    {
+        return (bool) ($this->getGC()->u->type_info & Core::engineConstant('IS_STR_PERMANENT'));
     }
 
     /**

--- a/tests/Memory/scenarios/persistent-hashtable-churn.php
+++ b/tests/Memory/scenarios/persistent-hashtable-churn.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Type\PersistentHashTable;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+// The persistent tables themselves are immortal-by-design malloc blocks; the gate
+// verifies that no REQUEST memory leaks while feeding and reading them
+$registry = PersistentHashTable::create();
+
+for ($index = 0; $index < 200; $index++) {
+    $value = new ReflectionValue($index);
+    $registry->add('key-' . ($index % 10), $value);
+    $registry->addIndex($index % 10, $value);
+    $value->release();
+
+    $found = $registry->find('key-' . ($index % 10));
+    if ($found === null) {
+        throw new RuntimeException('Persistent table lookup failed');
+    }
+    $found->getNativeValue($nativeValue);
+    if ($nativeValue !== $index) {
+        throw new RuntimeException('Persistent table round-trip failed');
+    }
+
+    foreach ($registry->getIterator() as $item) {
+        // Borrowed views only: iteration must not addref anything
+    }
+}
+
+// Sealed tables materialize as non-refcounted zvals: reading and copy-on-writing
+// them from userland must produce no request-memory leaks either
+$registry->markImmutable();
+for ($index = 0; $index < 200; $index++) {
+    $entry = ReflectionValue::newEntry(ReflectionValue::IS_ARRAY, $registry->getRawValue()[0]);
+    $entry->getNativeValue($native);
+    $entry->release();
+
+    $copy          = $native;
+    $copy['key-1'] = 'mutated ' . $index;
+    unset($copy, $native);
+}
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;

--- a/tests/Memory/scenarios/persistent-object-put-detach.php
+++ b/tests/Memory/scenarios/persistent-object-put-detach.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Type\ObjectEntry;
+use ZEngine\Type\PersistentObjectFactory;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+class FlatCandidate
+{
+    public int $counter = 0;
+
+    public bool $enabled = true;
+}
+
+// One immortal persistent clone attached and detached many times: simulates the
+// per-request lifecycle of a persistent object within a single process
+$source          = new FlatCandidate();
+$source->counter = 42;
+
+$sourceValue = new ReflectionValue($source);
+$clone       = PersistentObjectFactory::persistentClone($sourceValue->getRawObject());
+$sourceValue->release();
+unset($source);
+
+$store = Core::$executor->objectStore;
+
+for ($index = 0; $index < 500; $index++) {
+    $handle = $store->put($clone);
+
+    $entry = ReflectionValue::newEntry(ReflectionValue::IS_OBJECT, $clone[0]);
+    $entry->getNativeValue($alias);
+    $entry->release();
+
+    if ($alias->counter !== 42 || spl_object_id($alias) !== $handle) {
+        throw new RuntimeException('Persistent clone round-trip failed');
+    }
+    unset($alias);
+
+    if (ObjectEntry::fromCData($clone)->getReferenceCount() !== PersistentObjectFactory::PIN_BASELINE) {
+        throw new RuntimeException('Refcount drifted from the pin baseline');
+    }
+
+    $store->recycle($handle);
+}
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;

--- a/tests/Stub/TestPersistentCandidate.php
+++ b/tests/Stub/TestPersistentCandidate.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+/**
+ * Flat scalar-only class: a byte-copy-safe candidate for persistent object cloning
+ */
+class TestPersistentCandidate
+{
+    public int $counter = 0;
+
+    public float $ratio = 1.5;
+
+    public bool $enabled = false;
+}

--- a/tests/Type/PersistentHashTableTest.php
+++ b/tests/Type/PersistentHashTableTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Type;
+
+use PHPUnit\Framework\TestCase;
+use ZEngine\Reflection\ReflectionValue;
+
+class PersistentHashTableTest extends TestCase
+{
+    public function testCreateMintsPersistentNonCollectableTable(): void
+    {
+        $table = PersistentHashTable::create();
+
+        $this->assertTrue($table->isPersistent());
+        $this->assertFalse($table->isImmutable());
+        $this->assertSame(1, $table->getReferenceCount());
+        $this->assertCount(0, iterator_to_array($table->getIterator(), false));
+    }
+
+    public function testStringKeyUpsertAndFind(): void
+    {
+        $table = PersistentHashTable::create();
+
+        $value = new ReflectionValue(42);
+        $table->add('answer', $value);
+        $value->release();
+
+        $found = $table->find('answer');
+        $this->assertNotNull($found);
+        $found->getNativeValue($native);
+        $this->assertSame(42, $native);
+
+        // add() is an upsert for persistent registries: same key replaces in place
+        $replacement = new ReflectionValue(43);
+        $table->add('answer', $replacement);
+        $replacement->release();
+
+        $table->find('answer')->getNativeValue($updated);
+        $this->assertSame(43, $updated);
+        $this->assertNull($table->find('missing'));
+    }
+
+    public function testIndexKeyUpsertAndFind(): void
+    {
+        $table = PersistentHashTable::create();
+
+        $value = new ReflectionValue(100);
+        $table->addIndex(7, $value);
+        $value->release();
+
+        $found = $table->findIndex(7);
+        $this->assertNotNull($found);
+        $found->getNativeValue($native);
+        $this->assertSame(100, $native);
+
+        $replacement = new ReflectionValue(200);
+        $table->addIndex(7, $replacement);
+        $replacement->release();
+
+        $table->findIndex(7)->getNativeValue($updated);
+        $this->assertSame(200, $updated);
+        $this->assertNull($table->findIndex(8));
+    }
+
+    public function testSealedTableMaterializesAndCopiesOnWrite(): void
+    {
+        $table = PersistentHashTable::create();
+
+        $value = new ReflectionValue(42);
+        $table->add('answer', $value);
+        $value->release();
+
+        $table->markImmutable();
+        $this->assertTrue($table->isImmutable());
+        $this->assertSame(2, $table->getReferenceCount());
+
+        // An immutable payload materializes into a non-refcounted zval: userland copies
+        // share the pointer and copy-on-write into request memory on mutation
+        $entry = ReflectionValue::newEntry(ReflectionValue::IS_ARRAY, $table->getRawValue()[0]);
+        $entry->getNativeValue($native);
+        $entry->release();
+
+        $this->assertSame(['answer' => 42], $native);
+
+        $copy           = $native;
+        $copy['answer'] = 1000;
+
+        // The persistent block must stay untouched by the userland write
+        $table->find('answer')->getNativeValue($stillPersistent);
+        $this->assertSame(42, $stillPersistent);
+        $this->assertSame(1000, $copy['answer']);
+        $this->assertSame(2, $table->getReferenceCount());
+    }
+
+    public function testStringKeysAreStoredAsPersistentInterned(): void
+    {
+        $table = PersistentHashTable::create();
+
+        $value = new ReflectionValue(1);
+        $table->add('registry-key', $value);
+        $value->release();
+
+        foreach ($table->getIterator() as $key => $item) {
+            $this->assertSame('registry-key', $key);
+        }
+
+        // The minted key itself must be interned-style: immutable + persistent
+        $interned = StringEntry::persistentInterned('registry-key');
+        $this->assertTrue($interned->isInterned());
+        $this->assertTrue($interned->isPersistent());
+        $this->assertFalse($interned->isPermanent());
+        $this->assertSame(2, $interned->getReferenceCount());
+        $this->assertSame('registry-key', $interned->getStringValue());
+    }
+}

--- a/tests/Type/PersistentObjectFactoryTest.php
+++ b/tests/Type/PersistentObjectFactoryTest.php
@@ -112,6 +112,12 @@ class PersistentObjectFactoryTest extends TestCase
         $slot->getNativeValue($value);
         $this->assertSame(7, $value);
 
+        // Slots past the first exercise the pointer-arithmetic path (zval[1] flexible member)
+        $entry->getPropertySlot(1)->getNativeValue($ratio);
+        $this->assertSame(1.5, $ratio);
+        $entry->getPropertySlot(2)->getNativeValue($enabled);
+        $this->assertFalse($enabled);
+
         $this->assertInstanceOf(\FFI\CData::class, $entry->getPropertyTablePointer());
 
         $this->expectException(\OutOfBoundsException::class);

--- a/tests/Type/PersistentObjectFactoryTest.php
+++ b/tests/Type/PersistentObjectFactoryTest.php
@@ -33,8 +33,9 @@ class PersistentObjectFactoryTest extends TestCase
         $this->assertTrue($entry->isPersistent());
         $this->assertFalse($entry->isImmutable());
 
-        $destructorCalled = Core::engineConstant('IS_OBJ_DESTRUCTOR_CALLED');
-        $this->assertSame($destructorCalled, $entry->getExtraFlags() & $destructorCalled);
+        $shutdownSkipFlags = Core::engineConstant('IS_OBJ_DESTRUCTOR_CALLED')
+            | Core::engineConstant('IS_OBJ_FREE_CALLED');
+        $this->assertSame($shutdownSkipFlags, $entry->getExtraFlags() & $shutdownSkipFlags);
         $this->assertTrue(PersistentObjectFactory::usesStandardHandlers($clone));
         $this->assertNull($entry->getDynamicPropertiesPointer());
     }

--- a/tests/Type/PersistentObjectFactoryTest.php
+++ b/tests/Type/PersistentObjectFactoryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Type;
+
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Stub\TestPersistentCandidate;
+
+class PersistentObjectFactoryTest extends TestCase
+{
+    public function testPersistentCloneRewritesGcHeaderAndHandlers(): void
+    {
+        $source = new TestPersistentCandidate();
+
+        $sourceValue = new ReflectionValue($source);
+        $clone       = PersistentObjectFactory::persistentClone($sourceValue->getRawObject());
+        $sourceValue->release();
+
+        $entry = ObjectEntry::fromCData($clone);
+        $this->assertSame(PersistentObjectFactory::PIN_BASELINE, $entry->getReferenceCount());
+        $this->assertTrue($entry->isPersistent());
+        $this->assertFalse($entry->isImmutable());
+
+        $destructorCalled = Core::engineConstant('IS_OBJ_DESTRUCTOR_CALLED');
+        $this->assertSame($destructorCalled, $entry->getExtraFlags() & $destructorCalled);
+        $this->assertTrue(PersistentObjectFactory::usesStandardHandlers($clone));
+        $this->assertNull($entry->getDynamicPropertiesPointer());
+    }
+
+    public function testCloneRoundTripsThroughObjectStore(): void
+    {
+        $source          = new TestPersistentCandidate();
+        $source->counter = 99;
+
+        $sourceValue = new ReflectionValue($source);
+        $clone       = PersistentObjectFactory::persistentClone($sourceValue->getRawObject());
+        $sourceValue->release();
+
+        $store  = Core::$executor->objectStore;
+        $handle = $store->put($clone);
+        $this->assertSame($handle, $clone->handle);
+        $this->assertTrue(isset($store[$handle]));
+
+        // Materialize a userland alias of the persistent clone
+        $entry = ReflectionValue::newEntry(ReflectionValue::IS_OBJECT, $clone[0]);
+        $entry->getNativeValue($restored);
+        $entry->release();
+
+        $this->assertInstanceOf(TestPersistentCandidate::class, $restored);
+        $this->assertSame(99, $restored->counter);
+        $this->assertSame($handle, spl_object_id($restored));
+        $this->assertSame(PersistentObjectFactory::PIN_BASELINE + 1, ObjectEntry::fromCData($clone)->getReferenceCount());
+
+        // Dropping the alias returns the refcount to the pin baseline
+        unset($restored);
+        $this->assertSame(PersistentObjectFactory::PIN_BASELINE, ObjectEntry::fromCData($clone)->getReferenceCount());
+
+        // Detaching hides the object from the store (and from shutdown teardown passes)
+        $store->detach($handle);
+        $this->assertFalse(isset($store[$handle]));
+    }
+
+    public function testRecycleKeepsStoreSizeBoundedAcrossPutCycles(): void
+    {
+        $source = new TestPersistentCandidate();
+
+        $sourceValue = new ReflectionValue($source);
+        $clone       = PersistentObjectFactory::persistentClone($sourceValue->getRawObject());
+        $sourceValue->release();
+
+        $store = Core::$executor->objectStore;
+
+        // Warm up allocator/CData churn, then measure: recycled slots must be reused,
+        // so many put/recycle cycles may not grow the store top by more than a few
+        // slots of unrelated CData churn. (Slot-level assertions are unmeasurable
+        // here: every FFI CData is itself an object in this very store, so any
+        // inspection of a freed slot immediately reuses it.)
+        for ($i = 0; $i < 5; $i++) {
+            $store->recycle($store->put($clone));
+        }
+        $baselineTop = count($store);
+
+        for ($i = 0; $i < 50; $i++) {
+            $handle = $store->put($clone);
+            $this->assertSame($handle, $clone->handle);
+            $store->recycle($handle);
+        }
+
+        $this->assertLessThanOrEqual($baselineTop + 4, count($store));
+    }
+
+    public function testPropertySlotAccessors(): void
+    {
+        $source          = new TestPersistentCandidate();
+        $source->counter = 7;
+
+        $entry = ObjectEntry::weakFor($source);
+
+        $slot = $entry->getPropertySlot(0);
+        $slot->getNativeValue($value);
+        $this->assertSame(7, $value);
+
+        $this->assertInstanceOf(\FFI\CData::class, $entry->getPropertyTablePointer());
+
+        $this->expectException(\OutOfBoundsException::class);
+        $entry->getPropertySlot(42);
+    }
+}

--- a/tools/examples/worker-loop.php
+++ b/tools/examples/worker-loop.php
@@ -28,6 +28,8 @@ use ZEngine\Stub\TestClass;
 use ZEngine\Stub\TestInterface;
 use ZEngine\Stub\TestTrait;
 use ZEngine\Type\ClosureEntry;
+use ZEngine\Type\PersistentHashTable;
+use ZEngine\Type\PersistentObjectFactory;
 use ZEngine\Type\StringEntry;
 
 require __DIR__ . '/../../vendor/autoload.php';
@@ -52,6 +54,21 @@ $closureEntry = new ClosureEntry($closure);
 $propertyName = 'property';
 $baseline     = null;
 
+// Persistent structures are minted once at boot (immortal-by-design) and then
+// attached/detached every iteration like a per-request lifecycle would
+$persistentTable = PersistentHashTable::create();
+$seedValue       = new ReflectionValue(42);
+$persistentTable->add('seed', $seedValue);
+$seedValue->release();
+$persistentTable->markImmutable();
+
+$candidate          = new ZEngine\Stub\TestPersistentCandidate();
+$candidate->counter = 42;
+$candidateValue     = new ReflectionValue($candidate);
+$persistentClone    = PersistentObjectFactory::persistentClone($candidateValue->getRawObject());
+$candidateValue->release();
+unset($candidate, $candidateValue);
+
 for ($iteration = 1; $iteration <= $totalIterations; $iteration++) {
     // Value wrapper churn
     $value = new ReflectionValue('iteration payload ' . $iteration);
@@ -74,6 +91,24 @@ for ($iteration = 1; $iteration <= $totalIterations; $iteration++) {
 
     // Closure this-rebinding
     $closureEntry->setThis(new ArrayObject([$iteration]));
+
+    // Persistent object attach / materialize / detach cycle plus immutable-array COW
+    $handle = Core::$executor->objectStore->put($persistentClone);
+    $entry  = ReflectionValue::newEntry(ReflectionValue::IS_OBJECT, $persistentClone[0]);
+    $entry->getNativeValue($persistentAlias);
+    $entry->release();
+    if ($persistentAlias->counter !== 42) {
+        fwrite(STDERR, "Persistent clone read failed at iteration {$iteration}\n");
+        exit(1);
+    }
+    unset($persistentAlias);
+    Core::$executor->objectStore->recycle($handle);
+
+    $tableEntry = ReflectionValue::newEntry(ReflectionValue::IS_ARRAY, $persistentTable->getRawValue()[0]);
+    $tableEntry->getNativeValue($persistentCopy);
+    $tableEntry->release();
+    $persistentCopy['seed'] = $iteration; // must copy-on-write, never touch the block
+    unset($persistentCopy);
 
     // AST parse / destroy cycle
     if ($iteration % 10 === 0) {

--- a/tools/generator/symbols.php
+++ b/tools/generator/symbols.php
@@ -72,6 +72,8 @@ return [
         'zend_hash_del',
         'zend_hash_find',
         'zend_hash_add_or_update',
+        'zend_hash_index_add_or_update',
+        'zend_hash_index_find',
         // Opcode API
         'zend_set_user_opcode_handler',
         'zend_get_user_opcode_handler',
@@ -80,6 +82,7 @@ return [
         'zend_objects_new',
         'zend_object_std_init',
         'object_properties_init',
+        'zend_objects_store_put',
         // Language scanner API
         'zend_save_lexical_state',
         'zend_restore_lexical_state',
@@ -158,6 +161,7 @@ return [
         'HASH_FLAG_CONSISTENCY', 'HASH_FLAG_PACKED', 'HASH_FLAG_UNINITIALIZED',
         'HASH_FLAG_STATIC_KEYS', 'HASH_FLAG_HAS_EMPTY_IND', 'HASH_FLAG_ALLOW_COW_VIOLATION',
         'HASH_UPDATE', 'HASH_ADD', 'HASH_UPDATE_INDIRECT', 'HASH_ADD_NEW', 'HASH_ADD_NEXT',
+        'HT_MIN_MASK', 'HT_MIN_SIZE',
         // Module API (zend_modules.h)
         'ZEND_MODULE_API_NO', 'MODULE_PERSISTENT', 'MODULE_TEMPORARY',
         // Engine build info


### PR DESCRIPTION
## Summary

Engine-level primitives that let PHP objects survive the request boundary (per worker process), like interned strings do. The user-facing feature lives in [`lisachenko/php-shared-data-extension`](https://github.com/lisachenko/php-shared-data-extension) (companion PR on the same branch name); this PR provides the generic building blocks plus three PHP 8.4 compatibility fixes discovered along the way.

## New primitives

- **`PersistentHashTable`** — malloc-backed `zend_array` mirroring `_zend_hash_init(..., persistent = true)`: starts `HASH_FLAG_UNINITIALIZED` over a shared sentinel block (stand-in for the non-exported `uninitialized_bucket`), so the engine real-inits it on first insert with `pemalloc(..., 1)` — allocator-compatible with FFI persistent memory. String keys are interned persistently, `add()/addIndex()` are upserts, and `markImmutable()` seals the table interned-style (non-refcounted in zvals, engine copy-on-writes on mutation).
- **`PersistentObjectFactory::persistentClone()`** — refcount-pinned (`1 << 29`), non-collectable (`GC_NOT_COLLECTABLE`, so the cycle collector never buffers it), persistent byte-clone of a live `zend_object`, wired to the address-stable `std_object_handlers` with both shutdown passes over the object store suppressed (`IS_OBJ_DESTRUCTOR_CALLED | IS_OBJ_FREE_CALLED`).
- **`ObjectStore::put()`/`recycle()`** — engine registration via the newly exported `zend_objects_store_put`, and free-list slot recycling mirroring `zend_objects_store_del`'s bookkeeping.
- **`ObjectEntry`** — accessors for `extra_flags`, inline `properties_table` slots (pointer arithmetic — the `zval[1]` flexible member is FFI-bounds-checked), the dynamic-properties pointer, handlers, and the raw object.
- **`StringEntry::persistentInterned()`/`isPermanent()`** — interned-style persistent strings (immutable, non-refcounted in zvals), the only safe shape for a persistent string reachable from userland values.
- **Generator**: exports `zend_objects_store_put`, `zend_hash_index_add_or_update`, `zend_hash_index_find`, `HT_MIN_MASK`, `HT_MIN_SIZE` (regenerated artifacts included; the regen was verified byte-identical against the committed artifacts before the symbol change, and the no-Docker regeneration recipe is now documented in AGENTS.md).

## PHP 8.4 compatibility fixes

- **Module entries must be malloc-backed**: since 8.4 `zend_register_module_ex` stores the passed pointer directly (`zend_hash_add_ptr` replaced the copying `add_mem`), so the previous FFI-owned entry became dangling once collected — any later allocation reusing the block corrupted the module registry and crashed native `ReflectionExtension`.
- **Registry key must be persistent-interned**: runtime registration interns the `module_registry` key as a *request-lifetime* string, which crashed the registry teardown at process shutdown for persistent modules. The key is swapped for a persistent interned string right after registration.
- **`Core::cast` decay guard**: `count()` throws `TypeError` (not `FFI\Exception`) for scalar CData, which broke every scalar-to-pointer cast, including the pre-existing `ObjectStore::detach()`.
- **`ObjectStore::recycle` free-list race**: every FFI CData is itself an object in the store, so creating temporaries mid-edit popped the very free list being edited and orphaned one slot per cycle. All temporaries are now prepared before the edit — put/recycle cycles are byte-stable (verified +0 slots over 1000 cycles).

## Testing

- New unit tests: `PersistentHashTableTest` (create/upsert/find/seal/copy-on-write), `PersistentObjectFactoryTest` (GC header, store round-trip, refcount pinning, bounded slot recycling, property-slot accessors)
- New leak-gate scenarios: `persistent-hashtable-churn`, `persistent-object-put-detach`
- `tools/examples/worker-loop.php` soak extended with a persistent attach/materialize/detach + immutable-array COW block per iteration — final delta **+32 bytes over 3000 iterations**
- Full suite: 167 tests / 2776 assertions green; PHPStan level max clean (FFI-CData mixed-type noise baselined per repo convention); php-cs-fixer clean
- `docs/long-running.md` immortal-by-design table extended with the new allocation classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKeUJYmqgXbgr1ppx6gjX3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKeUJYmqgXbgr1ppx6gjX3)_