### PR TITLE
fix(core): make Core::init() idempotent per process

### DIFF
--- a/docs/long-running.md
+++ b/docs/long-running.md
@@ -74,6 +74,13 @@ structures (class entries, handler blocks) never carry a pointer into the next r
 freed trampolines. After shutdown, z-engine performs no engine writes at all — hooks are
 inactive during shutdown-phase object destructors, and installing a new hook throws.
 
+`Core::init()` is idempotent per process: a repeated call — eg re-booting z-engine after a
+manual `Core::shutdown()` inside one live worker process — reuses the process-wide FFI
+binding, so every CData minted before the re-boot (module entries, hook state, heap
+anchors) stays valid. Minting a second binding would free the first one's type data
+together with the old FFI object and leave those CData dangling by the time the exit
+handlers touch them.
+
 ### Runtime models
 
 - **Worker loops** (RoadRunner, Swoole, ReactPHP, FrankenPHP worker mode): the whole worker

--- a/src/Core.php
+++ b/src/Core.php
@@ -247,29 +247,40 @@ class Core
     private static bool $shutdownRegistered = false;
 
     /**
-     * Performs Z-engine core initialization
+     * Performs Z-engine core initialization (idempotent per process)
+     *
+     * A repeated call - eg a worker manager re-booting z-engine after Core::shutdown()
+     * inside one live process - reuses the process-wide FFI binding instead of minting a
+     * new one. Rebinding via a second FFI::cdef() frees the first binding's type data
+     * together with the old FFI object, which turns every CData minted against it
+     * (module entries, hooks, heap anchors) invalid by the time the exit handlers touch
+     * them (issue #108).
      */
     public static function init(): void
     {
         self::assertSupportedEnvironment();
 
-        try {
-            $engine = FFI::scope('ZEngine');
-        } catch (FFI\Exception $e) {
-            if (ini_get('ffi.enable') === 'preload' && PHP_SAPI !== 'cli') {
-                throw new RuntimeException('Preload mode requires that you call Core::preload before');
+        if (isset(self::$engine)) {
+            $engine = self::$engine;
+        } else {
+            try {
+                $engine = FFI::scope('ZEngine');
+            } catch (FFI\Exception $e) {
+                if (ini_get('ffi.enable') === 'preload' && PHP_SAPI !== 'cli') {
+                    throw new RuntimeException('Preload mode requires that you call Core::preload before');
+                }
+                // If not, then load definitions by hand
+                $definition = file_get_contents(self::resolveArtifact('engine.h'));
+                if ($definition === false) {
+                    throw new RuntimeException('Unable to read the engine definition file');
+                }
+                $engine = FFI::cdef($definition);
             }
-            // If not, then load definitions by hand
-            $definition = file_get_contents(self::resolveArtifact('engine.h'));
-            if ($definition === false) {
-                throw new RuntimeException('Unable to read the engine definition file');
-            }
-            $engine = FFI::cdef($definition);
-        }
-        self::$engine = $engine;
+            self::$engine = $engine;
 
-        if (getenv('ZENGINE_STRICT_LAYOUT_CHECK') === '1') {
-            self::verifyEngineLayouts($engine);
+            if (getenv('ZENGINE_STRICT_LAYOUT_CHECK') === '1') {
+                self::verifyEngineLayouts($engine);
+            }
         }
 
         if (\ZEND_THREAD_SAFE) {

--- a/tests/Memory/CoreReinitRequestCycleTest.php
+++ b/tests/Memory/CoreReinitRequestCycleTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Memory;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Re-boot simulation for the process-wide FFI binding (issue #108): a second Core::init()
+ * in one process must reuse the binding, so CData minted before the re-boot - module
+ * entries, the heap anchor - stays valid through the re-booted request and the exit-time
+ * shutdown chain.
+ *
+ * The scenario runs in a child process because it registers the persistent heap module in
+ * the engine module registry, which cannot be undone within a process. The same scenario
+ * file is picked up by the debug-build leak gate (MemoryLeakScenarioTest).
+ */
+class CoreReinitRequestCycleTest extends TestCase
+{
+    public function testBindingSurvivesAShutdownReinitCycle(): void
+    {
+        $command = [
+            PHP_BINARY,
+            '-d', 'ffi.enable=1',
+            '-d', 'zend.assertions=1',
+            '-d', 'assert.exception=1',
+            '-d', 'report_memleaks=1',
+            '-d', 'display_errors=on',
+            '-d', 'error_reporting=' . (E_ALL & ~E_DEPRECATED),
+            __DIR__ . '/scenarios/core-reinit-request-cycle.php',
+        ];
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        $this->assertIsResource($process, 'Unable to spawn the re-init child process');
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        $report = "STDOUT:\n{$stdout}\nSTDERR:\n{$stderr}";
+
+        $this->assertSame(0, $exitCode, "Re-init scenario exited with code {$exitCode}\n{$report}");
+
+        $expectedMarkers = [
+            'cdata-survives-double-init',
+            'put-in-request-a',
+            'inert-after-rshutdown',
+            'core-shutdown-simulated',
+            'reinit-done',
+            'module-entry-valid-after-reinit',
+            'graph-recovered-after-reinit',
+            'new-allocations-work-after-reinit',
+            'evicted-after-reinit',
+            'SCENARIO OK',
+        ];
+        $offset = 0;
+        foreach ($expectedMarkers as $marker) {
+            $position = strpos($stdout, $marker, $offset);
+            $this->assertNotFalse($position, "Marker '{$marker}' missing or out of order\n{$report}");
+            $offset = $position + strlen($marker);
+        }
+    }
+}

--- a/tests/Memory/scenarios/core-reinit-request-cycle.php
+++ b/tests/Memory/scenarios/core-reinit-request-cycle.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use FFI\CData;
+use ZEngine\Core;
+use ZEngine\EngineExtension\ExtensionManager;
+use ZEngine\EngineExtension\ZEngineModule;
+use ZEngine\Memory\HeapInertException;
+use ZEngine\Memory\PersistentHeap;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+/**
+ * Userland payload local to this fixture process
+ */
+class ReinitCyclePayload
+{
+    public int $answer = 0;
+}
+
+$expect = static function (bool $condition, string $marker): void {
+    if (!$condition) {
+        fwrite(STDERR, "FAILED: {$marker}\n");
+        exit(1);
+    }
+    echo $marker, PHP_EOL;
+};
+
+// ---------------------------------------------------------------------------------------
+// Core::init() is idempotent per process (issue #108): a repeated call must reuse the
+// process-wide FFI binding. Rebinding would free the first binding's type data, turning
+// every CData minted against it invalid.
+// ---------------------------------------------------------------------------------------
+Core::init();
+$probe = Core::new('zval');
+Core::init();
+$probeSlot = $probe->u1;
+assert($probeSlot instanceof CData);
+$expect($probeSlot->type_info === 0, 'cdata-survives-double-init');
+
+// ---------------------------------------------------------------------------------------
+// "Request A": boot the framework module (its entry CData belongs to the first binding)
+// and persist a payload behind the module-globals anchor.
+// ---------------------------------------------------------------------------------------
+$module = ExtensionManager::register(new ZEngineModule());
+$heap   = PersistentHeap::global();
+
+$payload         = new ReinitCyclePayload();
+$payload->answer = 42;
+$heap->put('reinit-key', $payload);
+$expect($heap->stats()['keys'] === 1, 'put-in-request-a');
+
+// ---------------------------------------------------------------------------------------
+// Full simulated request boundary: unlike the plain RSHUTDOWN/RINIT cycle exercised by
+// persistent-heap-request-cycle.php, this one also runs Core::shutdown() + Core::init(),
+// the way a worker manager re-boots z-engine inside one live process. Before the fix the
+// re-init minted a second FFI binding and the module entry (plus the exit-time
+// AbstractModule::deliverRequestShutdown delivery) touched freed first-binding state.
+// ---------------------------------------------------------------------------------------
+$module->requestShutdown();
+try {
+    $heap->get('reinit-key');
+    fwrite(STDERR, "FAILED: heap must be inert after request shutdown\n");
+    exit(1);
+} catch (HeapInertException) {
+    echo 'inert-after-rshutdown', PHP_EOL;
+}
+unset($heap);
+
+Core::shutdown();
+$expect(Core::isShutdown(), 'core-shutdown-simulated');
+
+Core::init();
+$expect(!Core::isShutdown(), 'reinit-done');
+
+// First-binding CData is still alive: the module entry stored in the persistent module
+// registry remains readable and the heap recovers from the module-globals anchor
+$expect($module->wasModuleStarted(), 'module-entry-valid-after-reinit');
+
+$module->requestStartup();
+$heapB     = PersistentHeap::global();
+$recovered = $heapB->get('reinit-key');
+$expect($recovered instanceof ReinitCyclePayload && $recovered->answer === 42, 'graph-recovered-after-reinit');
+
+// Fresh allocations against the reused binding keep working as well
+$fresh     = Core::new('zval');
+$freshSlot = $fresh->u1;
+assert($freshSlot instanceof CData);
+$expect($freshSlot->type_info === 0, 'new-allocations-work-after-reinit');
+
+unset($recovered);
+gc_collect_cycles();
+$heapB->remove('reinit-key');
+$expect($heapB->stats()['keys'] === 0, 'evicted-after-reinit');
+
+// The process exit below replays the REAL request-end ordering on the re-booted state:
+// Core::shutdown() first, then the deliverRequestShutdown delivery - both must find
+// valid CData (this very line crashing was the issue #108 symptom)
+echo 'SCENARIO OK', PHP_EOL;


### PR DESCRIPTION
Fixes #108. Replaces #150 (same commit, moved to a dedicated branch).

## What was broken

A second `Core::init()` in one process minted a fresh FFI binding via `FFI::cdef()` and reassigned `self::$engine`, dropping the only reference to the first binding. ext/ffi frees a cdef binding's type data with the FFI object, so every CData minted against the first binding — the module entry stored in the persistent module registry, hook state, the persistent-heap anchor — turned invalid (`FFI\Exception: Attempt to read field '...' of non C struct/union`). The exit-time `AbstractModule::deliverRequestShutdown` delivery then touched that freed state, exactly as described in the issue (reproduced before fixing: the fatal fires both on the first post-re-init engine access and again inside the shutdown chain at exit).

## The fix

Of the two directions the issue suggested, this takes the idempotent one: `Core::init()` now reuses the process-wide binding when one exists. Only the binding creation (and the strict layout verification, which is a property of the binding) is first-boot-only; environment assertions, executor/compiler wrapper creation, shutdown-handler arming and the `$isShutdown` reset still run on every call, so a worker manager can re-boot z-engine after a manual `Core::shutdown()` inside one live process and the framework comes back operational against the same binding.

`docs/long-running.md` documents the new per-process idempotency contract next to the shutdown invariant.

## Verification

New child-process scenario `tests/Memory/scenarios/core-reinit-request-cycle.php` (driven release-safe by `CoreReinitRequestCycleTest`, and picked up automatically by the debug-build leak gate `MemoryLeakScenarioTest`): boots the framework module, persists a graph, runs a full simulated request boundary (`requestShutdown` → `Core::shutdown()` → `Core::init()` → `requestStartup`), verifies the module entry and heap anchor are still valid, recovers the graph, and exits cleanly through the real shutdown-chain ordering. The scenario fails against the unfixed `Core::init()` (verified by stashing the fix) and passes with it.

Ran locally on PHP 8.4.19 NTS: `composer test` (409 tests), `composer test:internal` (145 tests), `composer phpstan` (level max, clean), `composer cs:check` (clean).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xp5hRnFtHAANDW9aJU3nB

---
_Generated by [Claude Code](https://claude.ai/code/session_018xp5hRnFtHAANDW9aJU3nB)_