### PR TITLE
feat(type): dismantle persistent data structures across requests

### DIFF
--- a/docs/long-running.md
+++ b/docs/long-running.md
@@ -134,9 +134,39 @@ The debug-build leak gate treats the following as expected, by design:
 | Refcount-0 persistent strings | never freed with the request allocator; bounded, reclaimed at process end |
 | Engine-original interface/trait buffers replaced by z-engine (including the trait alias/precedence lists replaced by `addTraitAlias()`/`addTraitPrecedence()` and their `remove*` counterparts) | possibly shared or in opcache SHM, never freed by z-engine; at most one per touched class |
 | Persistent interned strings (`StringEntry::persistentInterned`) | interned-style (immutable, non-refcounted) blocks referenced by persistent tables and object properties; bounded by the number of persisted keys/values, reclaimed at process end |
-| Persistent hashtables and their engine-grown data blocks (`PersistentHashTable`) | registries that must outlive the request by design; the engine resizes their data with the persistent allocator, nothing may free them mid-process |
+| Persistent hashtables and their engine-grown data blocks (`PersistentHashTable`) | registries that must outlive the request by design; the engine resizes their data with the persistent allocator, so only `PersistentHashTable::destroy()` may release them (see below) |
 | The shared `uninitialized_bucket` sentinel block | one `uint32_t[2]` per process backing every uninitialized persistent table, mirroring the engine's static |
 | Persistent object clones (`PersistentObjectFactory::persistentClone`) | refcount-pinned malloc objects designed to survive the request boundary; detached from the object store before teardown so no engine path ever frees them |
 
 Everything else is a bug: the test suite runs with `report_memleaks=1` on a debug build and
 fails on any leak report.
