### PR TITLE
fix: exception-safe engine-state restoration (fake scope, pDestructor, class-table guards)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -331,7 +331,7 @@ parameters:
 			path: src/ClassExtension/Hook/GetPropertiesForHook.php
 
 		-
-			message: '#^Parameter \#1 \$newScope of method ZEngine\\System\\Executor\:\:setFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$scope of method ZEngine\\System\\Executor\:\:withFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/ClassExtension/Hook/GetPropertiesForHook.php
@@ -373,7 +373,7 @@ parameters:
 			path: src/ClassExtension/Hook/GetPropertyPointerHook.php
 
 		-
-			message: '#^Parameter \#1 \$newScope of method ZEngine\\System\\Executor\:\:setFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$scope of method ZEngine\\System\\Executor\:\:withFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/ClassExtension/Hook/GetPropertyPointerHook.php
@@ -421,7 +421,7 @@ parameters:
 			path: src/ClassExtension/Hook/HasPropertyHook.php
 
 		-
-			message: '#^Parameter \#1 \$newScope of method ZEngine\\System\\Executor\:\:setFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$scope of method ZEngine\\System\\Executor\:\:withFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/ClassExtension/Hook/HasPropertyHook.php
@@ -505,7 +505,7 @@ parameters:
 			path: src/ClassExtension/Hook/ReadPropertyHook.php
 
 		-
-			message: '#^Parameter \#1 \$newScope of method ZEngine\\System\\Executor\:\:setFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$scope of method ZEngine\\System\\Executor\:\:withFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/ClassExtension/Hook/ReadPropertyHook.php
@@ -559,7 +559,7 @@ parameters:
 			path: src/ClassExtension/Hook/UnsetPropertyHook.php
 
 		-
-			message: '#^Parameter \#1 \$newScope of method ZEngine\\System\\Executor\:\:setFakeScope\(\) expects FFI\\CData\|null, ZEngine\\Generated\\zend_class_entry\|null given\.$#'
+			message: '#^Parameter \#1 \$scope of method ZEngine\\System\\Executor\:\:withFakeScope\(\) expects FFI\\CData\|null, ZEngine\\Generated\\zend_class_entry\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/ClassExtension/Hook/UnsetPropertyHook.php
@@ -613,7 +613,7 @@ parameters:
 			path: src/ClassExtension/Hook/WritePropertyHook.php
 
 		-
-			message: '#^Parameter \#1 \$newScope of method ZEngine\\System\\Executor\:\:setFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
+			message: '#^Parameter \#1 \$scope of method ZEngine\\System\\Executor\:\:withFakeScope\(\) expects FFI\\CData\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/ClassExtension/Hook/WritePropertyHook.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1033,12 +1033,6 @@ parameters:
 			path: src/Reflection/ReflectionClass.php
 
 		-
-			message: '#^Cannot call method getRawClass\(\) on ZEngine\\Reflection\\ReflectionValue\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Reflection/ReflectionClass.php
-
-		-
 			message: '#^Cannot call method isSubclassOf\(\) on ZEngine\\Reflection\\ReflectionClass\|null\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/src/ClassExtension/Hook/GetDebugInfoHook.php
+++ b/src/ClassExtension/Hook/GetDebugInfoHook.php
@@ -111,9 +111,10 @@ class GetDebugInfoHook extends AbstractHook
         $isTemp = Core::new('int');
 
         // As we will play with EG(fake_scope), we won't be able to access private or protected members
