### PR TITLE
fix: make Core::pointerAtAddress allocation-free (leaked ~116 B per call)

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -488,23 +488,27 @@ class Core
     /**
      * Materializes a typed pointer from a numeric address (the inverse of addressOf())
      *
-     * The address is written through an integer view of a fresh pointer slot and the
-     * typed pointer value is read back. This is the explicit form of C pointer
-     * arithmetic (base address plus a signed byte offset), which FFI otherwise only
-     * offers through CData operator overloads.
+     * FFI::cast() reinterprets a plain integer as a pointer value, which yields the
+     * typed pointer without allocating anything at all - the result is an unowned view
+     * that carries the address and nothing else.
+     *
+     * It must stay allocation-free: this is the primitive behind every "walk to that
+     * engine address" in the framework (hashtable construction alone calls it once per
+     * table), so an owned buffer per call would be a leak with no upper bound. The
+     * previous implementation wrote the address through an integer view of a fresh
+     * `{$type}[1]` slot and returned `$slot[0]`; because that element view pins its
+     * owning slot for as long as it lives, every call permanently retained the slot
+     * (~116 bytes) - the same FFI ownership trap documented on cast() above.
+     *
+     * The result needs no instanceof narrowing anymore: reading `$slot[0]` off a CData
+     * array yielded an untyped value, while cast() is declared to return CData.
      *
      * @param string $type    Pointer type of the result (eg "zend_arg_info *")
      * @param int    $address Numeric address the pointer should point at
      */
     public static function pointerAtAddress(string $type, int $address): CData
     {
-        $slot           = self::new("{$type}[1]");
-        $addressView    = self::cast('uintptr_t *', $slot);
-        $addressView[0] = $address;
-        $pointer        = $slot[0];
-        assert($pointer instanceof CData);
-
-        return $pointer;
+        return self::$engine->cast($type, $address);
     }
 
     /**

--- a/tests/CoreMemoryTest.php
+++ b/tests/CoreMemoryTest.php
@@ -94,4 +94,71 @@ final class CoreMemoryTest extends TestCase
         Core::untrack($pointer);
         $this->assertFalse(Core::isTrackedBlock($pointer));
     }
+
+    public function testPointerAtAddressTargetsTheGivenAddress(): void
+    {
+        $block   = Core::trackedNew('char[64]', true);
+        $pointer = Core::cast('char *', $block);
+        $address = Core::addressOf($pointer);
+
+        $materialized = Core::pointerAtAddress('char *', $address);
+
+        $this->assertSame(
+            $address,
+            Core::addressOf($materialized),
+            'pointerAtAddress() must be the exact inverse of addressOf()',
+        );
+
+        Core::untrack($pointer);
+        Core::persistentFree($pointer);
+    }
+
+    /**
+     * pointerAtAddress() is the primitive behind every walk to a raw engine address (a
+     * hashtable construction alone calls it once per table), so it has to be free of any
+     * per-call allocation. It used to write the address through an integer view of a
+     * fresh `{$type}[1]` slot and return `$slot[0]`; that element view pins its owning
+     * slot for as long as it lives, so every single call retained ~116 bytes for the rest
+     * of the request - about 5.8 MB over the loop below.
+     */
+    public function testPointerAtAddressDoesNotAllocatePerCall(): void
+    {
+        $residentKiloBytes = static function (): int {
+            foreach (file('/proc/self/status') ?: [] as $line) {
+                if (str_starts_with($line, 'VmRSS:')) {
+                    return (int) filter_var($line, FILTER_SANITIZE_NUMBER_INT);
+                }
+            }
+
+            return 0;
+        };
+
+        if ($residentKiloBytes() === 0) {
+            self::markTestSkipped('VmRSS is not readable on this platform');
+        }
+
+        $block   = Core::trackedNew('char[64]', true);
+        $address = Core::addressOf(Core::cast('char *', $block));
+
+        // Warm up so lazily built FFI state is not counted as growth
+        for ($cycle = 0; $cycle < 1_000; $cycle++) {
+            Core::pointerAtAddress('char *', $address);
+        }
+        $baseline = $residentKiloBytes();
+
+        for ($cycle = 0; $cycle < 50_000; $cycle++) {
+            Core::pointerAtAddress('char *', $address);
+        }
+
+        // The leaking implementation grew ~5.5 MB here; anything under a megabyte means
+        // the calls are not retaining a buffer each
+        $this->assertLessThan(
+            1_024,
+            $residentKiloBytes() - $baseline,
+            'pointerAtAddress() retained memory per call',
+        );
+
+        Core::untrack(Core::cast('char *', $block));
+        Core::persistentFree(Core::cast('char *', $block));
+    }
 }


### PR DESCRIPTION
Fixes a process-lifetime memory leak in `Core::pointerAtAddress()`: it minted an owned `T*[1]` FFI slot on every call and returned `$slot[0]` — a view that pins the owning slot forever, so ~116 B leaked per call for **every** caller. Introduced in `a56d59d` when `HashTable::uninitializedBucketData()` switched to this primitive, which made every hashtable construction leak.

**Fix**: `FFI::cast()` reinterprets a plain integer as a pointer value with no backing buffer, so the method collapses to a single allocation-free cast. The `assert($pointer instanceof CData)` is gone because the guarantee is now static (`cast()` returns `CData`; PHPStan level max rejects the redundant runtime check).

**Regression tests** (`tests/CoreMemoryTest.php`): an `addressOf()` round-trip, and a 50k-call loop asserting RSS growth stays under 1 MB — verified to fail (+5.4 MB) with the fix reverted.

**Measured, PHP 8.4.19, 50 000 calls**: request memory +5 832 192 B → **+0 B**; RSS +5 556 kB → **+0 kB**.

**Verification on this branch**: full phpunit 396/396, `--group opcache --fail-on-skipped` 26/26, `--group internal --process-isolation` 138/138, PHPStan clean, cs clean.

**Downstream proof** (lisachenko/php-shared-data-extension#13, which surfaced this): with this fix overlaid on tag 8.4.0, its failing "Reclaiming soak" goes from **+9 211 080 B FAIL** to **+32 048 B PASS** (budget 65 536), resident 3.73 kB/cycle (budget 6 kB).

**Release note**: master (8.5) has the same bug via the cascade lineage — the `8.4 → master` merge-up will carry this fix. A `8.4.1` tag after merge lets the `~8.4.0`-pinned dependents pick it up.

Note: branch `8.4` was auto-deleted when cascade PR #133 merged ("automatically delete head branches" acted on the PR head); it has been restored at its previous SHA. Consider excluding version branches from auto-delete, or the next cascade merge will delete it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRDZ2XsoVuB5uG4qXKL3ny

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRDZ2XsoVuB5uG4qXKL3ny)_