### PR TITLE
ci: cache the docker image layers with actions/cache (backport to 8.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
     # The segfault-prone destructive tests run only against a --enable-debug
     # PHP build, where corruption surfaces as assertion failures. There is no
     # official debug PHP image, so we build one here from the official image's
-    # own source with a plain `docker build` (the daemon's built-in BuildKit -
-    # no buildx setup, no moby/buildkit pull, fewer flaky Docker Hub round trips)
-    # and run the tests in it.
+    # own source (a full PHP compile) and run the tests in it. The build goes
+    # through buildx so its layers can be cached across runs with actions/cache
+    # - a warm cache turns the multi-minute compile into a layer restore.
     strategy:
       fail-fast: false
       matrix:
@@ -138,13 +138,35 @@ jobs:
       - name: Install dependencies
         uses: ramsey/composer-install@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Restore the debug image layer cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: docker-debug-${{ matrix.ts }}-${{ env.PHP_MINOR }}-${{ hashFiles('tools/docker/php-debug.Dockerfile') }}
+          restore-keys: |
+            docker-debug-${{ matrix.ts }}-${{ env.PHP_MINOR }}-
+
       - name: Build the debug PHP image
         run: |
-          docker build \
+          mkdir -p /tmp/.buildx-cache
+          docker buildx build \
             -f tools/docker/php-debug.Dockerfile \
             --build-arg "PHP_VERSION=${PHP_MINOR}" \
             --build-arg "PHP_TS=${{ matrix.ts }}" \
+            --cache-from "type=local,src=/tmp/.buildx-cache" \
+            --cache-to "type=local,dest=/tmp/.buildx-cache-new,mode=max" \
+            --load \
             -t z-engine-php:debug .
+
+      # Rotate instead of appending: a reused local cache dir accumulates stale
+      # layers without bound, so each run saves only the layers it actually used
+      - name: Rotate the layer cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Run internal group with process isolation
         run: |
@@ -167,8 +189,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+      # Caches the generator image's toolchain layers (apt/clang/ext-ffi); the
+      # emit stage itself always re-runs - it is the step that produces the
+      # artifacts being drift-checked. generate.php rotates per-target subdirs.
+      - name: Restore the generator image layer cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-gen-cache
+          key: docker-gen-${{ env.PHP_MINOR }}-${{ hashFiles('tools/generator/Dockerfile') }}
+          restore-keys: |
+            docker-gen-${{ env.PHP_MINOR }}-
       - name: Regenerate engine definitions
         run: composer gen-headers
+        env:
+          Z_ENGINE_BUILDX_CACHE_DIR: /tmp/.buildx-gen-cache
       - name: Fail if the committed artifacts are stale
         run: |
           if ! git diff --exit-code -- include/; then

--- a/tools/generator/generate.php
+++ b/tools/generator/generate.php
@@ -85,8 +85,8 @@ foreach ($targets as $target) {
     $baseImage = $mirror . ($target['ts'] === 'zts' ? "php:{$target['php']}-zts" : "php:{$target['php']}-cli");
     $outputDir = "{$repositoryRoot}/include/{$target['php']}/linux-{$arch}-{$target['ts']}";
 
-    $cacheArguments  = '';
-    $targetCacheDir  = '';
+    $cacheArguments = '';
+    $targetCacheDir = '';
     if ($layerCacheDir !== '') {
         $targetCacheDir = "{$layerCacheDir}/{$target['php']}-{$target['ts']}";
         if (is_dir($targetCacheDir)) {

--- a/tools/generator/generate.php
+++ b/tools/generator/generate.php
@@ -74,13 +74,31 @@ if ($usesProxy && is_string($caBundle) && $caBundle !== '' && is_readable($caBun
     $caBundleCopied = true;
 }
 
+// Optional buildx layer-cache directory (e.g. wrapped in actions/cache by CI):
+// per-target subdirectories, rotated after each successful build so the local
+// cache never accumulates stale layers across runs.
+$layerCacheDir = getenv('Z_ENGINE_BUILDX_CACHE_DIR');
+$layerCacheDir = is_string($layerCacheDir) && $layerCacheDir !== '' ? rtrim($layerCacheDir, '/') : '';
+
 $failures = 0;
 foreach ($targets as $target) {
     $baseImage = $mirror . ($target['ts'] === 'zts' ? "php:{$target['php']}-zts" : "php:{$target['php']}-cli");
     $outputDir = "{$repositoryRoot}/include/{$target['php']}/linux-{$arch}-{$target['ts']}";
-    $command   = 'docker buildx build --progress=plain'
+
+    $cacheArguments  = '';
+    $targetCacheDir  = '';
+    if ($layerCacheDir !== '') {
+        $targetCacheDir = "{$layerCacheDir}/{$target['php']}-{$target['ts']}";
+        if (is_dir($targetCacheDir)) {
+            $cacheArguments .= ' --cache-from ' . escapeshellarg("type=local,src={$targetCacheDir}");
+        }
+        $cacheArguments .= ' --cache-to ' . escapeshellarg("type=local,dest={$targetCacheDir}-new,mode=max");
+    }
+
+    $command = 'docker buildx build --progress=plain'
         . ' --build-arg ' . escapeshellarg("BASE_IMAGE={$baseImage}")
         . $proxyArguments
+        . $cacheArguments
         . ' --output ' . escapeshellarg("type=local,dest={$outputDir}")
         . ' ' . escapeshellarg($repositoryRoot . '/tools/generator');
 
@@ -90,6 +108,10 @@ foreach ($targets as $target) {
         fwrite(STDERR, "==> FAILED: {$target['php']} {$target['ts']} (exit {$exitCode})\n");
         $failures++;
         continue;
+    }
+    if ($targetCacheDir !== '' && is_dir("{$targetCacheDir}-new")) {
+        passthru('rm -rf ' . escapeshellarg($targetCacheDir));
+        passthru('mv ' . escapeshellarg("{$targetCacheDir}-new") . ' ' . escapeshellarg($targetCacheDir));
     }
     echo "==> OK: {$outputDir}\n";
 }


### PR DESCRIPTION
Backport of the CI docker-layer caching that landed on `master` via #145, so the `8.4` branch gets the same speedup and the two branches' `ci.yml`/`generate.php` stay in sync for future cascade merges (clean cherry-pick of the two commits, with this branch's `8.4` generator targets untouched).

- **`tests-internal-debug`** (both NTS and ZTS legs): the debug image now builds through buildx with `--cache-from/--cache-to type=local` wrapped in first-party `actions/cache`, keyed on the Dockerfile hash + PHP minor + TS mode, with a rotation step that keeps the cache bounded. A warm cache turns the multi-minute PHP source compile into a layer restore.
- **`header-drift`**: `generate.php` gains an opt-in `Z_ENGINE_BUILDX_CACHE_DIR` passthrough (per-target subdirectories, rotated in the script); the job wraps `composer gen-headers` in `actions/cache` so the generator's apt/clang/ext-ffi layers restore from cache while the emit stage — which produces the drift-checked artifacts — always re-runs.

First run on this PR populates the caches (timings unchanged); subsequent runs restore. CI itself is the verification here — all seven checks should stay green with the debug jobs getting faster once warm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mWPLkDoKWoDDS9W9LSaDa

---
_Generated by [Claude Code](https://claude.ai/code/session_019mWPLkDoKWoDDS9W9LSaDa)_