### PR TITLE
fix(core): make CastObjectHook fall through to default engine behaviour safely

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3303,7 +3303,7 @@ parameters:
 		-
 			message: '#^Cannot cast ZEngine\\Stub\\TestClass to int\.$#'
 			identifier: cast.int
-			count: 1
+			count: 2
 			path: tests/Reflection/ReflectionClassTest.php
 
 		-

--- a/src/ClassExtension/Hook/CastObjectHook.php
+++ b/src/ClassExtension/Hook/CastObjectHook.php
@@ -42,6 +42,15 @@ class CastObjectHook extends AbstractHook
     protected int $type;
 
     /**
+     * Status of the last proceed() call within the current handle() invocation, null if none
+     *
+     * The engine hands cast_object an UNINITIALIZED retval slot; only a successful original
+     * handler writes it. Tracking the status is what lets getResult() refuse to read scratch
+     * memory and lets handle() propagate a fall-through failure to the engine caller.
+     */
+    private ?int $lastProceedStatus = null;
+
+    /**
      * typedef int (*zend_object_cast_t)(zend_object *readobj, zval *retval, int type);
      *
      * @inheritDoc
@@ -49,8 +58,17 @@ class CastObjectHook extends AbstractHook
     public function handle(...$rawArguments): int
     {
         [$this->object, $this->returnValue, $this->type] = $rawArguments;
+        $this->lastProceedStatus                         = null;
 
         $result = ($this->userHandler)($this);
+        if ($result === null && $this->lastProceedFailed()) {
+            // The user handler fell through to the original handler and that handler could not
+            // produce a value. Propagate the failure so the engine caller applies its own
+            // default behaviour (diagnostic and substitute value for numeric casts, engine
+            // Error for string casts) instead of silently installing NULL as the cast result
+            return Core::FAILURE;
+        }
+
         // The retval slot is uninitialized scratch memory provided by the engine caller,
         // so there is no previous value to release in it
         ReflectionValue::fromValueEntry($this->returnValue)->initializeNativeValue($result);
@@ -79,10 +97,31 @@ class CastObjectHook extends AbstractHook
     }
 
     /**
-     * Returns result of casting (eg from call to proceed)
+     * Whether the user handler fell through to the original handler and that handler failed
+     *
+     * A method rather than an inline comparison on purpose: the property is mutated by
+     * proceed() from inside the userHandler closure invocation, a side effect static analysis
+     * cannot see through — inline, the null assignment in handle() would narrow the comparison
+     * to a compile-time constant.
+     */
+    private function lastProceedFailed(): bool
+    {
+        return $this->lastProceedStatus === Core::FAILURE;
+    }
+
+    /**
+     * Returns result of casting from a successful call to proceed(), null otherwise
+     *
+     * The retval slot is written only by a successful proceed(): reading it before one (or after
+     * a failed one) would dereference uninitialized scratch memory, so null is returned instead.
+     * Combined with handle() this makes the naive fall-through — `$hook->proceed(); return
+     * $hook->getResult();` — behave exactly like an uninstalled handler for every cast type.
      */
     public function getResult()
     {
+        if ($this->lastProceedStatus !== Core::SUCCESS) {
+            return null;
+        }
         ReflectionValue::fromValueEntry($this->returnValue)->getNativeValue($result);
 
         return $result;
@@ -90,14 +129,19 @@ class CastObjectHook extends AbstractHook
 
     /**
      * Proceeds with object casting
+     *
+     * @return int Core::SUCCESS when the original handler produced a value in the retval slot,
+     *             Core::FAILURE when it could not (numeric casts on plain objects, for example)
      */
     public function proceed()
     {
         if (!$this->hasOriginalHandler()) {
             throw new \LogicException('Original handler is not available');
         }
-        $result = ($this->originalHandler)($this->object, $this->returnValue, $this->type);
+        $status = ($this->originalHandler)($this->object, $this->returnValue, $this->type);
+        assert(is_int($status));
+        $this->lastProceedStatus = $status;
 
-        return $result;
+        return $this->lastProceedStatus;
     }
 }

--- a/tests/Reflection/ReflectionClassTest.php
+++ b/tests/Reflection/ReflectionClassTest.php
@@ -321,6 +321,62 @@ class ReflectionClassTest extends TestCase
     }
 
     #[RunInSeparateProcess]