-        $previousScope = Core::$executor->setFakeScope($scope);
-        $rawArray      = ($originalHandler)($object, Core::addr($isTemp));
-        Core::$executor->setFakeScope($previousScope);
+        $rawArray = Core::$executor->withFakeScope(
+            $scope,
+            static fn() => ($originalHandler)($object, Core::addr($isTemp)),
+        );
 
         if ($rawArray === null) {
             return [];

--- a/src/ClassExtension/Hook/GetPropertiesForHook.php
+++ b/src/ClassExtension/Hook/GetPropertiesForHook.php
@@ -100,10 +100,9 @@ class GetPropertiesForHook extends AbstractHook
         $object  = $this->object;
         $purpose = $this->purpose;
 
-        $previousScope = Core::$executor->setFakeScope($object->ce);
-        $result        = ($originalHandler)($object, $purpose);
-        Core::$executor->setFakeScope($previousScope);
-
-        return $result;
+        return Core::$executor->withFakeScope(
+            $object->ce,
+            static fn() => ($originalHandler)($object, $purpose),
+        );
     }
 }

--- a/src/ClassExtension/Hook/GetPropertyPointerHook.php
+++ b/src/ClassExtension/Hook/GetPropertyPointerHook.php
@@ -66,10 +66,9 @@ class GetPropertyPointerHook extends AbstractPropertyHook
         $type      = $this->type;
         $cacheSlot = $this->cacheSlot;
 
-        $previousScope = Core::$executor->setFakeScope($object->ce);
-        $result        = ($originalHandler)($object, $member, $type, $cacheSlot);
-        Core::$executor->setFakeScope($previousScope);
-
-        return $result;
+        return Core::$executor->withFakeScope(
+            $object->ce,
+            static fn() => ($originalHandler)($object, $member, $type, $cacheSlot),
+        );
     }
 }

--- a/src/ClassExtension/Hook/HasPropertyHook.php
+++ b/src/ClassExtension/Hook/HasPropertyHook.php
@@ -72,10 +72,9 @@ class HasPropertyHook extends AbstractPropertyHook
         $type      = $this->type;
         $cacheSlot = $this->cacheSlot;
 
-        $previousScope = Core::$executor->setFakeScope($object->ce);
-        $result        = ($originalHandler)($object, $member, $type, $cacheSlot);
-        Core::$executor->setFakeScope($previousScope);
-
-        return $result;
+        return Core::$executor->withFakeScope(
+            $object->ce,
+            static fn() => ($originalHandler)($object, $member, $type, $cacheSlot),
+        );
     }
 }

--- a/src/ClassExtension/Hook/ReadPropertyHook.php
+++ b/src/ClassExtension/Hook/ReadPropertyHook.php
@@ -82,9 +82,10 @@ class ReadPropertyHook extends AbstractPropertyHook
         $cacheSlot = $this->cacheSlot;
         $rv        = $this->rv;
 
-        $previousScope = Core::$executor->setFakeScope($object->ce);
-        $result        = ($originalHandler)($object, $member, $type, $cacheSlot, $rv);
-        Core::$executor->setFakeScope($previousScope);
+        $result = Core::$executor->withFakeScope(
+            $object->ce,
+            static fn() => ($originalHandler)($object, $member, $type, $cacheSlot, $rv),
+        );
 
         ReflectionValue::fromValueEntry($result)->getNativeValue($phpResult);
 

--- a/src/ClassExtension/Hook/UnsetPropertyHook.php
+++ b/src/ClassExtension/Hook/UnsetPropertyHook.php
@@ -55,8 +55,9 @@ class UnsetPropertyHook extends AbstractPropertyHook
             throw new \LogicException('Unset property hook expects a calling frame with a bound $this');
         }
 
-        $previousScope = Core::$executor->setFakeScope($callerThis->getRawObject()->ce);
-        ($originalHandler)($object, $member, $cacheSlot);
-        Core::$executor->setFakeScope($previousScope);
+        Core::$executor->withFakeScope(
+            $callerThis->getRawObject()->ce,
+            static fn() => ($originalHandler)($object, $member, $cacheSlot),
+        );
     }
 }

--- a/src/ClassExtension/Hook/WritePropertyHook.php
+++ b/src/ClassExtension/Hook/WritePropertyHook.php
@@ -82,10 +82,9 @@ class WritePropertyHook extends AbstractPropertyHook
         $value     = $this->value;
         $cacheSlot = $this->cacheSlot;
 
-        $previousScope = Core::$executor->setFakeScope($object->ce);
-        $result        = ($originalHandler)($object, $member, $value, $cacheSlot);
-        Core::$executor->setFakeScope($previousScope);
-
-        return $result;
+        return Core::$executor->withFakeScope(
+            $object->ce,
+            static fn() => ($originalHandler)($object, $member, $value, $cacheSlot),
+        );
     }
 }

--- a/src/Core.php
+++ b/src/Core.php
@@ -970,20 +970,18 @@ class Core
 
         // Unpublish generated global functions while writing the engine is still safe. Their
         // buckets point at a zend_function embedded in an immortalized closure object, so the
-        // table destructor (zend_function_dtor) must NOT run over them - delete each entry with
-        // the destructor disabled, exactly like ReflectionMethod::fromHookCData() does.
+        // table destructor (zend_function_dtor) must NOT run over them - each entry goes out
+        // through HashTable::deleteWithoutDestructor(), which disables the destructor for the
+        // duration of the delete and restores it even if the delete fails.
         if (self::$generatedFunctions !== [] && isset(self::$executor)) {
             $functionTable = self::$executor->functionTable;
-            $rawTable      = $functionTable->getRawValue();
-            $previousDtor  = $rawTable->pDestructor;
-
-            $rawTable->pDestructor = null;
             foreach (array_keys(self::$generatedFunctions) as $functionName) {
+                // zend_hash_del() reports an absent key as a failure, which delete() turns
+                // into an exception - only remove what is actually still published
                 if ($functionTable->find($functionName) !== null) {
-                    $functionTable->delete($functionName);
+                    $functionTable->deleteWithoutDestructor($functionName);
                 }
             }
-            $rawTable->pDestructor = $previousDtor;
         }
         self::$generatedFunctions = [];
 

--- a/src/HotSwap/HotSwap.php
+++ b/src/HotSwap/HotSwap.php
@@ -225,16 +225,9 @@ final class HotSwap
      */
     private static function unpublishClassEntry(string $lowerName): void
     {
-        $classTable = Core::$executor->classTable;
-        $rawTable   = $classTable->getRawValue();
-
-        $previousDestructor    = $rawTable->pDestructor;
-        $rawTable->pDestructor = null;
-        try {
-            $classTable->delete($lowerName);
-        } finally {
-            $rawTable->pDestructor = $previousDestructor;
-        }
+        // The table destructor is disabled around the delete so the bucket removal
+        // releases nothing - the class entry survives and is republished afterwards
+        Core::$executor->classTable->deleteWithoutDestructor($lowerName);
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -283,7 +283,10 @@ class ReflectionClass extends NativeReflectionClass
             if (!interface_exists($interfaceName)) {
                 throw new \ReflectionException("Interface {$interfaceName} was not found");
             }
-            $classValueEntry   = Core::$executor->classTable->find(strtolower($interfaceName));
+            $classValueEntry = Core::$executor->classTable->find(strtolower($interfaceName));
+            if ($classValueEntry === null) {
+                throw new \ReflectionException("Interface {$interfaceName} was not found in the engine");
+            }
             $interfaceClass    = $classValueEntry->getRawClass();
             $memory[$position] = $interfaceClass;
         }

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -149,7 +149,6 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
         // declaring class, and no shared engine structure is ever written.
         $boardName   = get_class(self::publicationBoard());
         $methodTable = (new ReflectionClass($boardName))->getMethodTable();
-        $boardTable  = $methodTable->getRawValue();
 
         // The temporary container is released right after the engine copied it into a bucket
         $rawFunction = Core::cast('zend_function *', $functionEntry)[0];
@@ -174,10 +173,7 @@ class ReflectionMethod extends NativeReflectionMethod implements FunctionLikeInt
             // Unpublish the transient entry without destroying the hook function: the table
             // destructor (zend_function_dtor) is disabled around the delete, so the bucket
             // removal releases nothing - the hook stays owned by zend_property_info.hooks
