### PR TITLE
fix(module): cast module globals through the pointer type in getGlobals()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -865,12 +865,6 @@ parameters:
 			path: src/EngineExtension/AbstractModule.php
 
 		-
-			message: '#^Parameter \#1 \$type of static method ZEngine\\Core\:\:cast\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/EngineExtension/AbstractModule.php
-
-		-
 			message: '#^Parameter \#1 \$variable of static method ZEngine\\Core\:\:addr\(\) expects FFI\\CData, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -215,7 +215,16 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
     }
 
     /**
-     * This getter extends general logic with automatic casting global memory to required type
+     * This getter extends general logic with automatic casting of the global memory pointer
+     * to the declared globals type
+     *
+     * Returns a `<globalType> *` view of the globals block (never a value copy): a pointer
+     * cast is size-safe for every globals type, while a value-type cast reinterprets the
+     * pointer variable itself - FFI only auto-dereferences a bare `void *` source and
+     * throws "attempt to cast to larger type" for anything else wider than a pointer
+     * (issue #109). FFI supports `->field` access directly on a pointer-to-struct, and
+     * array-typed globals (eg `unsigned int[10]`) decay to an element pointer, exactly
+     * like a C array expression, so indexing keeps working.
      *
      * @inheritDoc
      */
@@ -223,10 +232,31 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
     {
         $rawPointer = parent::getGlobals();
         if ($rawPointer !== null) {
-            $rawPointer = Core::cast(static::globalType(), $rawPointer);
+            $globalType = static::globalType();
+            // The engine only allocates a globals block when a type was declared
+            \assert($globalType !== null);
+            $rawPointer = Core::cast(self::pointerTypeFor($globalType), $rawPointer);
         }
 
         return $rawPointer;
+    }
+
+    /**
+     * Builds the pointer declaration for the given globals type (C array-to-pointer decay)
+     *
+     * `zend_counter_globals` => `zend_counter_globals *`, `unsigned int[10]` =>
+     * `unsigned int *`, `int[4][5]` => `int(*)[5]` (a pointer to the first row, as in C).
+     */
+    private static function pointerTypeFor(string $globalType): string
+    {
+        $matched = preg_match('/^(?<element>[^\[\]]+?)\s*\[\w*\](?<rows>(?:\[\w+\])*)$/', $globalType, $match);
+        if ($matched !== 1) {
+            return $globalType . ' *';
+        }
+
+        return $match['rows'] === ''
+            ? $match['element'] . ' *'
+            : $match['element'] . '(*)' . $match['rows'];
     }
 
     /**

--- a/src/EngineExtension/ZEngineModule.php
+++ b/src/EngineExtension/ZEngineModule.php
@@ -17,7 +17,6 @@ use FFI\CData;
 use ZEngine\Core;
 use ZEngine\Memory\PersistentHeap;
 use ZEngine\Memory\PersistentHeapException;
-use ZEngine\Reflection\ReflectionExtension;
 use ZEngine\Reflection\ReflectionValue;
 use ZEngine\Type\PersistentHashTable;
 
@@ -167,7 +166,11 @@ final class ZEngineModule extends AbstractModule implements ModuleLifecycleInter
      */
     public function onHeapDestroyed(): void
     {
-        $anchorTyped = $this->anchorSlot()->u1;
+        $anchor = $this->getGlobals();
+        if ($anchor === null) {
+            throw new PersistentHeapException('The zengine module has no globals block');
+        }
+        $anchorTyped = $anchor->u1;
         assert($anchorTyped instanceof CData);
         $anchorTyped->type_info = ReflectionValue::IS_UNDEF;
 
@@ -175,11 +178,15 @@ final class ZEngineModule extends AbstractModule implements ModuleLifecycleInter
     }
 
     /**
-     * Recovers the heap registry from the anchor slot, minting it on first use
+     * Recovers the heap registry from the anchor slot (the zval-typed module globals),
+     * minting it on first use
      */
     private function recoverHeapRegistry(): PersistentHashTable
     {
-        $anchor      = $this->anchorSlot();
+        $anchor = $this->getGlobals();
+        if ($anchor === null) {
+            throw new PersistentHeapException('The zengine module has no globals block');
+        }
         $anchorTyped = $anchor->u1;
         assert($anchorTyped instanceof CData);
         $anchorValue = $anchor->value;
@@ -204,26 +211,5 @@ final class ZEngineModule extends AbstractModule implements ModuleLifecycleInter
         $anchorTyped->type_info = ReflectionValue::IS_PTR;
 
         return $registry;
-    }
-
-    /**
-     * Returns the anchor slot (zval*) inside the persistent module globals
-     *
-     * Bypasses AbstractModule::getGlobals(), whose cast targets the globals STRUCT type;
-     * the anchor is addressed as a zval pointer instead.
-     *
-     * @todo AbstractModule::getGlobals() cannot cast a raw globals pointer to a
-     *       zval-sized type ("attempt to cast to larger type" - FFI casts reinterpret
-     *       the 8-byte pointer variable, they do not dereference); once the base class
-     *       casts through a pointer type, this bypass can delegate to it.
-     */
-    private function anchorSlot(): CData
-    {
-        $rawGlobals = ReflectionExtension::getGlobals();
-        if ($rawGlobals === null) {
-            throw new PersistentHeapException('The zengine module has no globals block');
-        }
-
-        return Core::cast('zval *', $rawGlobals);
     }
 }

