### PR TITLE
fix(reflection): property-hook reflection corrupts the SHM method table of opcache-immutable classes

### DIFF
--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -25,6 +25,12 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
 {
     use FunctionLikeTrait;
 
+    /**
+     * Keeps the anonymous publication-board instance (and thus its class entry) alive
+     * for the whole process
+     */
+    private static ?object $publicationBoard = null;
+
     public function __construct(string $className, string $methodName)
     {
         parent::__construct($className, $methodName);
@@ -94,10 +100,13 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
      *
      * Property hook bodies are real zend_function entries, but the engine does not publish
      * them in the class function table - they are only reachable via zend_property_info.hooks.
-     * The native ReflectionMethod constructor resolves methods through the function table, so
-     * the hook is published there under its mangled name ("$prop::get"/"$prop::set") just for
-     * the duration of the native construction and then unpublished again. The transient entry
-     * is removed with the table destructor disabled, so the hook function itself is untouched.
+     * The native ReflectionMethod constructor resolves methods through a function table, so
+     * the hook is published under its mangled name ("$prop::get"/"$prop::set") just for the
+     * duration of the native construction and then unpublished again. The publication target
+     * is a process-local board class, never the declaring class itself - an opcache-immutable
+     * class keeps its function table in shared memory, where a transient insert corrupts the
+     * table for every process. The transient entry is removed with the table destructor
+     * disabled, so the hook function itself is untouched.
      *
      * @param CData $functionEntry Pointer to the hook zend_function structure
      */
@@ -116,12 +125,23 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
 
         $scope = $commonPointer->scope;
         assert($scope instanceof CData);
-        $functionTable = Core::addr($scope->function_table);
-        $methodTable   = HashTable::fromCData($functionTable);
+        $methodTable = HashTable::fromCData(Core::addr($scope->function_table));
         if ($methodTable->find($lowerName) !== null) {
             // Already published (eg by a future engine version) - use the regular path
             return static::fromCData($functionEntry);
         }
+
+        // The declaring class's own method table is NOT a valid publication target: with
+        // opcache the class may be immutable, its function table living in shared memory
+        // with an exactly-sized bucket array - inserting forces a resize that reallocates
+        // the shared arData with the request allocator, corrupting the table for every
+        // process that maps it. The transient entry goes into a process-local publication
+        // board instead: the native constructor resolves the function through the board
+        // but adopts the hook's own scope, so the reflection still reports the real
+        // declaring class, and no shared engine structure is ever written.
+        $boardName   = get_class(self::publicationBoard());
+        $methodTable = (new ReflectionClass($boardName))->getMethodTable();
+        $boardTable  = $methodTable->getRawValue();
 
         // The temporary container is released right after the engine copied it into a bucket
         $rawFunction = Core::cast('zend_function *', $functionEntry)[0];
@@ -130,16 +150,41 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
         $methodTable->add($lowerName, $valueEntry);
         $valueEntry->release();
         try {
-            return static::fromCData($functionEntry);
+            /** @var ReflectionMethod $reflectionMethod */
+            $reflectionMethod = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+            Core::callParentConstructor(
+                $reflectionMethod,
+                static::class,
+                $boardName,
+                StringEntry::fromCData($functionNamePtr)->getStringValue(),
+            );
+            $reflectionMethod->pointer = $functionEntry;
+
+            return $reflectionMethod;
         } finally {
             // Unpublish the transient entry without destroying the hook function: the table
             // destructor (zend_function_dtor) is disabled around the delete, so the bucket
             // removal releases nothing - the hook stays owned by zend_property_info.hooks
-            $previousDestructor         = $functionTable->pDestructor;
-            $functionTable->pDestructor = null;
+            $previousDestructor      = $boardTable->pDestructor;
+            $boardTable->pDestructor = null;
             $methodTable->delete($lowerName);
-            $functionTable->pDestructor = $previousDestructor;
+            $boardTable->pDestructor = $previousDestructor;
         }
+    }
+
+    /**
+     * Process-local class whose method table hosts transient hook publications
+     *
+     * An anonymous class is created at runtime and is therefore never persisted by
+     * opcache: unlike a file-declared class it can not become IMMUTABLE with its
+     * function table in shared memory, which is what makes it a safe mutation target.
+     * The instance is cached so the class entry stays alive for the whole process.
+     */
+    private static function publicationBoard(): object
+    {
+        self::$publicationBoard ??= new class {};
+
+        return self::$publicationBoard;
     }
 
     /**

--- a/tests/Reflection/ReflectionPropertyHooksOpcacheTest.php
+++ b/tests/Reflection/ReflectionPropertyHooksOpcacheTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Reflection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression gate for the property-hook reflection path against an opcache-immutable
+ * class: getHook() used to publish the transient method-table entry into the declaring
+ * class's own function table, which lives in shared memory for an immutable class.
+ * The insert forced a bucket-array resize with the request allocator, corrupting the
+ * shared table - native reflection then saw an empty method table and the FFI walk
+ * over it segfaulted the process.
+ *
+ * The scenario runs in a child because opcache.enable_cli cannot be toggled at
+ * runtime, and the main suite intentionally runs without opcache.
+ */
+class ReflectionPropertyHooksOpcacheTest extends TestCase
+{
+    public function testHookReflectionLeavesAnImmutableClassIntact(): void
+    {
+        $command = [
+            PHP_BINARY,
+            '-d', 'ffi.enable=1',
+            '-d', 'opcache.enable=1',
+            '-d', 'opcache.enable_cli=1',
+            '-d', 'opcache.jit=off',
+            '-d', 'zend.assertions=1',
+            '-d', 'assert.exception=1',
+            '-d', 'display_errors=on',
+            '-d', 'error_reporting=' . (E_ALL & ~E_DEPRECATED),
+            __DIR__ . '/scenarios/hook-reflection-under-opcache.php',
+        ];
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        $this->assertIsResource($process, 'Unable to spawn the opcache scenario child process');
+
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        $report = "STDOUT:\n{$stdout}\nSTDERR:\n{$stderr}";
+
+        if ($exitCode === 2) {
+            $this->markTestSkipped('opcache is not available for the scenario child');
+        }
+        if ($exitCode === 3) {
+            $this->markTestSkipped('opcache did not serve the stub class as immutable');
+        }
+
+        // A segfault surfaces here as a signal exit code (139), not as a marker mismatch
+        $this->assertSame(0, $exitCode, "Opcache scenario exited with code {$exitCode}\n{$report}");
+
+        $expectedMarkers = [
+            'class-is-immutable',
+            'hook-name-intact',
+            'hook-scope-intact',
+            'hook-invokable',
+            'native-table-intact',
+            'engine-table-intact',
+            'scenario-complete',
+        ];
+        foreach ($expectedMarkers as $marker) {
+            $this->assertStringContainsString($marker, $stdout, "Missing marker {$marker}\n{$report}");
+        }
+    }
+}

--- a/tests/Reflection/scenarios/hook-reflection-under-opcache.php
+++ b/tests/Reflection/scenarios/hook-reflection-under-opcache.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionClass;
+use ZEngine\Reflection\ReflectionProperty;
+use ZEngine\Stub\TestHookedClass;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+// The scenario must observe an opcache-immutable hooked class: without opcache the
+// declaring class's function table is request-local and the historical corruption
+// cannot manifest. The parent test spawns this file with opcache.enable_cli=1.
+if (!function_exists('opcache_get_status') || opcache_get_status(false) === false) {
+    fwrite(STDERR, 'opcache is not active in the scenario process');
+    exit(2);
+}
+
+Core::init();
+
+class_exists(TestHookedClass::class);
+$classInfo = new ReflectionClass(TestHookedClass::class);
+if (!$classInfo->isImmutable()) {
+    // Nothing to regress against - the engine did not serve the class from SHM
+    // (eg opcache decided not to cache the stub). Report distinctly, do not fail.
+    echo "class-not-immutable\n";
+    exit(3);
+}
+echo "class-is-immutable\n";
+
+// The historical bug: publishing the hook into the immutable class's SHM function
+// table forced a bucket-array resize with the request allocator, corrupting the
+// shared table - afterwards native reflection saw an empty method table and any
+// FFI walk over it crashed the process.
+$property = new ReflectionProperty(TestHookedClass::class, 'hooked');
+$getHook  = $property->getHook(Core::ZEND_PROPERTY_HOOK_GET);
+
+assert($getHook !== null);
+echo $getHook->getName()                      === '$hooked::get' ? "hook-name-intact\n" : "hook-name-broken\n";
+echo $getHook->getDeclaringClass()->getName() === TestHookedClass::class
+    ? "hook-scope-intact\n"
+    : "hook-scope-broken\n";
+echo $getHook->invoke(new TestHookedClass()) === 6 ? "hook-invokable\n" : "hook-invoke-broken\n";
+
+// The transient publication must not leak into any visible method list
+$nativeMethods = array_map(
+    static fn(\ReflectionMethod $method): string => $method->getName(),
+    (new \ReflectionClass(TestHookedClass::class))->getMethods(),
+);
+echo $nativeMethods === ['annotatedMethod'] ? "native-table-intact\n" : "native-table-broken\n";
+
+// The FFI walk over the same table is what used to segfault on the corrupted arData
+$engineMethods = [];
+foreach ((new ReflectionClass(TestHookedClass::class))->getMethods() as $method) {
+    $engineMethods[] = $method->getName();
+}
+echo $engineMethods === ['annotatedMethod'] ? "engine-table-intact\n" : "engine-table-broken\n";
+
+echo "scenario-complete\n";


### PR DESCRIPTION
## The segfault, root-caused

Debugging the full-suite segfault observed in the review sandbox (`Tests: 425 … Segmentation fault` at ~59%, reported alongside #171) with gdb + bisection:

1. gdb put the fault inside `ffi.so` during VM execution; event-log streaming identified the dying test as `ReflectionPropertyHooksTest::testGetHookDoesNotPolluteTheMethodTable`, and it reproduces **in isolation** — earlier "passes standalone" observations were an exit-code-masking artifact of piped output.
2. The decisive variable is **`opcache.enable_cli=1`** (the sandbox's php.ini has it on; CI and the default CLI have it off — which is exactly why CI never caught this): `=0` passes, `=1` segfaults, deterministically.
3. Minimal repro (opcache on): `getHook()` alone succeeds, but afterwards **native** `ReflectionClass::getMethods()` on the hooked class returns an **empty list** and z-engine's FFI walk over the same table segfaults. The table itself is corrupted, not the walker.

**Mechanism.** `ReflectionMethod::fromHookCData()` initialized native reflection state by transiently inserting the hook `zend_function` into the declaring class's own `function_table`. Under opcache the class is served from shared memory as `ZEND_ACC_IMMUTABLE` (verified: `isImmutable()` is true for the test stub in the repro) with an exactly-sized bucket array — the insert forces `zend_hash` to resize, reallocating the **shared** `arData` with the **request allocator**. Everything sharing that SHM mapping is now broken: empty-looking method table, dangling `arData`, crash on the next FFI traversal. In web SAPIs this corruption would persist across requests and processes, so this is a production-grade bug, not a sandbox curiosity.

## The fix

The transient entry is published into the method table of a **process-local anonymous board class** instead. Anonymous classes are created at runtime and never opcache-persisted (verified: `IMMUTABLE` flag absent under `opcache.enable_cli=1`), so the mutated table is always request-local heap. The native `ReflectionMethod` constructor resolves the function through the board's table but **adopts the hook's own `common.scope`** — verified empirically: `getName()`, `getDeclaringClass()`, the readonly `->class` property and `invoke()` all report/use the real declaring class. The unpublish path (destructor-disabled delete) is unchanged, now aimed at the board. No shared engine structure is ever written; implementation reuses the typed accessors (`ReflectionClass::getMethodTable()`, `HashTable::getRawValue()`), so no phpstan baseline changes.

`Core::shutdown()`'s similar destructor-disabled dance was audited too — it targets the request-local global function table (entries z-engine itself added), not SHM, and is fine.

## Regression test

`ReflectionPropertyHooksOpcacheTest` spawns a child with `-d opcache.enable_cli=1` (pattern borrowed from `PersistentHeapRequestCycleTest`) running a marker scenario: class must be immutable, hook name/scope/invoke intact, native **and** FFI method-table walks intact. On unfixed code the child dies with signal 11 and the test fails with "exited with code 11"; skips distinctly when opcache is unavailable or chose not to serve the stub immutably.

## Verification

Per AGENTS.md the 8.4 suite cannot run on this container (PHP 8.5.9); the same patch applied to `master` (files identical across branches) was verified there:
- repro script: fixed output, no crash; hooks + method + new opcache tests: 20/20 green
- regression test: red (signal 11) on pristine, green on patched
- full suite with `opcache.enable_cli=1`: **runs to completion** (was: segfault at ~59%)
- phpstan level max + cs clean on this branch, no baseline additions

## Out of scope, for the record

With opcache on, six other pre-existing failures surface in the sandbox, unrelated to this fix: `ClassSpecializerSlotTest` (2), `SharedMemoryExceptionTest::testRuntimeDeclaredCodeIsNotReportedAsImmutable`, `FunctionLikeInfoTest::testStaticVariablesOfNamedFunction`, and `ExecutionDataTest`'s two CV-slot tests (the optimizer drops the unused-CV fixture). Happy to file a follow-up issue on opcache-mode coverage if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5EyK92Zsx1nXuns6wbho9)_