### PR TITLE
fix(reflection): correct _IS_BOOL/_IS_NUMBER for PHP 8.1+ and add named cast-type enums

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3277,15 +3277,9 @@ parameters:
 			path: tests/Reflection/ReflectionClassTest.php
 
 		-
-			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertSame\(\) with false and true will always evaluate to false\.$#'
-			identifier: method.impossibleType
-			count: 1
-			path: tests/Reflection/ReflectionClassTest.php
-
-		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertTrue\(\) with true will always evaluate to true\.$#'
 			identifier: method.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: tests/Reflection/ReflectionClassTest.php
 
 		-

--- a/src/ClassExtension/Hook/CastObjectHook.php
+++ b/src/ClassExtension/Hook/CastObjectHook.php
@@ -69,6 +69,18 @@ class CastObjectHook extends AbstractHook
     }
 
     /**
+     * Returns the cast type as a named case, or null for an id unknown to this PHP line
+     *
+     * Prefer this over comparing getCastType() against numeric constants: the cast-only type ids
+     * have shifted between PHP minors before, and the enum is guarded against the generated
+     * engine ground truth.
+     */
+    public function getCastTypeEnum(): ?CastType
+    {
+        return CastType::tryFrom($this->type);
+    }
+
+    /**
      * Returns an object instance
      */
     public function getObject(): object

--- a/src/ClassExtension/Hook/CastType.php
+++ b/src/ClassExtension/Hook/CastType.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+/**
+ * Named view of the type ids the engine passes to a cast_object handler
+ *
+ * The backing values are the zval type ids from Zend/zend_types.h for the PHP minor this branch
+ * targets, and they are guarded against the generated ground truth by EngineConstantsTest. Prefer
+ * dispatching on these cases over raw ReflectionValue constants: the cast-only ids have moved
+ * between PHP minors before (PHP 8.1 inserted IS_NEVER = 17, shifting _IS_BOOL and _IS_NUMBER up
+ * by one), and a namesake constant with a stale value misroutes casts silently.
+ */
+enum CastType: int
+{
+    /** IS_LONG: explicit (int) casts and integer coercion */
+    case Long = 4;
+
+    /** IS_DOUBLE: explicit (float) casts and float coercion */
+    case Double = 5;
+
+    /** IS_STRING: explicit (string) casts, string interpolation and echo */
+    case String = 6;
+
+    /** IS_ARRAY: passed by extensions that invoke cast_object directly with an array target */
+    case Array = 7;
+
+    /** IS_OBJECT: passed by extensions that invoke cast_object directly with an object target */
+    case Object = 8;
+
+    /** _IS_BOOL: explicit (bool) casts and every boolean context (if, &&, !, ...) */
+    case Bool = 18;
+
+    /** _IS_NUMBER: numeric coercion where either int or float is acceptable */
+    case Number = 19;
+}

--- a/src/ClassExtension/Hook/GetPropertiesForHook.php
+++ b/src/ClassExtension/Hook/GetPropertiesForHook.php
@@ -78,6 +78,14 @@ class GetPropertiesForHook extends AbstractHook
     }
 
     /**
+     * Returns the purpose as a named case, or null for a value unknown to this PHP line
+     */
+    public function getPurposeEnum(): ?PropertyPurpose
+    {
+        return PropertyPurpose::tryFrom($this->purpose);
+    }
+
+    /**
      * Proceeds with default handler
      */
     public function proceed()

--- a/src/ClassExtension/Hook/PropertyPurpose.php
+++ b/src/ClassExtension/Hook/PropertyPurpose.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\ClassExtension\Hook;
+
+/**
+ * Named view of the zend_prop_purpose values the engine passes to a get_properties_for handler
+ *
+ * The backing values mirror the zend_prop_purpose enumeration in Zend/zend_object_handlers.h for
+ * the PHP minor this branch targets. They are not yet exported by the header generator manifest,
+ * so unlike CastType they carry no generated-ground-truth guard — the enumeration has been stable
+ * since PHP 7.4 introduced it, but verify against zend_object_handlers.h when bumping the branch
+ * to a new minor.
+ */
+enum PropertyPurpose: int
+{
+    /** ZEND_PROP_PURPOSE_DEBUG: var_dump() and friends; supersedes the get_debug_info handler */
+    case Debug = 0;
+
+    /** ZEND_PROP_PURPOSE_ARRAY_CAST: explicit (array) casts */
+    case ArrayCast = 1;
+
+    /** ZEND_PROP_PURPOSE_SERIALIZE: serialize() using the "O" scheme */
+    case Serialize = 2;
+
+    /** ZEND_PROP_PURPOSE_VAR_EXPORT: var_export(); the data is passed to __set_state() */
+    case VarExport = 3;
+
+    /** ZEND_PROP_PURPOSE_JSON: json_encode() */
+    case Json = 4;
+
+    /** ZEND_PROP_PURPOSE_GET_OBJECT_VARS: get_object_vars() */
+    case GetObjectVars = 5;
+}