+    public function testCastObjectHandlerFallsThroughToEngineDefault(): void
+    {
+        $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);
+        $this->refClass->setCreateObjectHandler($handler);
+        $this->refClass->setCastObjectHandler(function (CastObjectHook $hook) {
+            // The naive fall-through: defer every cast to the engine and hand back its result
+            $hook->proceed();
+
+            return $hook->getResult();
+        });
+
+        $instance = new TestClass();
+
+        // Boolean casts succeed in the default handler, so the fall-through must yield its value
+        $this->assertTrue(self::convertToBooleanViaEngine($instance));
+
+        // Numeric casts FAIL in the default handler without writing the retval slot: the
+        // failure must propagate to the engine caller (which warns and substitutes 1) instead
+        // of reading uninitialized memory or silently installing null. Capturing every PHP
+        // diagnostic also proves the fall-through emits no "Undefined variable" corruption noise
+        $capturedWarnings = [];
+        set_error_handler(static function (int $code, string $message) use (&$capturedWarnings): bool {
+            $capturedWarnings[] = $message;
+
+            return true;
+        });
+        try {
+            $long = (int) $instance;
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(1, $long);
+        $this->assertSame(
+            ['Object of class ' . TestClass::class . ' could not be converted to int'],
+            $capturedWarnings,
+        );
+        $this->markTestIncomplete('Initialization object handler brings segfaults thus run it separately');
+    }
+
+    /**
+     * Converts an object through the engine's boolean-conversion path (cast_object)
+     *
+     * A helper on purpose: written inline, the conversion result is a compile-time constant
+     * for static analysis (object-to-bool is always true there), while the installed cast
+     * handler decides it at runtime — the declared bool return type erases the narrowing
+     */
+    private static function convertToBooleanViaEngine(object $instance): bool
+    {
+        $value = $instance;
+        settype($value, 'boolean');
+
+        return $value;
+    }
+
+    #[RunInSeparateProcess]
     public function testInstallReadPropertyHandler(): void
     {
         $handler = Closure::fromCallable([ObjectCreateTrait::class, '__init']);


### PR DESCRIPTION
Fixes #153.

## The bugs

Two defects made the documented fall-through pattern — `$hook->proceed(); return $hook->getResult();` — unusable for cast types the default handler cannot satisfy:

1. **`getResult()` read uninitialized memory.** The engine hands `cast_object` an *uninitialized* retval slot, and `zend_std_cast_object_tostring` returns `FAILURE` for numeric casts without writing it (the engine *caller* is what warns and substitutes `1`). `getResult()` dereferenced the slot regardless, running the by-ref `ReferenceEntry` machinery over garbage — observably unsetting local variables in the calling frames (`$result` in `handle()` itself became undefined after being assigned) and emitting spurious "Undefined variable" warnings.
2. **`handle()` always reported `Core::SUCCESS`**, so a `FAILURE` from the original handler could never propagate. Whatever the user handler returned — including an accidental `null` — was silently installed as the cast result, and the engine caller's default behaviour (warning + substitute value for numeric casts, engine `Error` for string casts) was unreachable.

## The fix

- `proceed()` records its status.
- `getResult()` refuses to read the slot unless the last `proceed()` succeeded, returning `null` instead of dereferencing scratch memory.
- `handle()` propagates `FAILURE` to the engine when the user handler fell through (returned `null` after a failed `proceed()`). The failure is surfaced by the engine's own caller *after* the FFI callback has returned, so even the throwing default paths (string casts) stay safe.

Together this makes the naive fall-through behave exactly like an uninstalled handler for every cast type.

## The regression test

`testCastObjectHandlerFallsThroughToEngineDefault` installs the naive fall-through handler and asserts:
- boolean conversion yields the default handler's `true` (via `getResult()` after a successful proceed);
- `(int)` yields `1` **with the engine's own diagnostic** `Object of class ... could not be converted to int` and — by capturing every PHP diagnostic into a strict `assertSame` — no "Undefined variable" corruption noise.

Against the unfixed hook the test fails with exactly the reported symptom (captured warning is `Undefined variable $result` instead of the engine diagnostic); with the fix it passes.

Verified: full suite green on PHP 8.4.19 NTS (409 tests), PHPStan level max clean, PER-CS2.0 clean.

Note: this PR touches the same file as #155 in non-overlapping regions; both are independent of each other and either merge order works.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsbdqisRfGuujN3QD9n8En

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsbdqisRfGuujN3QD9n8En)_