### PR TITLE
feat(core): add Core::isInitialized()

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -247,6 +247,15 @@ class Core
     private static bool $shutdownRegistered = false;
 
     /**
+     * Whether Core::init() has completed for this process/thread
+     *
+     * Set at the very end of init() only, so a boot that failed midway (unsupported
+     * environment, missing engine definitions, layout mismatch) never reports the
+     * bridge as ready.
+     */
+    private static bool $initialized = false;
+
+    /**
      * Performs Z-engine core initialization (idempotent per process)
      *
      * A repeated call - eg a worker manager re-booting z-engine after Core::shutdown()
@@ -307,6 +316,8 @@ class Core
         self::$isShutdown = false;
 
         self::preloadFrameworkClasses();
+
+        self::$initialized = true;
     }
 
     /**
@@ -321,6 +332,25 @@ class Core
 
         // Performs initialization of properties, otherwise we will get an error about uninitialized properties
         Core::init();
+    }
+
+    /**
+     * Checks if Core::init() (or preload(), which calls it) has completed for this
+     * process/thread - i.e. the engine bridge is ready to use.
+     *
+     * Embedders booting from auto_prepend_file (e.g. a debugger) use this to detect
+     * whether another component already initialized the bridge, instead of probing
+     * `isset(Core::$compiler)` and coupling to an implementation detail.
+     *
+     * Note on lifecycle: init() is deliberately re-invocable (it reuses the
+     * process-wide FFI binding, see its docblock), so calling it when this method
+     * returns true is safe. The flag stays true after Core::shutdown() - the binding
+     * and wrappers still exist; use isShutdown() to check whether engine writes have
+     * been stopped for the rest of the request.
+     */
+    public static function isInitialized(): bool
+    {
+        return self::$initialized;
     }
 
     /**

--- a/tests/CoreInitializationTest.php
+++ b/tests/CoreInitializationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the boot-state introspection of Core: whether the engine bridge is ready.
+ *
+ * The negative (pre-init) case is not testable here: the suite bootstrap calls
+ * Core::init(), and PHPUnit's process isolation re-runs that bootstrap in every
+ * child process, so no test ever observes an uninitialized Core.
+ */
+final class CoreInitializationTest extends TestCase
+{
+    public function testIsInitializedAfterSuiteBootstrap(): void
+    {
+        // tests/bootstrap.php called Core::init() for this process
+        $this->assertTrue(Core::isInitialized(), 'the suite bootstrap initialized the engine bridge');
+    }
+
+    public function testInitIsReInvocableWhenAlreadyInitialized(): void
+    {
+        // init() deliberately supports repeated calls (reuses the process-wide
+        // FFI binding, issue #108); the flag must survive a re-init
+        Core::init();
+        $this->assertTrue(Core::isInitialized());
+    }
+}


### PR DESCRIPTION
Closes #162

## What

Adds `public static function isInitialized(): bool` to `Core`, reporting whether `Core::init()` (or `preload()`, which calls it) has completed for this process/thread — i.e. the engine bridge is ready.

## Why

Embedders booting from `auto_prepend_file` (e.g. the zdebug debugger) must detect whether another component already initialized the bridge. Today they probe `isset(Core::$compiler)`, which couples them to an implementation detail of Core. This puts the boot state behind an honest, stable name.

## Implementation notes

- Chose the explicit-flag variant (choice B from the issue): a `private static bool $initialized` set at the **very end** of `init()`, so a boot that failed midway (unsupported environment, missing engine definitions, layout mismatch) never reports the bridge as ready. `preload()` needs no extra handling since it delegates to `init()`.
- `init()` is left untouched apart from the final flag assignment: it is already deliberately re-invocable (reuses the process-wide FFI binding, issue #108) and a re-boot after `Core::shutdown()` relies on it re-running (resetting `$isShutdown`), so no early-return guard was added. The docblock on `isInitialized()` documents this and its relationship to `isShutdown()` (the flag stays `true` after shutdown; `isShutdown()` remains the predicate for "engine writes stopped").

## Testing

- phpstan level max + php-cs-fixer run locally on PHP 8.5.9; the unit test suite was NOT run locally per AGENTS.md version-matching rule (container PHP ≠ branch target 8.4) — CI must run it.
- New `tests/CoreInitializationTest.php` asserts `Core::isInitialized() === true` after the suite bootstrap, and that the flag survives a repeated `Core::init()`.
- The negative (pre-init `false`) case is not covered: the suite bootstrap calls `Core::init()`, and PHPUnit's `#[RunInSeparateProcess]` isolation re-runs that bootstrap in every child process, so no test can observe an uninitialized Core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9)_