### PR TITLE
docs: add userland-php-generics to the "See it in action" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ These libraries are built entirely on Z-Engine and make good, real-world reading
 
 - **[lisachenko/immutable-object](https://github.com/lisachenko/immutable-object)** — mark a class immutable with a single interface; property writes outside the constructor throw
 - **[lisachenko/native-php-matrix](https://github.com/lisachenko/native-php-matrix)** — a `Matrix` type with fully overloaded arithmetic operators
+- **[lisachenko/userland-php-generics](https://github.com/lisachenko/userland-php-generics)** — reified generics: `Box::of('int')` monomorphizes a template into a real class entry whose `int` the engine enforces, and measures what that costs
 
 ## Contributing
 


### PR DESCRIPTION
One line in the README, requested by [lisachenko/userland-php-generics#7](https://github.com/lisachenko/userland-php-generics/issues/7).

`lisachenko/userland-php-generics` is the third library built entirely on Z-Engine and the one that exercises `ClassSpecializer` hardest: a template class is monomorphized into a real class entry whose substituted types the engine itself enforces, with the memory cost of doing so measured rather than assumed.

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ARbZTyQNYNvC7UxxnVJdR)_