### PR TITLE
feat(reflection): add closure-safe getFileName()/getFunctionName() accessors

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -86,7 +86,7 @@ parameters:
     # nested field read (already `mixed` via the CData ignores below) to the shape.
     typeAliases:
         ZendFunctionCommonShape: 'stdClass&object{function_name: FFI\CData|null, scope: FFI\CData|null, prototype: FFI\CData|null, fn_flags: int, num_args: int, arg_info: FFI\CData|null, attributes: FFI\CData|null}'
-        ZendOpArrayShape: 'stdClass&object{fn_flags: int, refcount: FFI\CData|null, cache_size: int, run_time_cache__ptr: FFI\CData|null, static_variables: FFI\CData|null, static_variables_ptr__ptr: FFI\CData|null, function_name: FFI\CData|null, opcodes: FFI\CData, literals: FFI\CData|null, last: int, last_var: int, last_literal: int, T: int, num_args: int, required_num_args: int, vars: FFI\CData|null}'
+        ZendOpArrayShape: 'stdClass&object{fn_flags: int, refcount: FFI\CData|null, cache_size: int, run_time_cache__ptr: FFI\CData|null, static_variables: FFI\CData|null, static_variables_ptr__ptr: FFI\CData|null, function_name: FFI\CData|null, filename: FFI\CData|null, opcodes: FFI\CData, literals: FFI\CData|null, last: int, last_var: int, last_literal: int, T: int, num_args: int, required_num_args: int, vars: FFI\CData|null}'
         ZvalTypeShape: 'stdClass&object{type: int, type_flags: int}'
         ZvalU1Shape: 'stdClass&object{v: ZvalTypeShape, type_info: int}'
         ZvalU2Shape: 'stdClass&object{constant_flags: int, extra: int, next: int}'

--- a/src/Reflection/FunctionLikeTrait.php
+++ b/src/Reflection/FunctionLikeTrait.php
@@ -50,6 +50,51 @@ trait FunctionLikeTrait
     }
 
     /**
+     * Returns the name of this function/method or null for main-scope/unnamed entries
+     * (callers render "{main}" for those)
+     *
+     * Unlike the native getName(), this accessor is purely pointer-based: it never
+     * constructs native reflection and never throws for a valid entry, so it is safe
+     * for closure-backed entries and inside FFI callbacks (where an uncaught throw
+     * from native reflection construction is fatal). Internal functions are served
+     * through the same common struct, which carries their name directly.
+     */
+    public function getFunctionName(): ?string
+    {
+        $functionName = $this->getCommonPointer()->function_name;
+        if ($functionName === null) {
+            return null;
+        }
+
+        return StringEntry::fromCData($functionName)->getStringValue();
+    }
+
+    /**
+     * Returns the file a user-defined function/method was declared in or null for
+     * internal functions
+     *
+     * Unlike the native accessor (which reports false for internal functions), this
+     * one is purely pointer-based and null-returning: it never constructs native
+     * reflection and never throws for a valid entry, so it is safe for closure-backed
+     * entries and inside FFI callbacks (where an uncaught throw from native reflection
+     * construction is fatal).
+     */
+    // @phpstan-ignore method.childReturnType (closure-safe nullable accessor instead of the native string|false)
+    #[\ReturnTypeWillChange]
+    public function getFileName(): ?string
+    {
+        if (!$this->isUserDefined()) {
+            return null;
+        }
+        $fileName = $this->getOpArrayPointer()->filename;
+        if ($fileName === null) {
+            return null;
+        }
+
+        return StringEntry::fromCData($fileName)->getStringValue();
+    }
+
+    /**
      * Marks this function as a closure or converts a closure-backed entry into a regular
      * function/method (toggles the ZEND_ACC_CLOSURE flag)
      *

--- a/tests/Reflection/FunctionLikeInfoTest.php
+++ b/tests/Reflection/FunctionLikeInfoTest.php
@@ -347,4 +347,50 @@ class FunctionLikeInfoTest extends TestCase
         $refFunction = new ReflectionFunction(__NAMESPACE__ . '\untypedInfoFunction');
         $this->assertSame([], $refFunction->getLiveRanges());
     }
+
+    public function testFileNameAndFunctionNameOfNamedFunction(): void
+    {
+        $refFunction = new ReflectionFunction(__NAMESPACE__ . '\argumentInfoFunction');
+
+        $this->assertSame(__FILE__, $refFunction->getFileName());
+        $this->assertSame(__NAMESPACE__ . '\argumentInfoFunction', $refFunction->getFunctionName());
+    }
+
+    public function testFileNameAndFunctionNameOfMethod(): void
+    {
+        $refMethod = new ReflectionMethod(self::class, __FUNCTION__);
+
+        $this->assertSame(__FILE__, $refMethod->getFileName());
+        // The engine stores the plain method name; the class is carried by the scope
+        $this->assertSame(__FUNCTION__, $refMethod->getFunctionName());
+    }
+
+    public function testFileNameAndFunctionNameOfClosure(): void
+    {
+        $closure = static function (): int {
+            return 42;
+        };
+
+        // The key case: the wrapper is built from the raw zend_function pointer without
+        // ever constructing native reflection (which can throw for closure-backed
+        // entries inside FFI callbacks), yet both accessors must serve real values
+        $closureEntry = new ClosureEntry($closure);
+        $refFunction  = ReflectionFunction::fromCData($closureEntry->getRawFunction());
+
+        $this->assertSame(__FILE__, $refFunction->getFileName());
+        $functionName = $refFunction->getFunctionName();
+        $this->assertNotNull($functionName);
+        $this->assertStringStartsWith('{closure', $functionName);
+    }
+
+    public function testFileNameAndFunctionNameOfInternalFunction(): void
+    {
+        $refFunction = new ReflectionFunction('strlen');
+
+        // Internal functions carry no op_array, hence no declaring file: this is a real
+        // null by definition, not a misuse - no exception is thrown
+        $this->assertNull($refFunction->getFileName());
+        // The name is still served through the common struct
+        $this->assertSame('strlen', $refFunction->getFunctionName());
+    }
 }


### PR DESCRIPTION
Closes #159

## What

Adds two closure-safe, pointer-based accessors to `Reflection\FunctionLikeTrait` (available on both `ReflectionFunction` and `ReflectionMethod`):

- `getFunctionName(): ?string` — the entry name served through the common struct (so internal functions work too); `null` for main-scope/unnamed entries, which callers render as `{main}`. Placed next to and consistent with the existing `setFunctionName()`.
- `getFileName(): ?string` — the declaring file of a user-defined function read from `op_array->filename` via `StringEntry::fromCData(...)->getStringValue()`; `null` for internal functions and null-pointer filenames. The native `string|false` contract is relaxed with `#[\ReturnTypeWillChange]`, the same pattern `getStaticVariables()` already uses.

Also extends the `ZendOpArrayShape` phpstan type alias in `phpstan.dist.neon` with `filename: FFI\CData|null` per the named-shapes convention in AGENTS.md (shape extended in config, never spelled inline).

## Why

zdebug's `OpArrayGate` needs the filename and function name of an op_array **inside an FFI opcode-handler callback**. Native reflection cannot be used there: `\ReflectionFunction` construction throws for closure-backed entries, and any uncaught throw inside an FFI callback is fatal. Downstream currently works around this by consuming the `@internal getOpArrayPointer()` and reading raw struct fields, which forces phpstan ignores and a C-layout dependency on consumers. These accessors never construct native reflection and never throw for valid entries, following the same `isUserDefined()` guard + pointer-read approach as `getVariableNames()`.

## Tests

New cases in `tests/Reflection/FunctionLikeInfoTest.php`:

- named function: filename is the declaring file, fully-qualified name
- class method: filename is the declaring file, plain method name (scope carries the class)
- **closure (the key case)**: wrapper built from the raw `zend_function` pointer via `ClosureEntry` + `ReflectionFunction::fromCData()`, i.e. without native reflection construction — both accessors serve real values
- internal function (`strlen`): `null` filename, non-null name

## Testing note

phpstan level max + php-cs-fixer run locally on PHP 8.5.9; the unit test suite was NOT run locally per AGENTS.md version-matching rule (container PHP ≠ branch target 8.4) — CI must run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9)_