+
+## Dismantling persistent data (cross-request free)
+
+"Immortal by design" is the *default* for persistent allocations, not a life sentence: a
+long-running process that keeps persisting new state needs a way to drop old state again.
+That path is deliberately narrow, because releasing persistent memory is the one operation
+the engine cannot help with.
+
+| Primitive | What it releases |
+|-----------|------------------|
+| `Core::untrackAndFree($ptr)` | a block **allocated in this same request**, through the owning CData in the tracked-block registry (right allocator guaranteed, no-op for engine-original buffers) |
+| `Core::persistentFree($ptr)` | any malloc-backed block, through libc `free()`, with no bookkeeping at all |
+| `PersistentHashTable::destroy()` | one persistent table: `zend_hash_destroy()` for the engine-grown data block, then the struct itself |
+
+`Core::persistentFree()` exists because the tracked-block registry is a PHP static: it dies
+with the request that filled it. A block persisted by request *N* can only be dropped by
+request *N+k*, where the registry no longer knows it — hence the raw form. It is a plain
+`free(3)`: pass only blocks that are provably malloc-backed (z-engine persistent FFI
+allocations, or engine structures allocated with `pemalloc(..., 1)`), never request memory,
+never an interned `zend_string` (the engine's interned-string table references it), and never
+a block that is still reachable from a live engine structure. The two primitives stay
+orthogonal — `persistentFree()` does not touch the registry, so a caller dropping a block
+allocated in the *current* request must `Core::untrack()` it as well, or a recycled address
+could later be freed a second time through `untrackAndFree()`.
+
+`PersistentHashTable::destroy()` composes both halves for a table and is safe on sealed
+(`markImmutable()`) tables: it re-baselines the immutable refcount so the engine's debug-build
+"nobody else holds this array" assertion in `zend_hash_destroy()` holds. Stored *payloads*
+are never touched (persistent tables carry a NULL `pDestructor` by construction), so nested
+tables and buffers must be released by their owner before the container goes away.

--- a/include/8.4/linux-x64-nts/engine.h
+++ b/include/8.4/linux-x64-nts/engine.h
@@ -956,10 +956,12 @@ typedef struct _zend_closure {
 
 /* Imported functions */
 extern zend_result zend_hash_del(HashTable *, zend_string *);
+extern zend_result zend_hash_index_del(HashTable *, zend_ulong);
 extern zval * zend_hash_find(const HashTable *, zend_string *);
 extern zval * zend_hash_add_or_update(HashTable *, zend_string *, zval *, uint32_t);
 extern zval * zend_hash_index_add_or_update(HashTable *, zend_ulong, zval *, uint32_t);
 extern zval * zend_hash_index_find(const HashTable *, zend_ulong);
+extern void zend_hash_destroy(HashTable *);
 extern zend_result zend_set_user_opcode_handler(uint8_t, user_opcode_handler_t);
 extern user_opcode_handler_t zend_get_user_opcode_handler(uint8_t);
 extern void zend_do_inheritance_ex(zend_class_entry *, zend_class_entry *, _Bool);
@@ -993,6 +995,7 @@ extern void zval_add_ref(zval *);
 extern void rc_dtor_func(zend_refcounted *);
 extern zend_string * zend_string_concat2(const char *, size_t, const char *, size_t);
 extern zend_ulong zend_string_hash_func(zend_string *);
+extern void free(void *);
 
 /* Imported globals */
 extern zend_executor_globals executor_globals;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2715,7 +2715,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$refcount on mixed\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 3
 			path: src/Type/PersistentHashTable.php
 
 		-
@@ -3107,6 +3107,18 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Memory/scenarios/persistent-hashtable-churn.php
+
+		-
+			message: '#^Cannot access offset ''key\-1'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/Memory/scenarios/persistent-hashtable-destroy.php
+
+		-
+			message: '#^Parameter \#2 \$value of static method ZEngine\\Reflection\\ReflectionValue\:\:newEntry\(\) expects FFI\\CData, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Memory/scenarios/persistent-hashtable-destroy.php
 
 		-
 			message: '#^Cannot access property \$counter on mixed\.$#'
@@ -3831,7 +3843,7 @@ parameters:
 		-
 			message: '#^Cannot call method getNativeValue\(\) on ZEngine\\Reflection\\ReflectionValue\|null\.$#'
 			identifier: method.nonObject
-			count: 3
+			count: 6
 			path: tests/Type/PersistentHashTableTest.php
 
 		-

--- a/src/Core.php
+++ b/src/Core.php
@@ -550,6 +550,36 @@ class Core
     }
 
     /**
+     * Releases a RAW malloc-backed pointer through libc free()
+     *
+     * DANGER - this is a plain free(3) with no ownership bookkeeping whatsoever. Passing a
+     * pointer that was not obtained from malloc(), or freeing the same block twice, corrupts
+     * the process heap. Only ever pass blocks that are provably malloc-backed:
+     *
+     *  - z-engine persistent FFI allocations: Core::new()/trackedNew() with $persistent=true
+     *    (ext/ffi allocates those with pemalloc(size, 1), i.e. malloc);
+     *  - engine structures the engine itself allocated persistently, e.g. the arData block
+     *    an engine hash API call grew for a GC_PERSISTENT HashTable.
+     *
+     * Never pass request-lifetime memory (the Zend MM owns it), interned zend_strings (the
+     * engine's interned-string table references them), or anything reachable from a live
+     * engine structure.
+     *
+     * This is the CROSS-REQUEST companion to untrackAndFree(): that one frees through the
+     * owning CData recorded in the tracked-block registry, which is a PHP static and therefore
+     * dies with the request that allocated the block. Persistent data structures are dismantled
+     * by a LATER request, when the registry no longer knows the block - hence the raw form.
+     * The two stay orthogonal: this method does not touch the tracked-block registry, so a
+     * caller that frees a block allocated in the same request must Core::untrack() it too.
+     *
+     * @param CData $pointer Pointer to the malloc-backed block to release
+     */
+    public static function persistentFree(CData $pointer): void
+    {
+        self::call('free', self::cast('void *', $pointer));
+    }
+
+    /**
      * Records a freshly installed hook at the top of its field chain
      *
      * @internal called by AbstractHook::install() and OpCodeHook::install()

--- a/src/Type/HashTable.php
+++ b/src/Type/HashTable.php
@@ -145,6 +145,23 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
     }
 
     /**
+     * Deletes a value by integer key from the hashtable
+     *
+     * Same ownership contract as delete(): the engine destructor releases the bucket
+     * payload, nothing on the PHP side may release it again.
+     *
+     * @param int $key Integer key in the hash to delete
+     * @internal
+     */
+    public function deleteIndex(int $key): void
+    {
+        $result = Core::call('zend_hash_index_del', $this->pointer, $key);
+        if ($result === Core::FAILURE) {
+            throw new \RuntimeException("Can not delete an item with index {$key}");
+        }
+    }
+
+    /**
      * Adds new value to the HashTable
      */
     public function add(string $key, ReflectionValue $value): void

--- a/src/Type/PersistentHashTable.php
+++ b/src/Type/PersistentHashTable.php
@@ -147,6 +147,45 @@ final class PersistentHashTable extends HashTable
     }
 
     /**
+     * Dismantles the table completely: engine data block first, then the struct itself
+     *
+     * The counterpart of create(): it turns an "immortal by design" persistent table back
+     * into free memory, which is what makes persistent registries droppable instead of
+     * process-lifetime only.
+     *
+     * Caller contract - violating any of these corrupts the heap:
+     *  - the caller must OWN the table (it minted it, or inherited ownership) and nothing,
+     *    in this request or a later one, may reference the struct or its buckets afterwards;
+     *  - the wrapper is dead after this call, as is every ReflectionValue previously
+     *    obtained from find()/findIndex()/getIterator();
+     *  - stored PAYLOADS are not touched: pDestructor is NULL on persistent tables by
+     *    construction, so whoever wrote a value into the table still owns it. Release
+     *    payloads (nested tables, persistent buffers) BEFORE destroying their container.
+     *
+     * Sealed (markImmutable()) tables are valid input: the refcount is dropped back to 1
+     * first, so the engine's debug-build "nobody else holds this array" assertion in
+     * zend_hash_destroy() is satisfied. That is the drop path for persisted user payloads.
+     *
+     * Both frees go through the persistent allocator: zend_hash_destroy() pefree()s the
+     * engine-grown arData block because the GC header carries GC_PERSISTENT (an
+     * uninitialized table keeps the shared sentinel and is skipped), and the struct block
+     * itself was minted with malloc by the FFI persistent allocator.
+     */
+    public function destroy(): void
+    {
+        // Sealed tables sit at the immutable refcount of 2; the engine asserts <= 1
+        $this->pointer->gc->refcount = 1;
+
+        Core::call('zend_hash_destroy', $this->pointer);
+
+        // Drop the block from z-engine's tracked registry before the memory goes away:
+        // a stale entry would make isTrackedBlock() lie about a recycled address and could
+        // turn a later untrackAndFree() into a double free
+        Core::untrack($this->pointer);
+        Core::persistentFree($this->pointer);
+    }
+
+    /**
      * Returns arData pointing right past the shared sentinel, as HT_SET_DATA_ADDR does
      *
      * @see zend_types.h:HT_SET_DATA_ADDR/HT_HASH_SIZE - for HT_MIN_MASK the hash part

--- a/tests/CoreMemoryTest.php
+++ b/tests/CoreMemoryTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the low-level allocation primitives of Core: the tracked-block registry and the
+ * raw persistent free() that releases malloc-backed blocks after their allocating request
+ * is long gone (see docs/long-running.md).
+ */
+final class CoreMemoryTest extends TestCase
+{
+    public function testTrackedPersistentBlockIsRecognizedAndUntrackable(): void
+    {
+        $block   = Core::trackedNew('char[128]', true);
+        $pointer = Core::cast('char *', $block);
+
+        $this->assertTrue(Core::isTrackedBlock($pointer));
+
+        Core::untrack($pointer);
+        $this->assertFalse(Core::isTrackedBlock($pointer), 'untrack() must drop the bookkeeping only');
+
+        // Ownership was handed over by untrack(), so the block is ours to free by hand
+        Core::persistentFree($pointer);
+    }
+
+    public function testPersistentFreeReleasesMallocBackedBlocks(): void
+    {
+        $residentKiloBytes = static function (): int {
+            foreach (file('/proc/self/status') ?: [] as $line) {
+                if (str_starts_with($line, 'VmRSS:')) {
+                    return (int) filter_var($line, FILTER_SANITIZE_NUMBER_INT);
+                }
+            }
+
+            return 0;
+        };
+
+        if ($residentKiloBytes() === 0) {
+            self::markTestSkipped('VmRSS is not readable on this platform');
+        }
+
+        $churn = static function (int $cycles): void {
+            for ($cycle = 0; $cycle < $cycles; $cycle++) {
+                // 256 KiB per cycle: not freeing this is visible in RSS within a few cycles
+                $block   = Core::trackedNew('char[262144]', true);
+                $pointer = Core::cast('char *', $block);
+                Core::memcpy($pointer, str_repeat('z', 4096), 4096);
+
+                Core::untrack($pointer);
+                Core::persistentFree($pointer);
+            }
+        };
+
+        $churn(16);
+        $baseline = $residentKiloBytes();
+        $churn(256);
+
+        $this->assertLessThan(
+            2_048,
+            $residentKiloBytes() - $baseline,
+            'persistentFree() did not return 64 MiB of malloc traffic to the allocator',
+        );
+    }
+
+    public function testPersistentFreeIsOrthogonalToTheTrackedRegistry(): void
+    {
+        // The registry is a PHP static and dies with its request; persistentFree() is the
+        // cross-request path and therefore deliberately does not consult (or update) it
+        $block   = Core::trackedNew('char[64]', true);
+        $pointer = Core::cast('char *', $block);
+
+        Core::persistentFree($pointer);
+
+        $this->assertTrue(
+            Core::isTrackedBlock($pointer),
+            'persistentFree() must leave the tracked-block registry untouched',
+        );
+
+        // ...which is exactly why a caller freeing a same-request block must untrack it:
+        // a stale entry would let untrackAndFree() free the very same address again
+        Core::untrack($pointer);
+        $this->assertFalse(Core::isTrackedBlock($pointer));
+    }
+}