--- a/tests/EngineExtension/AbstractModuleTest.php
+++ b/tests/EngineExtension/AbstractModuleTest.php
@@ -13,9 +13,13 @@ declare(strict_types=1);
 
 namespace ZEngine\EngineExtension;
 
+use FFI\CData;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use ZEngine\Reflection\ReflectionValue;
+use ZEngine\Stub\ArrayGlobalsModule;
+use ZEngine\Stub\GlobalsModule;
 use ZEngine\Stub\LifecycleModule;
 use ZEngine\Stub\ThrowingLifecycleModule;
 
@@ -99,6 +103,56 @@ class AbstractModuleTest extends TestCase
         $allWarnings = implode("\n", $capturedWarnings);
         $this->assertStringContainsString('module_startup_func failed: MINIT boom', $allWarnings);
         $this->assertStringContainsString('requestStartup failed: RINIT boom', $allWarnings);
+    }
+
+    /**
+     * getGlobals() must cast the raw globals pointer through the POINTER type - size-safe
+     * for every globals type, unlike the former value-type cast (issue #109: "attempt to
+     * cast to larger type")
+     */
+    #[RunInSeparateProcess]
+    public function testGetGlobalsReturnsTypedPointerForZvalGlobals(): void
+    {
+        $module = new GlobalsModule();
+        $module->register();
+        $module->startup();
+
+        $globals = $module->getGlobals();
+        $this->assertNotNull($globals);
+        $slotType = $globals->u1;
+        $this->assertInstanceOf(CData::class, $slotType);
+        if (!\ZEND_THREAD_SAFE) {
+            // The NTS globals block is zero-initialized at registration (IS_UNDEF): the
+            // contract the zengine heap anchor relies on
+            $this->assertSame(ReflectionValue::IS_UNDEF, $slotType->type_info);
+        }
+
+        // Write through the typed pointer and read the value back through a fresh view
+        $slotType->type_info = ReflectionValue::IS_TRUE;
+        $freshView           = $module->getGlobals();
+        $this->assertNotNull($freshView);
+        $freshSlotType = $freshView->u1;
+        $this->assertInstanceOf(CData::class, $freshSlotType);
+        $this->assertSame(ReflectionValue::IS_TRUE, $freshSlotType->type_info);
+    }
+
+    /**
+     * Array-typed globals (the README counter example) decay to an element pointer,
+     * exactly like a C array expression, so indexing keeps working (issue #109)
+     */
+    #[RunInSeparateProcess]
+    public function testGetGlobalsDecaysArrayTypedGlobalsToElementPointer(): void
+    {
+        $module = new ArrayGlobalsModule();
+        $module->register();
+        $module->startup();
+
+        $globals = $module->getGlobals();
+        $this->assertNotNull($globals);
+        $globals[3] = 42;
+        $freshView  = $module->getGlobals();
+        $this->assertNotNull($freshView);
+        $this->assertSame(42, $freshView[3]);
     }
 
     #[RunInSeparateProcess]