--- a/src/Reflection/ReflectionValue.php
+++ b/src/Reflection/ReflectionValue.php
@@ -124,6 +124,7 @@ class ReflectionValue implements ReferenceCountedInterface
     public const IS_VOID     = 14;
     public const IS_STATIC   = 15;
     public const IS_MIXED    = 16;
+    public const IS_NEVER    = 17;
 
     /* internal types */
     public const IS_INDIRECT  = 12;
@@ -132,8 +133,8 @@ class ReflectionValue implements ReferenceCountedInterface
     public const _IS_ERROR    = 15;
 
     /* used for casts */
-    public const _IS_BOOL   = 17;
-    public const _IS_NUMBER = 18;
+    public const _IS_BOOL   = 18;
+    public const _IS_NUMBER = 19;
 
     private const Z_TYPE_FLAGS_MASK = 0xFF00;
 

--- a/tests/EngineConstantsTest.php
+++ b/tests/EngineConstantsTest.php
@@ -16,6 +16,8 @@ namespace ZEngine;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use ZEngine\AbstractSyntaxTree\NodeKind;
+use ZEngine\ClassExtension\Hook\CastType;
+use ZEngine\Reflection\ReflectionValue;
 use ZEngine\System\OpCode;
 
 /**
@@ -31,10 +33,12 @@ final class EngineConstantsTest extends TestCase
     public static function constantOwnerProvider(): array
     {
         return [
-            'ZEND_ACC_* on Core'           => [Core::class, 'ZEND_ACC_'],
-            'ZEND_PROPERTY_HOOK_* on Core' => [Core::class, 'ZEND_PROPERTY_HOOK_'],
-            'opcodes on OpCode'            => [OpCode::class, ''],
-            'AST kinds on NodeKind'        => [NodeKind::class, 'AST_'],
+            'ZEND_ACC_* on Core'                   => [Core::class, 'ZEND_ACC_'],
+            'ZEND_PROPERTY_HOOK_* on Core'         => [Core::class, 'ZEND_PROPERTY_HOOK_'],
+            'opcodes on OpCode'                    => [OpCode::class, ''],
+            'AST kinds on NodeKind'                => [NodeKind::class, 'AST_'],
+            'zval type ids on ReflectionValue'     => [ReflectionValue::class, 'IS_'],
+            'cast/internal ids on ReflectionValue' => [ReflectionValue::class, '_IS_'],
         ];
     }
 
@@ -75,6 +79,30 @@ final class EngineConstantsTest extends TestCase
             self::loadGeneratedConstants()['ZEND_MODULE_API_NO'],
             Core::engineConstant('ZEND_MODULE_API_NO'),
         );
+    }
+
+    public function testCastTypeCasesMatchGeneratedGroundTruth(): void
+    {
+        $generated    = self::loadGeneratedConstants();
+        $symbolByCase = [
+            'Long'   => 'IS_LONG',
+            'Double' => 'IS_DOUBLE',
+            'String' => 'IS_STRING',
+            'Array'  => 'IS_ARRAY',
+            'Object' => 'IS_OBJECT',
+            'Bool'   => '_IS_BOOL',
+            'Number' => '_IS_NUMBER',
+        ];
+
+        foreach (CastType::cases() as $case) {
+            $this->assertArrayHasKey($case->name, $symbolByCase, "CastType::{$case->name} has no engine symbol mapping in this test");
+            $engineName = $symbolByCase[$case->name];
+            $this->assertSame(
+                $generated[$engineName],
+                $case->value,
+                "CastType::{$case->name} ({$case->value}) does not match engine {$engineName} ({$generated[$engineName]})",
+            );
+        }
     }
 
     /**

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use ZEngine\ClassExtension\Hook\CastObjectHook;
+use ZEngine\ClassExtension\Hook\CastType;
 use ZEngine\ClassExtension\Hook\CloneObjectHook;
 use ZEngine\ClassExtension\Hook\CompareValuesHook;
 use ZEngine\ClassExtension\Hook\CreateObjectHook;
@@ -293,19 +294,18 @@ class ReflectionClassTest extends TestCase
         $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
         $this->refClass->setCreateObjectHandler($handler);
         $this->refClass->setCastObjectHandler(function (CastObjectHook $hook) {
-            $castType = $hook->getCastType();
-            switch ($castType) {
-                case ReflectionValue::IS_LONG:
-                case ReflectionValue::_IS_NUMBER:
-                    return 1;
-                case ReflectionValue::IS_DOUBLE:
-                    return 2.0;
-                case ReflectionValue::IS_STRING:
-                    return 'test';
-                case ReflectionValue::_IS_BOOL:
-                    return false;
-            }
-            throw new \UnexpectedValueException('Unknown type ' . ReflectionValue::name($castType));
+            return match ($hook->getCastTypeEnum()) {
+                CastType::Long, CastType::Number => 1,
+                CastType::Double                 => 2.0,
+                CastType::String                 => 'test',
+                // The engine accepts a boolean cast result only as IS_TRUE/IS_FALSE: a handler
+                // misrouted into the numeric branch would produce long(1), which the engine
+                // reports as false - so asserting true below proves the _IS_BOOL id is correct
+                CastType::Bool => true,
+                default        => throw new \UnexpectedValueException(
+                    'Unknown type ' . ReflectionValue::name($hook->getCastType()),
+                ),
+            };
         });
 
         $testClass = new TestClass();
@@ -316,7 +316,7 @@ class ReflectionClassTest extends TestCase
         $string = (string) $testClass;
         $this->assertSame('test', $string);
         $bool = (bool) $testClass;
-        $this->assertSame(false, $bool);
+        $this->assertTrue($bool);
         $this->markTestIncomplete('Initialization object handler brings segfaults thus run it separately');
     }
 


### PR DESCRIPTION
Fixes #152.

## The bug

PHP 8.1 inserted `IS_NEVER = 17` into the zval type table (`Zend/zend_types.h`), shifting `_IS_BOOL` to 18 and `_IS_NUMBER` to 19 — but `ReflectionValue` still declared the pre-8.1 values. The drift was worse than a miss: the engine passes 18 for every boolean cast, which the stale table resolves to `_IS_NUMBER`, so a cast handler dispatching on the documented constants misroutes `(bool)` into its numeric branch silently.

The generated ground truth in `include/8.4/*/constants.php` has carried the correct values all along — `ReflectionValue` simply wasn't covered by `EngineConstantsTest`. It is now, for both the `IS_*` and `_IS_*` prefixes, so this class of drift fails CI in the future.

## The API addition

Because namesake integer constants can drift silently between minors, the hooks gain a named, ground-truth-guarded API (as discussed in #152):

- **`CastType`** (int-backed enum): `Long`, `Double`, `String`, `Array`, `Object`, `Bool`, `Number` — surfaced via `CastObjectHook::getCastTypeEnum(): ?CastType`. Case values are asserted against the generated constants in `EngineConstantsTest`.
- **`PropertyPurpose`** (int-backed enum): `Debug`, `ArrayCast`, `Serialize`, `VarExport`, `Json`, `GetObjectVars` — surfaced via `GetPropertiesForHook::getPurposeEnum(): ?PropertyPurpose`. `zend_prop_purpose` is not exported by the generator manifest yet, so this one carries no generated guard — adding `ZEND_PROP_PURPOSE_*` to `tools/generator/symbols.php` (with a header regeneration) would close that gap as a follow-up.

Both `getCastType(): int` / `getPurpose(): int` remain untouched for BC.

## The regression test

`testInstallCastObjectHandler` previously asserted `(bool)` → `false` and passed **by accident**: the bool cast (18) fell into the `_IS_NUMBER` branch returning `long(1)`, and the engine reports any non-`IS_TRUE` retval of a boolean cast as `false`. The handler now dispatches on the enum and asserts `(bool)` → `true`, which only the `Bool` branch can produce — the assertion fails on the stale ids and passes on the corrected ones.

Verified: full suite green on PHP 8.4.19 NTS (411 tests), PHPStan level max clean, PER-CS2.0 clean.

Note for merge-up: `master` (8.5) declares the same stale values, so the cascade applies cleanly; the 8.0 branch is untouched and correct (`IS_NEVER` did not exist there).

Downstream context: found implementing casts in lisachenko/native-php-matrix#17, which carries a local-constant workaround that can be dropped once this ships in a tagged release.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsbdqisRfGuujN3QD9n8En

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsbdqisRfGuujN3QD9n8En)_