### PR TITLE
refactor: finish the Core::sizeOfType() migration and hoist loop-invariant sizes

### DIFF
--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -145,7 +145,7 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
 
         $globalType = static::globalType();
         if ($globalType !== null) {
-            $module->globals_size = Core::sizeof(Core::type($globalType));
+            $module->globals_size = Core::sizeOfType($globalType);
             if (\ZEND_THREAD_SAFE) {
                 // On ZTS the entry carries a pointer to a ts_rsrc_id slot instead of the
                 // globals block: zend_startup_module_ex() passes it to ts_allocate_id(),

--- a/src/Memory/PersistentGraphCloner.php
+++ b/src/Memory/PersistentGraphCloner.php
@@ -15,6 +15,8 @@ namespace ZEngine\Memory;
 
 use FFI\CData;
 use ZEngine\Core;
+use ZEngine\Generated\HashTable;
+use ZEngine\Generated\zval;
 use ZEngine\Reflection\ReflectionClass;
 use ZEngine\Reflection\ReflectionValue;
 use ZEngine\Type\ObjectEntry;
@@ -344,9 +346,9 @@ final class PersistentGraphCloner
         // through an object cycle
         $this->arrayMap[$address] = $rawTable;
         $this->arrays[]           = $rawTable;
-        $this->bytes += Core::sizeof(Core::type('HashTable'));
+        $this->bytes += Core::sizeOfType(HashTable::class);
 
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         $this->walkArray($sourceArray, function (int|string $key, CData $value) use ($table, $zvalSize): void {
             // Start from a byte copy of the source element, then rewrite it in place;
             // the engine copies the fixed-up bytes into its own bucket on insert

--- a/src/OpCache/CacheMetaInfo.php
+++ b/src/OpCache/CacheMetaInfo.php
@@ -96,7 +96,7 @@ final class CacheMetaInfo
      */
     public static function byteSize(): int
     {
-        $size = Core::sizeof(Core::type('zend_file_cache_metainfo'));
+        $size = Core::sizeOfType(zend_file_cache_metainfo::class);
         if ($size < 1) {
             throw OpCacheException::unsupportedPayload('zend_file_cache_metainfo has no size in the loaded header');
         }

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -326,8 +326,9 @@ final class PayloadRelocator
         $dataAddress = $this->unPtr($ht, 'arData');
         $used        = $ht->nNumUsed;
         if (($ht->u->flags & self::HASH_FLAG_PACKED) !== 0) {
+            $zvalSize = Core::sizeOfType(zval::class);
             for ($i = 0; $i < $used; $i++) {
-                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * Core::sizeOfType(zval::class));
+                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * $zvalSize);
                 if ($zval->u1->v->type !== 0) {
                     $each($zval);
                 }
@@ -361,8 +362,9 @@ final class PayloadRelocator
         $dataAddress = $this->serPtr($ht, 'arData');
         $used        = $ht->nNumUsed;
         if (($ht->u->flags & self::HASH_FLAG_PACKED) !== 0) {
+            $zvalSize = Core::sizeOfType(zval::class);
             for ($i = 0; $i < $used; $i++) {
-                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * Core::sizeOfType(zval::class));
+                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * $zvalSize);
                 if ($zval->u1->v->type !== 0) {
                     $each($zval);
                 }

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -16,6 +16,16 @@ namespace ZEngine\OpCache;
 use FFI;
 use FFI\CData;
 use ZEngine\Core;
+use ZEngine\Generated\Bucket;
+use ZEngine\Generated\zend_arg_info;
+use ZEngine\Generated\zend_ast;
+use ZEngine\Generated\zend_ast_list;
+use ZEngine\Generated\zend_ast_ref;
+use ZEngine\Generated\zend_attribute_arg;
+use ZEngine\Generated\zend_class_name;
+use ZEngine\Generated\zend_early_binding;
+use ZEngine\Generated\zend_string;
+use ZEngine\Generated\zval;
 
 /**
  * Turns the position-independent file-cache payload into a live in-memory
@@ -108,7 +118,7 @@ final class PayloadRelocator
         $this->size           = $metaInfo->memSize();
         $this->strSectionBase = $this->base + $this->size;
         // _ZSTR_HEADER_SIZE = sizeof(zend_string) - sizeof(char) (the flexible val[1] member)
-        $this->zendStringHeaderSize = Core::sizeof(Core::type('zend_string')) - 1;
+        $this->zendStringHeaderSize = Core::sizeOfType(zend_string::class) - 1;
     }
 
     /**
@@ -317,7 +327,7 @@ final class PayloadRelocator
         $used        = $ht->nNumUsed;
         if (($ht->u->flags & self::HASH_FLAG_PACKED) !== 0) {
             for ($i = 0; $i < $used; $i++) {
-                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * Core::sizeof(Core::type('zval')));
+                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * Core::sizeOfType(zval::class));
                 if ($zval->u1->v->type !== 0) {
                     $each($zval);
                 }
@@ -325,7 +335,7 @@ final class PayloadRelocator
 
             return;
         }
-        $bucketSize = Core::sizeof(Core::type('Bucket'));
+        $bucketSize = Core::sizeOfType(Bucket::class);
         for ($i = 0; $i < $used; $i++) {
             $bucket = Core::pointerAtAddress('Bucket *', $dataAddress + $i * $bucketSize);
             if ($bucket->val->u1->v->type !== 0) {
@@ -352,7 +362,7 @@ final class PayloadRelocator
         $used        = $ht->nNumUsed;
         if (($ht->u->flags & self::HASH_FLAG_PACKED) !== 0) {
             for ($i = 0; $i < $used; $i++) {
-                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * Core::sizeof(Core::type('zval')));
+                $zval = Core::pointerAtAddress('zval *', $dataAddress + $i * Core::sizeOfType(zval::class));
                 if ($zval->u1->v->type !== 0) {
                     $each($zval);
                 }
@@ -360,7 +370,7 @@ final class PayloadRelocator
 
             return;
         }
-        $bucketSize = Core::sizeof(Core::type('Bucket'));
+        $bucketSize = Core::sizeOfType(Bucket::class);
         for ($i = 0; $i < $used; $i++) {
             $bucket = Core::pointerAtAddress('Bucket *', $dataAddress + $i * $bucketSize);
             if ($bucket->val->u1->v->type !== 0) {
@@ -396,7 +406,7 @@ final class PayloadRelocator
             case self::IS_CONSTANT_AST:
                 if (!$this->isUnserialized($this->ptrValue($zval->value, 'ast'))) {
                     $astRef = $this->unPtr($zval->value, 'ast');
-                    $this->unserializeAst($astRef + Core::sizeof(Core::type('zend_ast_ref')));
+                    $this->unserializeAst($astRef + Core::sizeOfType(zend_ast_ref::class));
                 }
                 break;
             case self::IS_INDIRECT:
@@ -428,7 +438,7 @@ final class PayloadRelocator
             case self::IS_CONSTANT_AST:
                 if (!$this->isSerialized($this->ptrValue($zval->value, 'ast'))) {
                     $astRef = $this->serPtr($zval->value, 'ast');
-                    $this->serializeAst($astRef + Core::sizeof(Core::type('zend_ast_ref')));
+                    $this->serializeAst($astRef + Core::sizeOfType(zend_ast_ref::class));
                 }
                 break;
             case self::IS_INDIRECT:
@@ -451,10 +461,10 @@ final class PayloadRelocator
         }
         if (($kind >> self::ZEND_AST_IS_LIST_SHIFT & 1) !== 0) {
             $list      = Core::pointerAtAddress('zend_ast_list *', $astAddress);
-            $childBase = $astAddress + Core::sizeof(Core::type('zend_ast_list')) - PHP_INT_SIZE;
+            $childBase = $astAddress + Core::sizeOfType(zend_ast_list::class) - PHP_INT_SIZE;
             $count     = $list->children;
         } else {
-            $childBase = $astAddress + Core::sizeof(Core::type('zend_ast')) - PHP_INT_SIZE;
+            $childBase = $astAddress + Core::sizeOfType(zend_ast::class) - PHP_INT_SIZE;
             $count     = $kind >> self::ZEND_AST_CHILDREN_SHIFT;
         }
         for ($i = 0; $i < $count; $i++) {
@@ -478,10 +488,10 @@ final class PayloadRelocator
         }
         if (($kind >> self::ZEND_AST_IS_LIST_SHIFT & 1) !== 0) {
             $list      = Core::pointerAtAddress('zend_ast_list *', $astAddress);
-            $childBase = $astAddress + Core::sizeof(Core::type('zend_ast_list')) - PHP_INT_SIZE;
+            $childBase = $astAddress + Core::sizeOfType(zend_ast_list::class) - PHP_INT_SIZE;
             $count     = $list->children;
         } else {
-            $childBase = $astAddress + Core::sizeof(Core::type('zend_ast')) - PHP_INT_SIZE;
+            $childBase = $astAddress + Core::sizeOfType(zend_ast::class) - PHP_INT_SIZE;
             $count     = $kind >> self::ZEND_AST_CHILDREN_SHIFT;
         }
         for ($i = 0; $i < $count; $i++) {
@@ -536,7 +546,7 @@ final class PayloadRelocator
         $attr = Core::pointerAtAddress('zend_attribute *', $this->unPtr($zval->value, 'ptr'));
         $this->unStr($attr, 'name');
         $this->unStr($attr, 'lcname');
-        $argSize = Core::sizeof(Core::type('zend_attribute_arg'));
+        $argSize = Core::sizeOfType(zend_attribute_arg::class);
         $argBase = Core::addressOf($attr->args);
         for ($i = 0; $i < $attr->argc; $i++) {
             $arg = Core::pointerAtAddress('zend_attribute_arg *', $argBase + $i * $argSize);
@@ -554,7 +564,7 @@ final class PayloadRelocator
         $attr    = Core::pointerAtAddress('zend_attribute *', $address);
         $this->serStr($attr, 'name');
         $this->serStr($attr, 'lcname');
-        $argSize = Core::sizeof(Core::type('zend_attribute_arg'));
+        $argSize = Core::sizeOfType(zend_attribute_arg::class);
         $argBase = Core::addressOf($attr->args);
         for ($i = 0; $i < $attr->argc; $i++) {
             $arg = Core::pointerAtAddress('zend_attribute_arg *', $argBase + $i * $argSize);
@@ -648,7 +658,7 @@ final class PayloadRelocator
         }
         if ($this->ptrValue($opArray, 'literals') !== 0) {
             $address  = $this->unPtr($opArray, 'literals');
-            $zvalSize = Core::sizeof(Core::type('zval'));
+            $zvalSize = Core::sizeOfType(zval::class);
             for ($i = 0; $i < $opArray->last_literal; $i++) {
                 $this->unserializeZval(Core::pointerAtAddress('zval *', $address + $i * $zvalSize));
             }
@@ -711,7 +721,7 @@ final class PayloadRelocator
         }
         if ($this->ptrValue($opArray, 'literals') !== 0) {
             $address  = $this->serPtr($opArray, 'literals');
-            $zvalSize = Core::sizeof(Core::type('zval'));
+            $zvalSize = Core::sizeOfType(zval::class);
             for ($i = 0; $i < $opArray->last_literal; $i++) {
                 $this->serializeZval(Core::pointerAtAddress('zval *', $address + $i * $zvalSize));
             }
@@ -760,7 +770,7 @@ final class PayloadRelocator
             return;
         }
         $address       = $this->unPtr($opArray, 'arg_info');
-        $argInfoSize   = Core::sizeof(Core::type('zend_arg_info'));
+        $argInfoSize   = Core::sizeOfType(zend_arg_info::class);
         [$start, $end] = $this->argInfoBounds($opArray);
         for ($i = $start; $i < $end; $i++) {
             $arg = Core::pointerAtAddress('zend_arg_info *', $address + $i * $argInfoSize);
@@ -780,7 +790,7 @@ final class PayloadRelocator
             return;
         }
         $address       = $this->serPtr($opArray, 'arg_info');
-        $argInfoSize   = Core::sizeof(Core::type('zend_arg_info'));
+        $argInfoSize   = Core::sizeOfType(zend_arg_info::class);
         [$start, $end] = $this->argInfoBounds($opArray);
         for ($i = $start; $i < $end; $i++) {
             $arg = Core::pointerAtAddress('zend_arg_info *', $address + $i * $argInfoSize);
@@ -925,7 +935,7 @@ final class PayloadRelocator
             return;
         }
         $address  = $this->unPtr($ce, $field);
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         for ($i = 0; $i < $count; $i++) {
             $this->unserializeZval(Core::pointerAtAddress('zval *', $address + $i * $zvalSize));
         }
@@ -940,7 +950,7 @@ final class PayloadRelocator
             return;
         }
         $address  = $this->serPtr($ce, $field);
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         for ($i = 0; $i < $count; $i++) {
             $this->serializeZval(Core::pointerAtAddress('zval *', $address + $i * $zvalSize));
         }
@@ -987,7 +997,7 @@ final class PayloadRelocator
     private function unserializeClassNames(object $ce, string $field, int $count): void
     {
         $address  = $this->unPtr($ce, $field);
-        $nameSize = Core::sizeof(Core::type('zend_class_name'));
+        $nameSize = Core::sizeOfType(zend_class_name::class);
         for ($i = 0; $i < $count; $i++) {
             $name = Core::pointerAtAddress('zend_class_name *', $address + $i * $nameSize);
             $this->unStr($name, 'name');
@@ -1001,7 +1011,7 @@ final class PayloadRelocator
     private function serializeClassNames(object $ce, string $field, int $count): void
     {
         $address  = $this->serPtr($ce, $field);
-        $nameSize = Core::sizeof(Core::type('zend_class_name'));
+        $nameSize = Core::sizeOfType(zend_class_name::class);
         for ($i = 0; $i < $count; $i++) {
             $name = Core::pointerAtAddress('zend_class_name *', $address + $i * $nameSize);
             $this->serStr($name, 'name');
@@ -1175,7 +1185,7 @@ final class PayloadRelocator
             return;
         }
         $address     = $this->unPtr($script, 'early_bindings');
-        $bindingSize = Core::sizeof(Core::type('zend_early_binding'));
+        $bindingSize = Core::sizeOfType(zend_early_binding::class);
         for ($i = 0; $i < $script->num_early_bindings; $i++) {
             $binding = Core::pointerAtAddress('zend_early_binding *', $address + $i * $bindingSize);
             $this->unStr($binding, 'lcname');
@@ -1193,7 +1203,7 @@ final class PayloadRelocator
             return;
         }
         $address     = $this->serPtr($script, 'early_bindings');
-        $bindingSize = Core::sizeof(Core::type('zend_early_binding'));
+        $bindingSize = Core::sizeOfType(zend_early_binding::class);
         for ($i = 0; $i < $script->num_early_bindings; $i++) {
             $binding = Core::pointerAtAddress('zend_early_binding *', $address + $i * $bindingSize);
             $this->serStr($binding, 'lcname');

--- a/src/Reflection/ClassSpecializer.php
+++ b/src/Reflection/ClassSpecializer.php
@@ -867,12 +867,13 @@ class ClassSpecializer
         $aliasList = $sourceEntry->trait_aliases;
         if ($aliasList !== null) {
             assert($aliasList instanceof CData);
-            $aliases = [];
+            $aliasSize = Core::sizeOfType(zend_trait_alias::class);
+            $aliases   = [];
             for ($index = 0; $aliasList[$index] !== null; $index++) {
                 $sourceAlias = $aliasList[$index];
                 assert($sourceAlias instanceof CData);
                 $aliasCopy = Core::new('zend_trait_alias', false);
-                Core::memcpy($aliasCopy, $sourceAlias, Core::sizeOfType(zend_trait_alias::class));
+                Core::memcpy($aliasCopy, $sourceAlias, $aliasSize);
                 $aliasMethodRef = $aliasCopy->trait_method;
                 assert($aliasMethodRef instanceof CData);
                 $this->addTraitMethodReferenceNames($aliasMethodRef);
@@ -889,16 +890,16 @@ class ClassSpecializer
         $precedenceList = $sourceEntry->trait_precedences;
         if ($precedenceList !== null) {
             assert($precedenceList instanceof CData);
-            $pointerSize = Core::sizeOfType('zend_string *');
-            $precedences = [];
+            $pointerSize    = Core::sizeOfType('zend_string *');
+            $precedenceSize = Core::sizeOfType(zend_trait_precedence::class);
+            $precedences    = [];
             for ($index = 0; $precedenceList[$index] !== null; $index++) {
                 $sourcePrecedence = $precedenceList[$index];
                 assert($sourcePrecedence instanceof CData);
                 $totalExcludes = $sourcePrecedence->num_excludes;
                 assert(is_int($totalExcludes));
-                $structSize = Core::sizeOfType(zend_trait_precedence::class)
-                    + max(0, $totalExcludes - 1) * $pointerSize;
-                $memory = Core::new("char[{$structSize}]", false);
+                $structSize = $precedenceSize + max(0, $totalExcludes - 1) * $pointerSize;
+                $memory     = Core::new("char[{$structSize}]", false);
                 Core::memcpy($memory, $sourcePrecedence, $structSize);
                 $precedenceCopy      = Core::cast('zend_trait_precedence *', $memory);
                 $precedenceMethodRef = $precedenceCopy->trait_method;
@@ -1474,6 +1475,7 @@ class ClassSpecializer
         $newPropertiesTable = $newEntry->properties_info;
         assert($newPropertiesTable instanceof CData);
         $newTable    = HashTable::fromCData(Core::addr($newPropertiesTable));
+        $infoSize    = Core::sizeOfType(zend_property_info::class);
         $propertyMap = [];
         $ownCopies   = [];
 
@@ -1485,7 +1487,7 @@ class ClassSpecializer
 
             if (Core::addressOf($declaringClass) === $sourceAddress) {
                 $infoCopy = Core::new('zend_property_info', false);
-                Core::memcpy($infoCopy, $sourceInfo, Core::sizeOfType(zend_property_info::class));
+                Core::memcpy($infoCopy, $sourceInfo, $infoSize);
                 $infoCopy->ce      = $newEntry;
                 $propertyNameValue = $infoCopy->name;
                 assert($propertyNameValue instanceof CData);
@@ -1581,7 +1583,8 @@ class ClassSpecializer
         $sourceAddress     = Core::addressOf($sourceEntry);
         $newConstantsTable = $newEntry->constants_table;
         assert($newConstantsTable instanceof CData);
-        $newTable = HashTable::fromCData(Core::addr($newConstantsTable));
+        $newTable     = HashTable::fromCData(Core::addr($newConstantsTable));
+        $constantSize = Core::sizeOfType(zend_class_constant::class);
 
         foreach ($this->constantsTable($sourceEntry) as $constantName => $constantValue) {
             assert(is_string($constantName));
@@ -1598,7 +1601,7 @@ class ClassSpecializer
 
             if ($isOwnDeclaration || $isOwnedValue) {
                 $constantCopy = Core::new('zend_class_constant', false);
-                Core::memcpy($constantCopy, $sourceConstant, Core::sizeOfType(zend_class_constant::class));
+                Core::memcpy($constantCopy, $sourceConstant, $constantSize);
                 if ($isOwnDeclaration) {
                     $constantCopy->ce = $newEntry;
                 }

--- a/src/Reflection/ClassSpecializer.php
+++ b/src/Reflection/ClassSpecializer.php
@@ -15,6 +15,17 @@ namespace ZEngine\Reflection;
 
 use FFI\CData;
 use ZEngine\Core;
+use ZEngine\Generated\zend_arg_info;
+use ZEngine\Generated\zend_class_constant;
+use ZEngine\Generated\zend_class_entry;
+use ZEngine\Generated\zend_class_name;
+use ZEngine\Generated\zend_op;
+use ZEngine\Generated\zend_op_array;
+use ZEngine\Generated\zend_property_info;
+use ZEngine\Generated\zend_trait_alias;
+use ZEngine\Generated\zend_trait_precedence;
+use ZEngine\Generated\zend_type;
+use ZEngine\Generated\zval;
 use ZEngine\System\OpCode;
 use ZEngine\Type\HashTable;
 use ZEngine\Type\OpLine;
@@ -686,7 +697,7 @@ class ClassSpecializer
         // request allocator reclaims the block at request end
         $entryStruct = Core::new('zend_class_entry', false);
         $newEntry    = Core::cast('zend_class_entry *', Core::addr($entryStruct));
-        Core::memcpy($newEntry, $sourceEntry, Core::sizeof(Core::type('zend_class_entry')));
+        Core::memcpy($newEntry, $sourceEntry, Core::sizeOfType(zend_class_entry::class));
 
         // Identity: fresh refcount, owned name, no shared-memory storage flags
         $newEntry->refcount = 1;
@@ -794,7 +805,7 @@ class ClassSpecializer
      */
     private function copyZvalTable(object $sourceTable, int $totalSlots): object
     {
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         $memory   = Core::new("zval[{$totalSlots}]", false);
         Core::memcpy($memory, $sourceTable, $zvalSize * $totalSlots);
         for ($slot = 0; $slot < $totalSlots; $slot++) {
@@ -819,7 +830,7 @@ class ClassSpecializer
         if ($totalInterfaces === 0) {
             return;
         }
-        $itemSize = Core::sizeof(Core::type('zend_class_entry *'));
+        $itemSize = Core::sizeOfType('zend_class_entry *');
         $memory   = Core::new("zend_class_entry *[{$totalInterfaces}]", false);
         Core::memcpy($memory, $sourceEntry->interfaces, $itemSize * $totalInterfaces);
         $newEntry->interfaces = Core::cast('zend_class_entry **', Core::addr($memory));
@@ -838,7 +849,7 @@ class ClassSpecializer
         $totalTraits = $sourceEntry->num_traits;
         assert(is_int($totalTraits));
         if ($totalTraits > 0) {
-            $itemSize = Core::sizeof(Core::type('zend_class_name'));
+            $itemSize = Core::sizeOfType(zend_class_name::class);
             $memory   = Core::new("zend_class_name[{$totalTraits}]", false);
             Core::memcpy($memory, $sourceEntry->trait_names, $itemSize * $totalTraits);
             for ($index = 0; $index < $totalTraits; $index++) {
@@ -861,7 +872,7 @@ class ClassSpecializer
                 $sourceAlias = $aliasList[$index];
                 assert($sourceAlias instanceof CData);
                 $aliasCopy = Core::new('zend_trait_alias', false);
-                Core::memcpy($aliasCopy, $sourceAlias, Core::sizeof(Core::type('zend_trait_alias')));
+                Core::memcpy($aliasCopy, $sourceAlias, Core::sizeOfType(zend_trait_alias::class));
                 $aliasMethodRef = $aliasCopy->trait_method;
                 assert($aliasMethodRef instanceof CData);
                 $this->addTraitMethodReferenceNames($aliasMethodRef);
@@ -878,14 +889,14 @@ class ClassSpecializer
         $precedenceList = $sourceEntry->trait_precedences;
         if ($precedenceList !== null) {
             assert($precedenceList instanceof CData);
-            $pointerSize = Core::sizeof(Core::type('zend_string *'));
+            $pointerSize = Core::sizeOfType('zend_string *');
             $precedences = [];
             for ($index = 0; $precedenceList[$index] !== null; $index++) {
                 $sourcePrecedence = $precedenceList[$index];
                 assert($sourcePrecedence instanceof CData);
                 $totalExcludes = $sourcePrecedence->num_excludes;
                 assert(is_int($totalExcludes));
-                $structSize = Core::sizeof(Core::type('zend_trait_precedence'))
+                $structSize = Core::sizeOfType(zend_trait_precedence::class)
                     + max(0, $totalExcludes - 1) * $pointerSize;
                 $memory = Core::new("char[{$structSize}]", false);
                 Core::memcpy($memory, $sourcePrecedence, $structSize);
@@ -1077,7 +1088,7 @@ class ClassSpecializer
         string $methodName,
     ): object {
         $opArrayCopy = Core::new('zend_op_array', false);
-        Core::memcpy($opArrayCopy, $sourceOpArray, Core::sizeof(Core::type('zend_op_array')));
+        Core::memcpy($opArrayCopy, $sourceOpArray, Core::sizeOfType(zend_op_array::class));
 
         // Share the compiled body through the op_array refcount; each holder owns one
         // reference on the display name (destroy_op_array releases it per holder)
@@ -1178,7 +1189,7 @@ class ClassSpecializer
             return;
         }
 
-        $entrySize  = Core::sizeof(Core::type('zend_arg_info'));
+        $entrySize  = Core::sizeOfType(zend_arg_info::class);
         $sourceArgs = $sourceOpArray->arg_info;
         assert($sourceArgs instanceof CData);
         // The allocation starts one entry before arg_info when a return entry exists
@@ -1324,7 +1335,7 @@ class ClassSpecializer
     {
         $sourceOpcodes = $sourceOpArray->opcodes;
         assert($sourceOpcodes instanceof CData);
-        $opcodeSize = Core::sizeof(Core::type('zend_op'));
+        $opcodeSize = Core::sizeOfType(zend_op::class);
         $memory     = Core::new("zend_op[{$total}]", false);
         Core::memcpy($memory, $sourceOpcodes, $total * $opcodeSize);
 
@@ -1474,7 +1485,7 @@ class ClassSpecializer
 
             if (Core::addressOf($declaringClass) === $sourceAddress) {
                 $infoCopy = Core::new('zend_property_info', false);
-                Core::memcpy($infoCopy, $sourceInfo, Core::sizeof(Core::type('zend_property_info')));
+                Core::memcpy($infoCopy, $sourceInfo, Core::sizeOfType(zend_property_info::class));
                 $infoCopy->ce      = $newEntry;
                 $propertyNameValue = $infoCopy->name;
                 assert($propertyNameValue instanceof CData);
@@ -1587,7 +1598,7 @@ class ClassSpecializer
 
             if ($isOwnDeclaration || $isOwnedValue) {
                 $constantCopy = Core::new('zend_class_constant', false);
-                Core::memcpy($constantCopy, $sourceConstant, Core::sizeof(Core::type('zend_class_constant')));
+                Core::memcpy($constantCopy, $sourceConstant, Core::sizeOfType(zend_class_constant::class));
                 if ($isOwnDeclaration) {
                     $constantCopy->ce = $newEntry;
                 }
@@ -1794,7 +1805,7 @@ class ClassSpecializer
         $totalTypes = $sourceList->num_types;
         assert(is_int($totalTypes));
 
-        $typeSize   = Core::sizeof(Core::type('zend_type'));
+        $typeSize   = Core::sizeOfType(zend_type::class);
         $baseOffset = Core::type('zend_type_list')->getStructFieldOffset('types');
         $blockSize  = $baseOffset + $totalTypes * $typeSize;
         $memory     = Core::new("char[{$blockSize}]", false);
@@ -1933,7 +1944,7 @@ class ClassSpecializer
         assert(is_int($functionFlags) && is_int($numberOfArgs));
         $firstIndex = ($functionFlags & Core::ZEND_ACC_HAS_RETURN_TYPE) !== 0 ? -1 : 0;
         $lastIndex  = $numberOfArgs - 1 + (($functionFlags & Core::ZEND_ACC_VARIADIC) !== 0 ? 1 : 0);
-        $entrySize  = Core::sizeof(Core::type('zend_arg_info'));
+        $entrySize  = Core::sizeOfType(zend_arg_info::class);
         for ($index = $firstIndex; $index <= $lastIndex; $index++) {
             $entry = Core::pointerAtAddress(
                 'zend_arg_info *',

--- a/src/Reflection/FunctionBodySwap.php
+++ b/src/Reflection/FunctionBodySwap.php
@@ -150,7 +150,7 @@ final class FunctionBodySwap
 
         // Replace the whole function with the donor-backed one (the donor structure
         // itself stays untouched - it keeps sole ownership of its own fields)
-        Core::memcpy($entry, $donor, Core::sizeof(Core::type('zend_function')));
+        Core::memcpy($entry, $donor, Core::sizeOfType(zend_function::class));
 
         // Restore the entry identity: the single owned reference on the previous name
         // stays with this entry, and the scope always survives (the donor was compiled

--- a/src/Reflection/FunctionLikeTrait.php
+++ b/src/Reflection/FunctionLikeTrait.php
@@ -489,7 +489,7 @@ trait FunctionLikeTrait
         $entryType = $this->isUserDefined() ? 'zend_arg_info' : 'zend_internal_arg_info';
         $entry     = Core::pointerAtAddress(
             "{$entryType} *",
-            Core::addressOf($argInfoTable) + $index * Core::sizeof(Core::type($entryType)),
+            Core::addressOf($argInfoTable) + $index * Core::sizeOfType($entryType),
         );
         $entryTypeStruct = $entry->type;
         assert($entryTypeStruct instanceof CData);

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -66,6 +66,8 @@ use ZEngine\ClassExtension\ObjectWritePropertyInterface;
 use ZEngine\Core;
 use ZEngine\Generated\zend_class_entry;
 use ZEngine\Generated\zend_class_name;
+use ZEngine\Generated\zend_object;
+use ZEngine\Generated\zend_trait_precedence;
 use ZEngine\Generated\zval;
 use ZEngine\OpCache\SharedMemoryException;
 use ZEngine\Type\ClosureEntry;
@@ -274,7 +276,7 @@ class ReflectionClass extends NativeReflectionClass
         $isPersistent = $this->isPersistentAllocation();
         $memory       = Core::trackedNew("zend_class_entry *[$numResultInterfaces]", $isPersistent);
 
-        $itemsSize = Core::sizeof(Core::type('zend_class_entry *'));
+        $itemsSize = Core::sizeOfType('zend_class_entry *');
         if ($totalInterfaces > 0) {
             Core::memcpy($memory, $this->pointer->interfaces, $itemsSize * $totalInterfaces);
         }
@@ -745,7 +747,7 @@ class ReflectionClass extends NativeReflectionClass
      */
     public function getDefaultPropertyValueOf(ReflectionProperty $property): ReflectionValue
     {
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         $slotBase = Core::type('zend_object')->getStructFieldOffset('properties_table');
         $slot     = intdiv($property->getOffset() - $slotBase, $zvalSize);
         $table    = $this->pointer->default_properties_table;
@@ -923,7 +925,7 @@ class ReflectionClass extends NativeReflectionClass
         $isPersistent = $this->isPersistentAllocation();
         $memory       = Core::trackedNew("zend_class_name [$numResultTraits]", $isPersistent);
 
-        $itemsSize = Core::sizeof(Core::type('zend_class_name'));
+        $itemsSize = Core::sizeOfType(zend_class_name::class);
         if ($totalTraits > 0) {
             Core::memcpy($memory, $this->pointer->trait_names, $itemsSize * $totalTraits);
         }
@@ -1232,8 +1234,8 @@ class ReflectionClass extends NativeReflectionClass
         // zend_trait_precedence embeds a flexible array of excluded names, so the block is
         // sized manually like the compiler does (one zend_string* slot is already part of
         // the structure itself)
-        $pointerSize = Core::sizeof(Core::type('zend_string *'));
-        $structSize  = Core::sizeof(Core::type('zend_trait_precedence')) + ($totalExcludes - 1) * $pointerSize;
+        $pointerSize = Core::sizeOfType('zend_string *');
+        $structSize  = Core::sizeOfType(zend_trait_precedence::class) + ($totalExcludes - 1) * $pointerSize;
         $memory      = Core::trackedNew("char[{$structSize}]", $isPersistent);
 
         $precedenceEntry = Core::cast('zend_trait_precedence *', $memory);
@@ -1691,7 +1693,7 @@ class ReflectionClass extends NativeReflectionClass
      */
     private function detachParentProperties(int $selfAddress): void
     {
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         $slotBase = Core::type('zend_object')->getStructFieldOffset('properties_table');
 
         // Partition properties_info into inherited entries and own instance/static definitions
@@ -2023,7 +2025,7 @@ class ReflectionClass extends NativeReflectionClass
         }
         $materialized = $this->getMaterializedStaticMembersTable();
         if ($materialized !== null) {
-            $zvalSize     = Core::sizeof(Core::type('zval'));
+            $zvalSize     = Core::sizeOfType(zval::class);
             $defaultTable = $this->pointer->default_static_members_table;
             $totalSlots   = $this->pointer->default_static_members_count;
             assert($defaultTable instanceof CData && is_int($totalSlots));
@@ -2081,7 +2083,7 @@ class ReflectionClass extends NativeReflectionClass
         }
         assert($infoTable instanceof CData);
         $selfAddress = Core::addressOf($this->pointer);
-        $zvalSize    = Core::sizeof(Core::type('zval'));
+        $zvalSize    = Core::sizeOfType(zval::class);
         $slotBase    = Core::type('zend_object')->getStructFieldOffset('properties_table');
         $totalSlots  = $this->pointer->default_properties_count;
         assert(is_int($totalSlots));
@@ -2804,7 +2806,7 @@ class ReflectionClass extends NativeReflectionClass
      */
     public static function newInstanceRaw(object $classType, bool $persistent = false): object
     {
-        $objectSize = Core::sizeof(Core::type('zend_object'));
+        $objectSize = Core::sizeOfType(zend_object::class);
         $totalSize  = $objectSize + self::getObjectPropertiesSize($classType);
         $memory     = Core::new("char[{$totalSize}]", false, $persistent);
         $object     = Core::cast('zend_object *', $memory);
@@ -2826,7 +2828,7 @@ class ReflectionClass extends NativeReflectionClass
      */
     public static function getObjectSize(object $classType): int
     {
-        return Core::sizeof(Core::type('zend_object')) + self::getObjectPropertiesSize($classType);
+        return Core::sizeOfType(zend_object::class) + self::getObjectPropertiesSize($classType);
     }
 
     /**

--- a/src/Reflection/ReflectionValue.php
+++ b/src/Reflection/ReflectionValue.php
@@ -667,7 +667,7 @@ class ReflectionValue implements ReferenceCountedInterface
     public function replaceWith(ReflectionValue $donor): ReflectionValue
     {
         $this->assertNotReleased();
-        $zvalSize = Core::sizeof(Core::type('zval'));
+        $zvalSize = Core::sizeOfType(zval::class);
         $snapshot = Core::new('zval');
         Core::memcpy($snapshot, $this->pointer, $zvalSize);
         Core::memcpy($this->pointer, $donor->getRawValue(), $zvalSize);
@@ -685,7 +685,7 @@ class ReflectionValue implements ReferenceCountedInterface
     {
         $this->assertNotReleased();
         Core::call('zval_ptr_dtor', $this->zvalPointer());
-        Core::memcpy($this->pointer, $snapshot->getRawValue(), Core::sizeof(Core::type('zval')));
+        Core::memcpy($this->pointer, $snapshot->getRawValue(), Core::sizeOfType(zval::class));
     }
 
     /**

--- a/src/System/Compiler.php
+++ b/src/System/Compiler.php
@@ -18,6 +18,7 @@ use ZEngine\AbstractSyntaxTree\AstOwnership;
 use ZEngine\AbstractSyntaxTree\NodeFactory;
 use ZEngine\AbstractSyntaxTree\NodeInterface;
 use ZEngine\Core;
+use ZEngine\Generated\zend_arena;
 use ZEngine\Reflection\ReflectionClass;
 use ZEngine\Reflection\ReflectionValue;
 use ZEngine\Type\HashTable;
@@ -400,7 +401,7 @@ class Compiler
         $rawBuffer = Core::new("char[$size]", false);
         $arena     = Core::cast('zend_arena *', $rawBuffer);
 
-        $arena->ptr  = $rawBuffer + Core::getAlignedSize(Core::sizeof(Core::type('zend_arena')));
+        $arena->ptr  = $rawBuffer + Core::getAlignedSize(Core::sizeOfType(zend_arena::class));
         $arena->end  = $rawBuffer + $size;
         $arena->prev = null;
 

--- a/src/System/ExecutionData.php
+++ b/src/System/ExecutionData.php
@@ -416,8 +416,8 @@ class ExecutionData
     {
         static $slotSize;
         if ($slotSize === null) {
-            $alignedSizeOfExecuteData = Core::getAlignedSize(Core::sizeof(Core::type('zend_execute_data')));
-            $alignedSizeOfZval        = Core::getAlignedSize(Core::sizeof(Core::type('zval')));
+            $alignedSizeOfExecuteData = Core::getAlignedSize(Core::sizeOfType(zend_execute_data::class));
+            $alignedSizeOfZval        = Core::getAlignedSize(Core::sizeOfType(zval::class));
 
             $slotSize = intdiv(($alignedSizeOfExecuteData + $alignedSizeOfZval) - 1, $alignedSizeOfZval);
         }


### PR DESCRIPTION
Finishes the migration recorded in AGENTS.md: `Core::type()` is `@internal` and must not hand a raw `FFI\CType` across the API boundary just so it can be measured — `Core::sizeOfType()` is the named replacement for the `sizeof(type(...))` pair. `src/Reflection` and `src/Type` were already migrated; the rest of the tree was not.

## What changed

**`refactor:` — 58 call sites converted** across 11 files (every remaining `Core::sizeof(Core::type(...))` in `src/`; `tools/` had none):

| File | Sites |
|---|---|
| `src/OpCache/PayloadRelocator.php` | 23 |
| `src/Reflection/ClassSpecializer.php` | 14 |
| `src/Reflection/ReflectionClass.php` | 10 |
| `src/Memory/PersistentGraphCloner.php` | 2 |
| `src/System/ExecutionData.php` | 2 |
| `src/Reflection/ReflectionValue.php` | 2 |
| `src/OpCache/CacheMetaInfo.php`, `src/System/Compiler.php`, `src/EngineExtension/AbstractModule.php`, `src/Reflection/FunctionLikeTrait.php`, `src/Reflection/FunctionBodySwap.php` | 1 each |

Plain struct names use the generated stub class constant (`Core::sizeOfType(zval::class)`) — analyser-checked, never autoloaded, referenced by `::class` only. The forms no stub models keep the C type-name string overload: the pointer sizes `'zend_class_entry *'` / `'zend_string *'`, and the two type names resolved dynamically at runtime (`AbstractModule::globalType()`, the `zend_arg_info` / `zend_internal_arg_info` choice in `FunctionLikeTrait`).

The remaining `Core::sizeof()` calls in `src/` are the legitimate ones — they measure an existing `CData` value (`Core::sizeof($writableEntry)`), not a type name — and are left alone.

**`perf:` — loop-invariant sizes hoisted**, since each `sizeOfType()` re-resolves the C type through FFI:

- `PayloadRelocator::unserializeHash()` / `serializeHash()` — the packed-array branch re-resolved `sizeof(zval)` on **every bucket of every hash** in the payload, while the sibling non-packed branch already hoisted `$bucketSize`; `$zvalSize` now matches it.
- `ClassSpecializer` — trait-alias, trait-precedence, property-info and class-constant struct sizes hoisted out of their copy loops (the precedence loop already hoisted its sibling `$pointerSize`).

Byte-for-byte the same size computations in both commits; no behavior change.

## Validation

Static only — **local tests are impossible here**: the container runs PHP 8.5.9 while this branch targets PHP 8.4, and AGENTS.md's non-negotiable version rule forbids running z-engine code (anything reaching `Core::init()`) against a mismatched minor. CI on 8.4 is the first real execution.

- `composer phpstan` (level max) — **no errors**; no baseline entries were freed or added (verified by diffing the unmatched-ignore report against the pristine tree with `reportUnmatchedIgnoredErrors` forced on), so `phpstan-baseline.neon` is untouched.
- `composer cs:check` (php-cs-fixer, `@PER-CS2.0`) — **clean**, 0 of 296 files fixable.
- `php -l` clean on all 11 touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG)_