### PR TITLE
perf(reflection): mint instances via native reflection and drop redundant casts on hot paths

### DIFF
--- a/src/Reflection/FunctionBodySwap.php
+++ b/src/Reflection/FunctionBodySwap.php
@@ -222,13 +222,11 @@ final class FunctionBodySwap
             }
             $seenClasses[$classAddress] = true;
 
-            // Both answers come straight off the entry through the owning class: a full
-            // reflection per engine class would pay a native parent constructor and the
-            // low-level table wrappers just to serve one flag read and one table lookup
-            if (!ReflectionClass::entryIsUserDefined($rawClass)) {
+            $reflectionClass = ReflectionClass::fromCData($rawClass);
+            if (!$reflectionClass->isUserDefined()) {
                 continue;
             }
-            $bucketValue = ReflectionClass::entryMethodTable($rawClass)->find($lowerName);
+            $bucketValue = $reflectionClass->getMethodTable()->find($lowerName);
             if ($bucketValue !== null && Core::addressOf($bucketValue->getRawFunction()) === $entryAddress) {
                 $shares++;
             }

--- a/src/Reflection/FunctionBodySwap.php
+++ b/src/Reflection/FunctionBodySwap.php
@@ -222,11 +222,13 @@ final class FunctionBodySwap
             }
             $seenClasses[$classAddress] = true;
 