-            $previousDestructor      = $boardTable->pDestructor;
-            $boardTable->pDestructor = null;
-            $methodTable->delete($lowerName);
-            $boardTable->pDestructor = $previousDestructor;
+            $methodTable->deleteWithoutDestructor($lowerName);
         }
     }
 

--- a/src/System/Executor.php
+++ b/src/System/Executor.php
@@ -103,6 +103,32 @@ class Executor
     }
 
     /**
+     * Runs the given callback under a temporary fake scope, restoring the previous one afterwards
+     *
+     * EG(fake_scope) drives the visibility checks of the engine's default object handlers, so it
+     * is request-global state that must be handed back no matter how the callback leaves: a
+     * throwing __get(), a typed-property error or an uninitialized readonly access would
+     * otherwise leave the whole rest of the request running under a foreign scope. Restoration
+     * therefore happens in a finally block, and this helper is the only supported way to install
+     * a temporary scope - never pair setFakeScope() calls by hand.
+     *
+     * @param \FFI\CData|null $scope   Class entry to impersonate, or null to drop the fake scope
+     * @param \Closure        $body    Callback to invoke while the fake scope is installed
+     *
+     * @return mixed Whatever the callback returned
+     */
+    public function withFakeScope(?object $scope, \Closure $body): mixed
+    {
+        $previousScope = $this->setFakeScope($scope);
+
+        try {
+            return $body();
+        } finally {
+            $this->setFakeScope($previousScope);
+        }
+    }
+
+    /**
      * Checks if the engine carries an exception in flight (EG(exception) != NULL)
      *
      * Memory contract: pure pointer comparison, no refcount changes.

--- a/src/Type/ObjectEntry.php
+++ b/src/Type/ObjectEntry.php
@@ -57,8 +57,6 @@ class ObjectEntry implements ReferenceCountedInterface
     use ReferenceCountedTrait;
     use ReleasableTrait;
 
-    private HashTable $properties;
-
     /**
      * @var zend_object Typed view of the wrapped engine object; the runtime value is
      *                  the raw FFI\CData handle (see stubs/zend-engine-structs.php)
@@ -352,8 +350,12 @@ class ObjectEntry implements ReferenceCountedInterface
             'handle'   => $this->getHandle(),
             'refcount' => $this->getReferenceCount(),
         ];
-        if (isset($this->properties)) {
-            $info['properties'] = $this->properties;
+        // Resolved from the live pointer on every dump: setDynamicPropertiesPointer() may
+        // have replaced (or dropped) the table since this entry was built, and a cached
+        // wrapper would then dump a stale or already-freed HashTable
+        $properties = $this->getDynamicPropertiesPointer();
+        if ($properties !== null) {
+            $info['properties'] = HashTable::fromCData($properties);
         }
 
         return $info;
@@ -391,10 +393,6 @@ class ObjectEntry implements ReferenceCountedInterface
     {
         /** @var zend_object $pointer Narrowed to the stub view at the owning boundary */
         $this->pointer = $pointer;
