### PR TITLE
fix(core): repair nullable getThis() call left by the 8.4 cascade on master

### DIFF
--- a/tests/System/ExecutionDataTest.php
+++ b/tests/System/ExecutionDataTest.php
@@ -218,7 +218,7 @@ class ExecutionDataTest extends TestCase
         // frame cleanup from the one still referenced elsewhere, which corrupts the heap
         // on stricter allocators (PHP 8.5). Swapping is a real capability; not cleaning
         // up after it in the *live* frame is the bug.
-        Core::$executor->getExecutionState()->getThis()->setNativeValue($self);
+        $thisValue->setNativeValue($self);
         $self->assertSame($self, $this);
     }
 


### PR DESCRIPTION
## What

Fixes the PHPStan failure on `master` introduced by the 8.4→master cascade of #164 (nullable `getThis()`):

```
tests/System/ExecutionDataTest.php:221
Cannot call method setNativeValue() on ZEngine\Reflection\ReflectionValue|null.
```

The master-only `$this`-restore block in `testGetThis()` (the PHP 8.5 heap-safety cleanup) still chained `getExecutionState()->getThis()->setNativeValue($self)` on the now-nullable accessor. The fix reuses `$thisValue`, which is already null-asserted at the top of the test and wraps the very same `This` slot of the live frame, so the restore semantics are unchanged. One line, deliberately line-count-preserving.

## Why base = master

The broken line exists only on `master` (the restore block is master-only code), so per the branch model this is fixed on master directly — nothing to cascade.

## Testing

Run locally on PHP 8.5.9 NTS (matches the master line):
- `composer phpstan` (level max): green (was red on `e573807`)
- `composer cs:check`: clean
- `ExecutionDataTest`: 27/27 green (incl. `testGetThis` and the hasThis/getThis frame-kind tests)
- Full `composer test` segfaults at ~59% in this sandbox **identically on pristine `e573807`** — pre-existing environment limitation of the container, not related to this diff; CI is authoritative there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9)_