--- a/tests/Memory/scenarios/persistent-hashtable-destroy.php
+++ b/tests/Memory/scenarios/persistent-hashtable-destroy.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Type\PersistentHashTable;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+Core::init();
+
+/**
+ * Dismantling side of the persistent-table lifecycle: create/fill/destroy in a loop must
+ * leave neither request memory (the leak gate below) nor malloc'd blocks (the RSS check)
+ * behind. Sealed and mutable, string-keyed and index-keyed, empty and filled tables all
+ * go through the same drop path.
+ */
+$residentKiloBytes = static function (): int {
+    foreach (file('/proc/self/status') ?: [] as $line) {
+        if (str_starts_with($line, 'VmRSS:')) {
+            return (int) filter_var($line, FILTER_SANITIZE_NUMBER_INT);
+        }
+    }
+
+    return 0;
+};
+
+$cycle = static function (bool $sealed): void {
+    $table = PersistentHashTable::create();
+
+    for ($index = 0; $index < 64; $index++) {
+        $value = new ReflectionValue($index);
+        $table->add('key-' . $index, $value);
+        $table->addIndex($index, $value);
+        $value->release();
+    }
+
+    // Deleting through both key flavours before the drop exercises the bucket paths too
+    $table->delete('key-7');
+    $table->deleteIndex(7);
+
+    if ($sealed) {
+        $table->markImmutable();
+
+        $entry = ReflectionValue::newEntry(ReflectionValue::IS_ARRAY, $table->getRawValue()[0]);
+        $entry->getNativeValue($native);
+        $entry->release();
+        if (($native['key-1'] ?? null) !== 1) {
+            throw new RuntimeException('Sealed persistent table did not materialize correctly');
+        }
+        unset($native);
+    }
+
+    $table->destroy();
+};
+
+// An empty table keeps the shared sentinel: destroy() must free the struct only
+PersistentHashTable::create()->destroy();
+
+for ($iteration = 0; $iteration < 100; $iteration++) {
+    $cycle($iteration % 2 === 0);
+}
+
+$baseline = $residentKiloBytes();
+for ($iteration = 0; $iteration < 500; $iteration++) {
+    $cycle($iteration % 2 === 0);
+}
+$growth = $residentKiloBytes() - $baseline;
+if ($baseline > 0 && $growth > 2048) {
+    throw new RuntimeException("Destroyed persistent tables retained {$growth} kB of process memory");
+}
+
+gc_collect_cycles();
+echo 'SCENARIO OK', PHP_EOL;

--- a/tests/Type/PersistentHashTableTest.php
+++ b/tests/Type/PersistentHashTableTest.php
@@ -103,6 +103,115 @@ class PersistentHashTableTest extends TestCase
         $this->assertSame(2, $table->getReferenceCount());
     }
 
+    public function testDeleteIndexRemovesTheBucket(): void
+    {
+        $table = PersistentHashTable::create();
+
+        foreach ([1, 2, 3] as $index) {
+            $value = new ReflectionValue($index * 10);
+            $table->addIndex($index, $value);
+            $value->release();
+        }
+
+        $table->deleteIndex(2);
+
+        $this->assertNull($table->findIndex(2));
+        $table->findIndex(1)->getNativeValue($first);
+        $table->findIndex(3)->getNativeValue($third);
+        $this->assertSame(10, $first);
+        $this->assertSame(30, $third);
+
+        // Deleting a key that is not there is a failure, not a silent no-op
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/index 2/');
+        $table->deleteIndex(2);
+    }
+
+    public function testDestroyReleasesAnUninitializedTable(): void
+    {
+        // An empty table still points at the shared uninitialized-bucket sentinel, which
+        // zend_hash_destroy() must NOT free - only the struct block goes away here. The
+        // sentinel is shared process-wide, so the next table minted after the drop proves
+        // it survived (freeing it would have taken every other persistent table with it)
+        PersistentHashTable::create()->destroy();
+
+        $survivor = PersistentHashTable::create();
+        $value    = new ReflectionValue('still alive');
+        $survivor->add('probe', $value);
+        $value->release();
+
+        $survivor->find('probe')->getNativeValue($native);
+        $this->assertSame('still alive', $native);
+
+        $survivor->destroy();
+    }
+
+    public function testDestroyReleasesFilledAndSealedTables(): void
+    {
+        $handles = 0;
+        foreach ([false, true] as $sealed) {
+            $table = PersistentHashTable::create();
+
+            $value = new ReflectionValue(1);
+            $table->add('interned-key', $value);
+            $table->addIndex(42, $value);
+            $value->release();
+
+            if ($sealed) {
+                // Sealed tables sit at refcount 2; destroy() re-baselines it for the engine
+                $table->markImmutable();
+            }
+            $table->destroy();
+            $handles++;
+        }
+
+        $this->assertSame(2, $handles, 'Both the mutable and the sealed table were destroyed');
+    }
+
+    public function testDestroyReturnsProcessMemoryToTheAllocator(): void
+    {
+        $residentKiloBytes = static function (): int {
+            foreach (file('/proc/self/status') ?: [] as $line) {
+                if (str_starts_with($line, 'VmRSS:')) {
+                    return (int) filter_var($line, FILTER_SANITIZE_NUMBER_INT);
+                }
+            }
+
+            return 0;
+        };
+
+        if ($residentKiloBytes() === 0) {
+            self::markTestSkipped('VmRSS is not readable on this platform');
+        }
+
+        $churn = static function (int $cycles): void {
+            for ($cycle = 0; $cycle < $cycles; $cycle++) {
+                $table = PersistentHashTable::create();
+                for ($index = 0; $index < 64; $index++) {
+                    $value = new ReflectionValue($index);
+                    $table->addIndex($index, $value);
+                    $value->release();
+                }
+                $table->destroy();
+            }
+        };
+
+        // Warm up first: the very first cycles also grow the interned-string table and
+        // the request heap, which has nothing to do with the tables being churned
+        $churn(200);
+        $baseline = $residentKiloBytes();
+
+        // 1000 tables x (struct + a 64-element persistent data block) is several megabytes
+        // of malloc traffic - if destroy() did not free it, RSS would climb accordingly
+        $churn(1_000);
+
+        $this->assertLessThan(
+            2_048,
+            $residentKiloBytes() - $baseline,
+            'Destroyed persistent tables did not return their memory to the allocator',
+        );
+    }
+
     public function testStringKeysAreStoredAsPersistentInterned(): void
     {
         $table = PersistentHashTable::create();

--- a/tools/generator/symbols.php
+++ b/tools/generator/symbols.php
@@ -77,10 +77,12 @@ return [
     'functions' => [
         // Hash API
         'zend_hash_del',
+        'zend_hash_index_del',
         'zend_hash_find',
         'zend_hash_add_or_update',
         'zend_hash_index_add_or_update',
         'zend_hash_index_find',
+        'zend_hash_destroy',
         // Opcode API
         'zend_set_user_opcode_handler',
         'zend_get_user_opcode_handler',
@@ -125,6 +127,11 @@ return [
         'rc_dtor_func',
         'zend_string_concat2',
         'zend_string_hash_func',
+        // libc free(): the ONLY way to release a malloc-backed block whose allocating
+        // request is already over (FFI::free needs the original owning CData, which is a
+        // PHP static and therefore request-scoped). Used by Core::persistentFree for
+        // persistent blocks minted by z-engine or by the engine's pemalloc(..., 1).
+        'free',
     ],
 
     'variables' => [


### PR DESCRIPTION
Primitives needed by lisachenko/php-shared-data-extension#4 (`drop()` with memory reclamation): until now every persistent structure was immortal by design; this adds the owner-side teardown path so persistent registries become droppable.

## What's added

- **`Core::persistentFree(CData $pointer)`** — raw libc `free()` for provably malloc-backed blocks (persistent FFI allocations, engine `pemalloc(…, 1)` blocks). This is the cross-request companion to `untrackAndFree()`: the tracked-block registry is a per-request PHP static, so blocks persisted by an earlier request must be freed raw. The doc block spells out the ownership contract; a test asserts the two stay orthogonal.
- **`HashTable::deleteIndex(int)`** — mirrors `delete()` via `zend_hash_index_del`.
- **`PersistentHashTable::destroy()`** — the counterpart of `create()`: re-baselines the refcount (sealed tables sit at the immutable refcount of 2 and the engine debug-asserts ≤ 1), `zend_hash_destroy` (arData goes back through the persistent allocator thanks to `GC_PERSISTENT`; the shared uninitialized-bucket sentinel is skipped), then untrack + free of the struct. Payloads stay with their owner (`pDestructor` is NULL by construction).
- **Generator manifest**: `zend_hash_index_del`, `zend_hash_destroy`, and libc `free` (in the AST via `php.h` → stdlib.h). `include/8.4/linux-x64-nts/engine.h` regenerated — the diff is exactly the three added extern declarations; `constants.php`/`layouts.json`/`probe.c` are byte-identical.
- Docs: `docs/long-running.md` gains a "Dismantling persistent data (cross-request free)" section; the persistent-hashtable ownership row no longer claims tables are unfreeable.

Header regeneration note: the sandbox proxy blocks the Docker apt path, so the headers were regenerated on the host per the AGENTS.md host-recipe — with the mandatory pre-check that regenerating the *committed* manifest reproduces the committed artifacts byte-identically (it did), and the generator's FFI validation passing (33 struct layouts match the C compiler). The `gen-headers` CI job independently verifies freshness.

## Validation

- phpunit: 254 tests / 3137 assertions green (was 247): `deleteIndex` round-trip + failure path, destroy on filled and sealed tables, empty-table sentinel survival, `persistentFree` churn (64 MiB) under a VmRSS gate, tracked-registry orthogonality.
- New debug-build leak-gate scenario `tests/Memory/scenarios/persistent-hashtable-destroy.php` (create/fill/delete/seal/destroy × 600).
- phpstan baseline updated for the new test files (local phar patch-version disagrees with the pinned CI one on the *clean* tree as well; zero findings in touched files — CI is authoritative).

Merge order: this PR first, then lisachenko/php-shared-data-extension's v3 PR that consumes these primitives (its composer.json temporarily points at this branch and will be reverted to `dev-master` once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qW4SGxVu3CBj3upzPqDwG

---
_Generated by [Claude Code](https://claude.ai/code/session_012qW4SGxVu3CBj3upzPqDwG)_