-        $properties    = $this->pointer->properties;
-        if ($properties !== null) {
-            $this->properties = HashTable::fromCData($properties);
-        }
     }
 
     /**


### PR DESCRIPTION
Four related fixes where engine-global state could be left corrupted if an operation threw halfway through, plus one stale-cache read.

## 1. `EG(fake_scope)` is never restored when the original handler throws

Seven property hooks paired `setFakeScope()` calls by hand:

```php
$previousScope = Core::$executor->setFakeScope($object->ce);
$result        = ($originalHandler)(...);
Core::$executor->setFakeScope($previousScope);
```

Any throw from the original handler — a throwing `__get()`, a typed-property error, an uninitialized readonly access — skips the restoring call and leaves `EG(fake_scope)` pointing at a foreign class entry for the **rest of the request**, silently changing every visibility check that follows.

`Executor::withFakeScope(?CData $scope, Closure $body)` (`src/System/Executor.php`) now owns the install/restore pair and restores in a `finally`. All seven call sites go through it, so the unsafe pattern cannot be written again:

- `src/ClassExtension/Hook/ReadPropertyHook.php`
- `src/ClassExtension/Hook/WritePropertyHook.php`
- `src/ClassExtension/Hook/HasPropertyHook.php`
- `src/ClassExtension/Hook/UnsetPropertyHook.php`
- `src/ClassExtension/Hook/GetPropertyPointerHook.php`
- `src/ClassExtension/Hook/GetPropertiesForHook.php`
- `src/ClassExtension/Hook/GetDebugInfoHook.php`

The baselined `argument.type` entries for those call sites are renamed to the new callee — same pre-existing `CData` typing gap, no new baseline entries.

## 2. Hand-rolled `pDestructor` disable/restore duplicating `HashTable::deleteWithoutDestructor()`

Three sites reimplemented the "null out `pDestructor`, delete, put it back" dance that `HashTable::deleteWithoutDestructor()` (`src/Type/HashTable.php:299`) already performs with a `finally`:

- **`src/Reflection/ReflectionMethod.php`** (`fromHookCData`) did it *inside* its `finally` block with **no** `try`, so a failing `delete()` left the publication board's function table with a `NULL` destructor for the rest of the process — every later bucket removal there would leak. The now-unused `$boardTable = $methodTable->getRawValue()` handle is dropped with it.
- **`src/HotSwap/HotSwap.php`** (`unpublishClassEntry`) duplicated the logic; `ClassDelta` already used the helper, so this just follows the existing precedent.
- **`src/Core.php`** (`shutdown()`) duplicated it around the generated-function unpublish loop.

Semantics are unchanged — the destructor is still disabled for the delete, so the payload (a shared `zend_function`, a rehomed class entry, a function embedded in an immortalized closure) survives the bucket removal. The `find() !== null` pre-check in `Core::shutdown()` is **kept**: `zend_hash_del()` reports an absent key as `FAILURE`, which `HashTable::delete()` turns into a `RuntimeException`, so the guard is load-bearing.

## 3. Missing null guard in `ReflectionClass::addInterfaces()`

`src/Reflection/ReflectionClass.php` called `getRawClass()` on the result of `HashTable::find()` without checking for `null`. The `interface_exists()` pre-check is not sufficient: it accepts a leading-backslash name (`"\Countable"`) that `strtolower()` never turns into a class-table key, so the lookup misses and the method dies with a call-on-null instead of a `ReflectionException` — halfway through, with a freshly allocated interface buffer already tracked.

Adds the same guard every sibling lookup carries (`setParent()`, `ObjectEntry`, `ClosureEntry`, …). This retires one baseline entry, removed by hand from `phpstan-baseline.neon`.

## 4. Stale shadow property in `ObjectEntry`

`src/Type/ObjectEntry.php` cached a `HashTable` wrapper over `zobj->properties` once in `initLowLevelStructures()`, but `setDynamicPropertiesPointer()` rewrites that very field without touching the shadow copy. The only reader, `__debugInfo()`, therefore dumped a table the object no longer owns — possibly one already freed, i.e. a dangling read from a debug dump. Objects whose table was built *after* the entry (the common lazy case) were missing from the dump entirely.

The field is removed and the table resolved from the live pointer at dump time, so `ObjectEntry` keeps exactly one source of truth for `zobj->properties`.

## Validation

**Local test execution was impossible in this container**: it runs PHP 8.5.9 while this branch targets PHP 8.4. Per AGENTS.md's non-negotiable version-matching rule, nothing that reaches `Core::init()` may be executed against a mismatched minor, so no test — and no code touching engine memory — was run here. **CI must provide the test signal for this PR.**

Validation performed was static only, and both gates are clean:

- `composer phpstan` (level max) — no errors
- `composer cs:check` (php-cs-fixer, `@PER-CS2.0`) — no fixable files

No generated artifacts (`include/`, `stubs/`, `.phpstorm.meta.php`) were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG)_