### PR TITLE
feat(reflection): add ReflectionValue::dereference() as ZVAL_DEREF equivalent

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -90,6 +90,7 @@ parameters:
         ZvalTypeShape: 'stdClass&object{type: int, type_flags: int}'
         ZvalU1Shape: 'stdClass&object{v: ZvalTypeShape, type_info: int}'
         ZvalU2Shape: 'stdClass&object{constant_flags: int, extra: int, next: int}'
-        ZendValueShape: 'stdClass&object{lval: int, dval: float, str: FFI\CData, ptr: FFI\CData, counted: FFI\CData}'
+        ZendReferenceShape: 'stdClass&object{gc: FFI\CData, val: FFI\CData, sources: FFI\CData}'
+        ZendValueShape: 'stdClass&object{lval: int, dval: float, str: FFI\CData, ptr: FFI\CData, counted: FFI\CData, ref: ZendReferenceShape}'
         ZvalShape: 'stdClass&object{value: ZendValueShape, u1: ZvalU1Shape, u2: ZvalU2Shape}'
         ZendFileCacheMetaInfoShape: 'stdClass&object{magic: FFI\CData, system_id: FFI\CData, mem_size: int, str_size: int, script_offset: int, timestamp: int, checksum: int}'

--- a/src/Reflection/ReflectionValue.php
+++ b/src/Reflection/ReflectionValue.php
@@ -445,6 +445,28 @@ class ReflectionValue implements ReferenceCountedInterface
     }
 
     /**
+     * Follows a reference to the value it points to (ZVAL_DEREF equivalent)
+     *
+     * Safe to call unconditionally, exactly like the C macro: for a non-reference value
+     * this is an identity operation and returns the SAME instance. For an IS_REFERENCE
+     * zval it returns a BORROWED view over the zend_reference's embedded `val` slot -
+     * nothing is addref'd or released, so the result stays valid only while the
+     * zend_reference itself is kept alive (by the referencing variables or by this
+     * wrapper's own payload reference).
+     *
+     * @see zend_types.h:ZVAL_DEREF(z) macro
+     */
+    public function dereference(): self
+    {
+        if ($this->getBaseType() !== self::IS_REFERENCE) {
+            return $this;
+        }
+
+        // Borrowed view over the inner val slot, same as ReferenceEntry::getValue()
+        return self::fromValueEntry($this->valueUnion()->ref->val);
+    }
+
+    /**
      * Type-friendly getter to return pointer
      */
     public function getRawPointer(): CData

--- a/tests/Reflection/ReflectionValueTest.php
+++ b/tests/Reflection/ReflectionValueTest.php
@@ -162,6 +162,45 @@ class ReflectionValueTest extends TestCase
         $this->assertSame(spl_object_id($this), $object->getHandle());
     }
 
+    public function testDereferenceReturnsSameInstanceForPlainValue(): void
+    {
+        $refValue = new ReflectionValue(100);
+
+        // ZVAL_DEREF on a non-reference is an identity operation...
+        $this->assertSame($refValue, $refValue->dereference());
+        // ...and stays stable when applied repeatedly
+        $this->assertSame($refValue, $refValue->dereference()->dereference());
+    }
+
+    public function testDereferenceFollowsReferenceToInnerValue(): void
+    {
+        $variable = 42;
+        $this->assertReferenceArgumentDereferences($variable);
+        // The referenced variable is intact after inspection
+        $this->assertSame(42, $variable);
+    }
+
+    /**
+     * The frame argument inspection needs the value passed as a real by-ref argument,
+     * which makes the argument slot an IS_REFERENCE zval sharing the caller's variable
+     */
+    private function assertReferenceArgumentDereferences(mixed &$argument): void
+    {
+        $refValue = Core::$executor->getExecutionState()->getArgument(0);
+        $this->assertSame(ReflectionValue::IS_REFERENCE, $refValue->getBaseType());
+
+        $dereferenced = $refValue->dereference();
+        $this->assertNotSame($refValue, $dereferenced);
+        $this->assertSame(ReflectionValue::IS_LONG, $dereferenced->getBaseType());
+
+        $dereferenced->getNativeValue($nativeValue);
+        $this->assertSame(42, $nativeValue);
+
+        // Calling dereference() twice is stable: the inner value is not a reference,
+        // so the second call is an identity operation
+        $this->assertSame($dereferenced, $dereferenced->dereference());
+    }
+
     public function testGetRawString()
     {
         $value = self::class;


### PR DESCRIPTION
Closes #160

## What

Adds `ReflectionValue::dereference(): self` — a single-call ZVAL_DEREF equivalent:

- Non-reference value: identity operation, returns the **same** instance, so the call is always safe to make unconditionally (exactly like the C `ZVAL_DEREF` macro).
- `IS_REFERENCE` zval: returns a **borrowed** `ReflectionValue` view over the `zend_reference`'s embedded `val` slot, produced via `fromValueEntry()` so nothing is addref'd or released and nothing can be double-freed.

## Why

Consumers walking engine zvals previously had to detect `IS_REFERENCE` themselves and round-trip through `Type\ReferenceEntry` (or poke raw `CData`) to reach the inner value. Per the AGENTS.md ownership rule ("engine structs are owned by their reflection/type class"), the `zend_reference.val` field poke now lives inside `ReflectionValue` itself, behind a typed accessor.

The `zend_reference` field access is typed through a new `ZendReferenceShape` PHPStan alias (plus a `ref` field on `ZendValueShape`) in `phpstan.dist.neon`, keeping the new code clean at level max — the baseline is untouched.

## Changes

- `src/Reflection/ReflectionValue.php` — new `dereference()` method
- `tests/Reflection/ReflectionValueTest.php` — plain-value identity, by-ref argument dereferencing to the inner value (base type + native value), double-call stability
- `phpstan.dist.neon` — `ZendReferenceShape` alias, `ref` field on `ZendValueShape`

## Testing

phpstan level max + php-cs-fixer run locally on PHP 8.5.9; the unit test suite was NOT run locally per AGENTS.md version-matching rule (container PHP ≠ branch target 8.4) — CI must run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9)_