--- a/tests/Stub/ArrayGlobalsModule.php
+++ b/tests/Stub/ArrayGlobalsModule.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use ZEngine\EngineExtension\AbstractModule;
+
+/**
+ * Test module (engine name "array_globals") declaring array-typed globals
+ *
+ * Exercises the C array-to-pointer decay in AbstractModule::getGlobals() (issue #109):
+ * the README documents exactly this globals shape for a per-process counter module.
+ */
+final class ArrayGlobalsModule extends AbstractModule
+{
+    public static function targetDebug(): bool
+    {
+        return ZEND_DEBUG_BUILD;
+    }
+
+    public static function targetPersistent(): bool
+    {
+        return false;
+    }
+
+    public static function targetThreadSafe(): bool
+    {
+        return ZEND_THREAD_SAFE;
+    }
+
+    public static function globalType(): string
+    {
+        return 'unsigned int[10]';
+    }
+}

--- a/tests/Stub/GlobalsModule.php
+++ b/tests/Stub/GlobalsModule.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Stub;
+
+use ZEngine\EngineExtension\AbstractModule;
+
+/**
+ * Test module (engine name "globals") declaring a zval-typed globals block
+ *
+ * Exercises AbstractModule::getGlobals() with a globals type larger than a pointer
+ * (issue #109: the base-class cast must go through the pointer type).
+ */
+final class GlobalsModule extends AbstractModule
+{
+    public static function targetDebug(): bool
+    {
+        return ZEND_DEBUG_BUILD;
+    }
+
+    public static function targetPersistent(): bool
+    {
+        return false;
+    }
+
+    public static function targetThreadSafe(): bool
+    {
+        return ZEND_THREAD_SAFE;
+    }
+
+    public static function globalType(): string
+    {
+        return 'zval';
+    }
+}


### PR DESCRIPTION
Fixes #109.

## What was broken

`AbstractModule::getGlobals()` cast the raw globals pointer to the **value** type declared by `globalType()`. FFI casts reinterpret the pointer variable itself — only a bare `void *` source is auto-dereferenced, any other source wider than a pointer throws `attempt to cast to larger type`. So the accessor's behavior depended on an FFI special case rather than on the declared globals type, and `ZEngineModule` (globals type `zval`) carried its own `anchorSlot()` bypass with a `@todo` pointing at this issue.

The old cast was also broken for the README's documented array example (`'unsigned int[10]'`) once turned into a pointer naively: `"unsigned int[10] *"` is not a valid C declarator.

## The fix

- `AbstractModule::getGlobals()` now casts through the **pointer** type (`<globalType> *`), which is size-safe for every globals type. `->field` access works directly on a pointer-to-struct, so struct-typed consumers keep natural field access.
- Array-typed globals get C array-to-pointer decay: `unsigned int[10]` → `unsigned int *` (indexing keeps working), `int[4][5]` → `int(*)[5]`.
- `ZEngineModule` reads its heap anchor through `getGlobals()` directly; the `anchorSlot()` bypass and its `@todo` are removed.
- The now-stale phpstan baseline entry for the nullable cast argument is removed (the null-impossibility is asserted at the call site).

## Verification

Two new regression tests in `AbstractModuleTest` (group `internal`, process-isolated), backed by new stubs `GlobalsModule` (`zval` globals — write/read `u1.type_info` through the typed pointer, plus the NTS zero-init contract the heap anchor relies on) and `ArrayGlobalsModule` (`unsigned int[10]` globals — element-pointer indexing round trip).

Ran locally on PHP 8.4.19 NTS: `composer test` (408 tests), `composer test:internal` (144 tests), `composer phpstan` (level max, clean), `composer cs:check` (clean).

One note for the record: on this build the *old* code did not actually throw for the NTS `zval` case, because the raw `globals_ptr` is `void *` and FFI auto-dereferences exactly that one source kind (verified empirically; a typed pointer source does throw). The pointer cast removes the dependence on that special case and gives every globals type — struct, scalar, `zval`, array — one uniform, size-safe access path, which is what the issue asked for.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xp5hRnFtHAANDW9aJU3nB

---
_Generated by [Claude Code](https://claude.ai/code/session_018xp5hRnFtHAANDW9aJU3nB)_