-            $reflectionClass = ReflectionClass::fromCData($rawClass);
-            if (!$reflectionClass->isUserDefined()) {
+            // Both answers come straight off the entry through the owning class: a full
+            // reflection per engine class would pay a native parent constructor and the
+            // low-level table wrappers just to serve one flag read and one table lookup
+            if (!ReflectionClass::entryIsUserDefined($rawClass)) {
                 continue;
             }
-            $bucketValue = $reflectionClass->getMethodTable()->find($lowerName);
+            $bucketValue = ReflectionClass::entryMethodTable($rawClass)->find($lowerName);
             if ($bucketValue !== null && Core::addressOf($bucketValue->getRawFunction()) === $entryAddress) {
                 $shares++;
             }
@@ -401,8 +403,7 @@ final class FunctionBodySwap
             // must set the flag or its materialized table leaks at request end
             $entryScope = $entryFunction->getCommonPointer()->scope;
             if ($entryScope !== null) {
-                ReflectionClass::fromCData(Core::cast('zend_class_entry *', $entryScope))
-                    ->markHasStaticInMethods();
+                ReflectionClass::fromCData($entryScope)->markHasStaticInMethods();
             }
         }
         if ($defaultsTable === null || !$duplicateStatics) {

--- a/src/Reflection/FunctionLikeTrait.php
+++ b/src/Reflection/FunctionLikeTrait.php
@@ -281,7 +281,7 @@ trait FunctionLikeTrait
      */
     private function copyMethodOutOfSharedMemory(object $entryScope): object
     {
-        $declaringClass = ReflectionClass::fromCData(Core::cast('zend_class_entry *', $entryScope));
+        $declaringClass = ReflectionClass::fromCData($entryScope);
         $declaringClass->copyOutOfSharedMemory();
 
         $methodName  = $this->getName();

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -497,24 +497,6 @@ class ReflectionClass extends NativeReflectionClass
     }
 
     /**
-     * Tells whether the given raw class entry describes a user-defined (compiled) class
-     *
-     * Entry-level counterpart of isUserDefined() for the machinery that walks the whole
-     * engine class table and only needs this one answer: constructing a full reflection
-     * per class entry would pay a native parent constructor plus the low-level table
-     * wrappers for a single byte read.
-     *
-     * @param CData|zend_class_entry $classEntry Pointer to the structure
-     *
-     * @internal shared with the body-swap machinery (FunctionBodySwap)
-     */
-    public static function entryIsUserDefined(object $classEntry): bool
-    {
-        /** @var zend_class_entry $classEntry Narrowed to the stub view at the owning boundary */
-        return ord($classEntry->type) === Core::ZEND_USER_CLASS;
-    }
-
-    /**
      * Checks if this class entry lives in opcache shared memory (ZEND_ACC_IMMUTABLE)
      *
      * Opcache marks every class it publishes from its shared memory as immutable:
@@ -636,25 +618,6 @@ class ReflectionClass extends NativeReflectionClass
     public function getMethodTable(): HashTable
     {
         return $this->methodTable;
-    }
-
-    /**
-     * Returns the borrowed method-table view of the given raw class entry
-     *
-     * Entry-level counterpart of getMethodTable(): the table lives inside the class
-     * entry, so a lookup does not need the rest of the reflection state (see
-     * entryIsUserDefined() for why the class-table walks avoid building one).
-     *
-     * @param CData|zend_class_entry $classEntry Pointer to the structure
-     *
-     * @return HashTable|ReflectionValue[]
-     *
-     * @internal shared with the body-swap machinery (FunctionBodySwap)
-     */
-    public static function entryMethodTable(object $classEntry): HashTable
-    {
-        /** @var zend_class_entry $classEntry Narrowed to the stub view at the owning boundary */
-        return HashTable::fromCData(Core::addr($classEntry->function_table));
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -497,6 +497,24 @@ class ReflectionClass extends NativeReflectionClass
     }
 
     /**
+     * Tells whether the given raw class entry describes a user-defined (compiled) class
+     *
+     * Entry-level counterpart of isUserDefined() for the machinery that walks the whole
+     * engine class table and only needs this one answer: constructing a full reflection
+     * per class entry would pay a native parent constructor plus the low-level table
+     * wrappers for a single byte read.
+     *
+     * @param CData|zend_class_entry $classEntry Pointer to the structure
+     *
+     * @internal shared with the body-swap machinery (FunctionBodySwap)
+     */
+    public static function entryIsUserDefined(object $classEntry): bool
+    {
+        /** @var zend_class_entry $classEntry Narrowed to the stub view at the owning boundary */
+        return ord($classEntry->type) === Core::ZEND_USER_CLASS;
+    }
+
+    /**
      * Checks if this class entry lives in opcache shared memory (ZEND_ACC_IMMUTABLE)
      *
      * Opcache marks every class it publishes from its shared memory as immutable:
@@ -618,6 +636,25 @@ class ReflectionClass extends NativeReflectionClass
     public function getMethodTable(): HashTable
     {
         return $this->methodTable;
+    }
+
+    /**
+     * Returns the borrowed method-table view of the given raw class entry
+     *
+     * Entry-level counterpart of getMethodTable(): the table lives inside the class
+     * entry, so a lookup does not need the rest of the reflection state (see
+     * entryIsUserDefined() for why the class-table walks avoid building one).
+     *
+     * @param CData|zend_class_entry $classEntry Pointer to the structure
+     *
+     * @return HashTable|ReflectionValue[]
+     *
+     * @internal shared with the body-swap machinery (FunctionBodySwap)
+     */
+    public static function entryMethodTable(object $classEntry): HashTable
+    {
+        /** @var zend_class_entry $classEntry Narrowed to the stub view at the owning boundary */
+        return HashTable::fromCData(Core::addr($classEntry->function_table));
     }
 
     /**

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ZEngine\Reflection;
 
 use FFI\CData;
+use ReflectionClass as NativeReflectionClass;
 use ReflectionClassConstant as NativeReflectionClassConstant;
 use ZEngine\Core;
 use ZEngine\Generated\zend_class_constant;
@@ -68,7 +69,7 @@ class ReflectionClassConstant extends NativeReflectionClassConstant
     public static function fromCData(object $constantEntry, string $constantName): ReflectionClassConstant
     {
         /** @var ReflectionClassConstant $reflectionConstant */
-        $reflectionConstant = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionConstant = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_class_constant $constantEntry Narrowed to the stub view at the owning boundary */
         $classEntry = $constantEntry->ce;
         assert($classEntry !== null);
@@ -101,7 +102,7 @@ class ReflectionClassConstant extends NativeReflectionClassConstant
     public static function fromRawEntry(object $constantEntry): ReflectionClassConstant
     {
         /** @var ReflectionClassConstant $reflectionConstant */
-        $reflectionConstant = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionConstant = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_class_constant $constantEntry Narrowed at the boundary (may be a struct or a pointer view) */
         $reflectionConstant->pointer = $constantEntry;
 

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -15,6 +15,7 @@ namespace ZEngine\Reflection;
 
 use Closure;
 use FFI\CData;
+use ReflectionClass as NativeReflectionClass;
 use ReflectionFunction as NativeReflectionFunction;
 use ZEngine\Core;
 use ZEngine\Generated\zend_function;
@@ -48,7 +49,7 @@ class ReflectionFunction extends NativeReflectionFunction implements FunctionLik
     public static function fromCData(object $functionEntry): ReflectionFunction
     {
         /** @var ReflectionFunction $reflectionFunction */
-        $reflectionFunction = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionFunction = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_function|zend_internal_function $entry Narrowed to the stub views at the owning boundary */
         $entry = $functionEntry;
         if ($entry->type === Core::ZEND_INTERNAL_FUNCTION) {
@@ -140,7 +141,7 @@ class ReflectionFunction extends NativeReflectionFunction implements FunctionLik
     public static function fromClosureEntry(ClosureEntry $closureEntry, string $functionName): ReflectionFunction
     {
         /** @var ReflectionFunction $reflectionFunction */
-        $reflectionFunction          = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionFunction          = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         $reflectionFunction->pointer = Core::cast(zend_function::class, Core::addr($closureEntry->getRawFunction()));
 
         $reflectionFunction->setFunctionName($functionName);

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ZEngine\Reflection;
 
 use FFI\CData;
+use ReflectionClass as NativeReflectionClass;
 use ReflectionMethod as NativeReflectionMethod;
 use ZEngine\Core;
 use ZEngine\Generated\zend_function;
@@ -68,7 +69,7 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
     public static function fromCData(object $functionEntry): ReflectionMethod
     {
         /** @var ReflectionMethod $reflectionMethod */
-        $reflectionMethod = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionMethod = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_function|zend_internal_function $entry Narrowed to the stub views at the owning boundary */
         $entry        = $functionEntry;
         $isTrampoline = false;
@@ -159,7 +160,7 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
         $valueEntry->release();
         try {
             /** @var ReflectionMethod $reflectionMethod */
-            $reflectionMethod = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+            $reflectionMethod = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
             Core::callParentConstructor(
                 $reflectionMethod,
                 static::class,
@@ -230,7 +231,7 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
     public static function fromRawEntry(object $functionEntry): ReflectionMethod
     {
         /** @var ReflectionMethod $reflectionMethod */
-        $reflectionMethod = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionMethod = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_function|zend_internal_function $functionEntry Narrowed to the stub views at the owning boundary */
         $reflectionMethod->pointer = $functionEntry;
 
@@ -243,7 +244,7 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
         string $methodName,
     ): ReflectionMethod {
         /** @var ReflectionMethod $reflectionMethod */
-        $reflectionMethod          = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionMethod          = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         $reflectionMethod->pointer = Core::cast(zend_function::class, Core::addr($closureEntry->getRawFunction()));
 
         $reflectionMethod->setFunctionName($methodName);
@@ -328,7 +329,7 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
             throw new \InvalidArgumentException('Not in a class scope');
         }
 
-        return ReflectionClass::fromCData(Core::cast('zend_class_entry *', $scope));
+        return ReflectionClass::fromCData($scope);
     }
 
     /**

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ZEngine\Reflection;
 
 use FFI\CData;
+use ReflectionClass as NativeReflectionClass;
 use ReflectionProperty as NativeReflectionProperty;
 use ZEngine\Core;
 use ZEngine\Generated\zend_property_info;
@@ -71,7 +72,7 @@ class ReflectionProperty extends NativeReflectionProperty
     public static function fromCData(object $propertyEntry): ReflectionProperty
     {
         /** @var ReflectionProperty $reflectionProperty */
-        $reflectionProperty = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionProperty = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_property_info $propertyEntry Narrowed to the stub view at the owning boundary */
         $propertyNamePointer = $propertyEntry->name;
         assert($propertyNamePointer !== null);
@@ -101,7 +102,7 @@ class ReflectionProperty extends NativeReflectionProperty
     public static function fromRawEntry(object $propertyInfo): ReflectionProperty
     {
         /** @var ReflectionProperty $reflectionProperty */
-        $reflectionProperty = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $reflectionProperty = (new NativeReflectionClass(static::class))->newInstanceWithoutConstructor();
         /** @var zend_property_info $propertyInfo Narrowed at the boundary (may be a struct or a pointer view) */
         $reflectionProperty->pointer = $propertyInfo;
 

--- a/src/Type/ObjectEntry.php
+++ b/src/Type/ObjectEntry.php
@@ -128,7 +128,7 @@ class ObjectEntry implements ReferenceCountedInterface
         // Engine invariant: every live object carries its class entry
         assert($classEntry !== null);
 
-        return ReflectionClass::fromCData(Core::cast('zend_class_entry *', $classEntry));
+        return ReflectionClass::fromCData($classEntry);
     }
 
     /**


### PR DESCRIPTION
Two independent, behavior-preserving reductions on reflection hot paths. No public API changes.

> Note: the PR originally carried a third part (entry-level static helpers used by `countPublishedShares()`); it was dropped per maintainer review — consumers hold `Reflection*` objects, entry-level static utilities cut against the framework's model.

## A. Stop building full z-engine `ReflectionClass` instances just to bypass constructors

Inside `namespace ZEngine\Reflection` the unqualified name `ReflectionClass` resolves to z-engine's own class, whose constructor runs the native `parent::__construct()`, a class-table `find()` and `initLowLevelStructures()` (four `HashTable` wrappers) — every bit of it discarded when the instance exists only to serve `newInstanceWithoutConstructor()`.

All ten such sites now use `ReflectionClass as NativeReflectionClass`, the alias already used by `ReflectionClass::fromCData()` (`src/Reflection/ReflectionClass.php:183`) and the `src/Type/*` wrappers:

- `src/Reflection/ReflectionMethod.php` — `fromCData()`, `fromHookCData()`, `fromRawEntry()`, `fromClosureEntry()`
- `src/Reflection/ReflectionProperty.php` — `fromCData()`, `fromRawEntry()`
- `src/Reflection/ReflectionClassConstant.php` — `fromCData()`, `fromRawEntry()`
- `src/Reflection/ReflectionFunction.php` — `fromCData()`, `fromClosureEntry()`

**Deliberately left unchanged:** `src/Reflection/ReflectionMethod.php:152`, `(new ReflectionClass($boardName))->getMethodTable()` — that one genuinely needs the z-engine class, since `getMethodTable()` only exists once `initLowLevelStructures()` has run. Every other site was checked the same way.

## B. Remove redundant `zend_class_entry *` casts

Each of these passed an already-typed `zend_class_entry *` through `Core::cast('zend_class_entry *', …)`, which costs a `count()` array probe, a caught `FFI\Exception`, and a type-name lookup per call. The producing expression was checked at every site — all four are pointer struct fields (`zend_object.ce`, `zend_function_common.scope`), never a C array needing decay — so the cast is dropped, matching the existing direct form in `ReflectionProperty::getDeclaringClass()` and `ReflectionClassConstant::getDeclaringClass()`:

- `src/Type/ObjectEntry.php:131` — `$this->pointer->ce`, `zend_object.ce` is `?zend_class_entry` in the stubs
- `src/Reflection/ReflectionMethod.php:332` — `$this->getCommonPointer()->scope`
- `src/Reflection/FunctionLikeTrait.php:284` — `$entryScope`, fed from `$this->getCommonPointer()->scope` at line 198
- `src/Reflection/FunctionBodySwap.php:406` — `$entryFunction->getCommonPointer()->scope`

No site had to be left in place for array decay.

## Merge note

`ReflectionMethod::fromHookCData()` is also touched by the concurrently-open exception-safety PR #197. The hunks are different and roughly ten lines apart, so a textual proximity conflict is possible but the resolution is trivial in either merge order — keep both edits.

## Validation

- `vendor/bin/phpstan analyse` (level max) — **clean**, no baseline changes needed (verified via a temporary `reportUnmatchedIgnoredErrors: true` run on both trees).
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix` — 0 of 296 files changed; `--dry-run` clean.
- **Local tests were not run and could not be:** the container runs PHP 8.5.9 while this branch targets PHP 8.4, and AGENTS.md forbids executing z-engine code against a mismatched minor. Validation here is static-only; CI on the 8.4 legs is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG