### PR TITLE
refactor: align Type and EngineExtension exceptions with the named-constructor convention

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -853,12 +853,6 @@ parameters:
 			path: src/Core.php
 
 		-
-			message: '#^Parameter \#1 \$string of function strtolower expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/EngineExtension/AbstractModule.php
-
-		-
 			message: '#^Parameter \#1 \$stringPointer of static method ZEngine\\Type\\StringEntry\:\:fromCData\(\) expects FFI\\CData\|ZEngine\\Generated\\zend_string, mixed given\.$#'
 			identifier: argument.type
 			count: 1

--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -124,7 +124,7 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
     final public function register(): void
     {
         if ($this->isModuleRegistered()) {
-            throw new \RuntimeException('Module ' . $this->moduleName . ' was already registered.');
+            throw ModuleRegistrationException::alreadyRegistered($this->moduleName);
         }
 
         // Since PHP 8.4 zend_register_module_ex stores THIS pointer directly in the
@@ -167,7 +167,7 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
             // The engine refused the entry (conflicting dependency or duplicate name) and
             // reported an E_CORE_WARNING; the persistent buffers above are bounded, error-path
             // allocations that stay in the tracked-block registry
-            throw new \RuntimeException('Can not register module ' . $moduleName . ' in the engine');
+            throw ModuleRegistrationException::registrationRefused($moduleName);
         }
         \assert($realModulePointer instanceof CData);
 
@@ -205,7 +205,7 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
 
         $result = Core::call('zend_startup_module_ex', $this->moduleEntry);
         if ($result !== Core::SUCCESS) {
-            throw new \RuntimeException('Can not startup module ' . $this->moduleName);
+            throw ModuleRegistrationException::startupFailed($this->moduleName);
         }
 
         // dl() parity: a module started in the middle of a request receives the current

--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -452,11 +452,13 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
         if ($prefixName !== false) {
             $className = $prefixName;
         }
-        // Converts camelCase to snake_case
-        $moduleName = strtolower(preg_replace_callback('/([a-z])([A-Z])/', function ($match) {
+        // Converts camelCase to snake_case; preg_replace_callback() returns null on a PCRE
+        // error (backtrack/recursion limit), in which case the class name is used unsplit
+        // instead of being handed to strtolower() as null (deprecated since PHP 8.1)
+        $snakeCased = preg_replace_callback('/([a-z])([A-Z])/', function ($match) {
             return $match[1] . '_' . $match[2];
-        }, $className));
+        }, $className);
 
-        return $moduleName;
+        return strtolower($snakeCased ?? $className);
     }
 }

--- a/src/EngineExtension/ModuleRegistrationException.php
+++ b/src/EngineExtension/ModuleRegistrationException.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension;
+
+/**
+ * Raised when a module cannot be published into (or started up inside) the engine module
+ * registry: the name is already taken, the engine refused the entry (conflicting
+ * dependency, duplicate name - it reports an E_CORE_WARNING of its own) or the module
+ * startup callbacks failed.
+ *
+ * Extends \RuntimeException exactly like the inline throws it replaces, so existing
+ * `catch (\RuntimeException)` around register()/startup() keeps matching.
+ */
+final class ModuleRegistrationException extends \RuntimeException
+{
+    public static function alreadyRegistered(string $moduleName): self
+    {
+        return new self("Module {$moduleName} was already registered.");
+    }
+
+    public static function registrationRefused(string $moduleName): self
+    {
+        return new self("Can not register module {$moduleName} in the engine");
+    }
+
+    public static function startupFailed(string $moduleName): self
+    {
+        return new self("Can not startup module {$moduleName}");
+    }
+}

--- a/src/EngineExtension/ZEngineModule.php
+++ b/src/EngineExtension/ZEngineModule.php
@@ -15,6 +15,7 @@ namespace ZEngine\EngineExtension;
 
 use FFI\CData;
 use ZEngine\Core;
+use ZEngine\Memory\HeapAnchorMissingException;
 use ZEngine\Memory\PersistentHeap;
 use ZEngine\Memory\PersistentHeapException;
 use ZEngine\Reflection\ReflectionValue;
@@ -168,7 +169,7 @@ final class ZEngineModule extends AbstractModule implements ModuleLifecycleInter
     {
         $anchor = $this->getGlobals();
         if ($anchor === null) {
-            throw new PersistentHeapException('The zengine module has no globals block');
+            throw HeapAnchorMissingException::create();
         }
         $anchorTyped = $anchor->u1;
         assert($anchorTyped instanceof CData);
@@ -185,7 +186,7 @@ final class ZEngineModule extends AbstractModule implements ModuleLifecycleInter
     {
         $anchor = $this->getGlobals();
         if ($anchor === null) {
-            throw new PersistentHeapException('The zengine module has no globals block');
+            throw HeapAnchorMissingException::create();
         }
         $anchorTyped = $anchor->u1;
         assert($anchorTyped instanceof CData);

--- a/src/Memory/HeapAnchorMissingException.php
+++ b/src/Memory/HeapAnchorMissingException.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Memory;
+
+/**
+ * Raised when the persistent heap registry cannot be reached because the zengine module
+ * carries no globals block - the zval-typed module globals ARE the anchor slot the
+ * registry is recovered from, so without them there is nothing to mint or clear.
+ *
+ * Stays inside the PersistentHeapException hierarchy: the anchor is heap state, and
+ * every `catch (PersistentHeapException)` around a heap lookup must keep matching.
+ */
+final class HeapAnchorMissingException extends PersistentHeapException
+{
+    public static function create(): self
+    {
+        return new self('The zengine module has no globals block');
+    }
+}

--- a/src/System/Hook/OpCodeHook.php
+++ b/src/System/Hook/OpCodeHook.php
@@ -99,7 +99,7 @@ final class OpCodeHook implements HookInterface
 
         $result = Core::call('zend_set_user_opcode_handler', $this->opCode, Closure::fromCallable([$this, 'handle']));
         if ($result === Core::FAILURE) {
-            throw new \RuntimeException('Can not install user opcode handler');
+            throw OpCodeHookException::handlerInstallFailed();
         }
         $this->installed = true;
         Core::registerHook($this);
@@ -130,7 +130,7 @@ final class OpCodeHook implements HookInterface
 
         $result = Core::call('zend_set_user_opcode_handler', $this->opCode, $this->originalHandler);
         if ($result === Core::FAILURE) {
-            throw new \RuntimeException('Can not restore original opcode handler');
+            throw OpCodeHookException::handlerRestoreFailed();
         }
         $this->installed = false;
         Core::unregisterHook($this);

--- a/src/System/Hook/OpCodeHookException.php
+++ b/src/System/Hook/OpCodeHookException.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\System\Hook;
+
+/**
+ * Raised when the engine refuses to publish or restore a user opcode handler through
+ * zend_set_user_opcode_handler(): the handler table rejected the write, so the hook chain
+ * is left exactly as it was - install() did not take effect, or uninstall() could not put
+ * the captured predecessor back.
+ *
+ * Extends \RuntimeException, exactly what the inline throws it replaces threw.
+ */
+final class OpCodeHookException extends \RuntimeException
+{
+    public static function handlerInstallFailed(): self
+    {
+        return new self('Can not install user opcode handler');
+    }
+
+    public static function handlerRestoreFailed(): self
+    {
+        return new self('Can not restore original opcode handler');
+    }
+}

--- a/src/Type/HashTable.php
+++ b/src/Type/HashTable.php
@@ -282,7 +282,7 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
         $stringEntry = new StringEntry($key);
         $result      = Core::call('zend_hash_del', $this->pointer, $stringEntry->getRawValue());
         if ($result === Core::FAILURE) {
-            throw new \RuntimeException("Can not delete an item with key {$key}");
+            throw TypeOperationException::cannotDeleteKey($key);
         }
     }
 
@@ -320,7 +320,7 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
     {
         $result = Core::call('zend_hash_index_del', $this->pointer, $key);
         if ($result === Core::FAILURE) {
-            throw new \RuntimeException("Can not delete an item with index {$key}");
+            throw TypeOperationException::cannotDeleteIndex($key);
         }
     }
 
@@ -342,7 +342,7 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
             self::HASH_ADD,
         );
         if ($result === null) {
-            throw new \RuntimeException("Can not add an item with key {$key}");
+            throw TypeOperationException::cannotAddKey($key);
         }
     }
 
@@ -380,7 +380,7 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
         // wrapper APIs like redefine() operate on the entry the engine will actually dispatch
         $storedEntry = $this->find($lowerKey);
         if ($storedEntry === null) {
-            throw new \RuntimeException("Function {$key} was not published in the table");
+            throw TypeOperationException::functionNotPublished($key);
         }
 
         return $storedEntry->getRawFunction();
@@ -422,7 +422,7 @@ class HashTable implements IteratorAggregate, ReferenceCountedInterface
             self::HASH_ADD_NEW,
         );
         if ($result === null) {
-            throw new \RuntimeException("Can not add an item with index {$key}");
+            throw TypeOperationException::cannotAddIndex($key);
         }
     }
 

--- a/src/Type/ObjectEntry.php
+++ b/src/Type/ObjectEntry.php
@@ -403,7 +403,7 @@ class ObjectEntry implements ReferenceCountedInterface
     private function assertObjectAlive(): void
     {
         if ($this->weakSource !== null && $this->weakSource->get() === null) {
-            throw new \RuntimeException('The underlying object has been destroyed, this entry is dangling');
+            throw TypeOperationException::danglingObjectEntry();
         }
     }
 }

--- a/src/Type/PersistentHashTable.php
+++ b/src/Type/PersistentHashTable.php
@@ -100,7 +100,7 @@ final class PersistentHashTable extends HashTable
             self::HASH_UPDATE,
         );
         if ($result === null) {
-            throw new \RuntimeException('Can not store an item with key ' . $key->getStringValue());
+            throw TypeOperationException::cannotStoreKey($key->getStringValue());
         }
     }
 
@@ -117,7 +117,7 @@ final class PersistentHashTable extends HashTable
             self::HASH_UPDATE,
         );
         if ($result === null) {
-            throw new \RuntimeException("Can not store an item with index {$key}");
+            throw TypeOperationException::cannotStoreIndex($key);
         }
     }
 

--- a/src/Type/ReferenceCountedTrait.php
+++ b/src/Type/ReferenceCountedTrait.php
@@ -74,7 +74,7 @@ trait ReferenceCountedTrait
             );
         }
         if ($this->getGC()->refcount <= 0) {
-            throw new \RuntimeException('Reference counter underflow: the value has already been released');
+            throw TypeOperationException::referenceCountUnderflow();
         }
 
         return --$this->getGC()->refcount;

--- a/src/Type/TypeOperationException.php
+++ b/src/Type/TypeOperationException.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Type;
+
+/**
+ * Raised when an operation on a Type-layer wrapper is refused by the engine: a hashtable
+ * bucket that could not be added, stored or deleted, a value entry that did not appear in
+ * the table it was published into, a dangling wrapper over destroyed engine memory or a
+ * reference counter that would go below zero.
+ *
+ * These are engine-state failures, not argument validation: the call was well-formed and
+ * the engine still said no, so they extend \RuntimeException exactly like the inline
+ * throws they replace - every existing `catch (\RuntimeException)` keeps matching.
+ *
+ * Every failure mode has a named static constructor (project convention, see AGENTS.md).
+ */
+class TypeOperationException extends \RuntimeException
+{
+    public static function cannotAddKey(string $key): self
+    {
+        return new self("Can not add an item with key {$key}");
+    }
+
+    public static function cannotAddIndex(int $key): self
+    {
+        return new self("Can not add an item with index {$key}");
+    }
+
+    public static function cannotStoreKey(string $key): self
+    {
+        return new self("Can not store an item with key {$key}");
+    }
+
+    public static function cannotStoreIndex(int $key): self
+    {
+        return new self("Can not store an item with index {$key}");
+    }
+
+    public static function cannotDeleteKey(string $key): self
+    {
+        return new self("Can not delete an item with key {$key}");
+    }
+
+    public static function cannotDeleteIndex(int $key): self
+    {
+        return new self("Can not delete an item with index {$key}");
+    }
+
+    public static function functionNotPublished(string $key): self
+    {
+        return new self("Function {$key} was not published in the table");
+    }
+
+    public static function danglingObjectEntry(): self
+    {
+        return new self('The underlying object has been destroyed, this entry is dangling');
+    }
+
+    public static function referenceCountUnderflow(): self
+    {
+        return new self('Reference counter underflow: the value has already been released');
+    }
+}


### PR DESCRIPTION
AGENTS.md is explicit: *"Domain exceptions are never thrown with a hand-written message at the call site. Each failure mode is a `public static` factory on the exception class."* Two layers had never been brought in line — `src/Type` had no domain exception class at all, and `EngineExtension` had one (`ExtensionNotRegisteredException`) that covered a single failure mode while five others were hand-written inline, two of them character-for-character identical.

## New exception classes and their factories

### `ZEngine\Type\TypeOperationException extends \RuntimeException`

The Type layer's first domain exception class. Nine failure modes moved onto it; six were near-duplicates of each other spread over three files (`Can not add/store/delete an item with key/index …`).

| Factory | Replaced site |
|---|---|
| `cannotAddKey($key)` | `Type/HashTable.php` `add()` |
| `cannotAddIndex($key)` | `Type/HashTable.php` `addIndex()` |
| `cannotDeleteKey($key)` | `Type/HashTable.php` `delete()` |
| `cannotDeleteIndex($key)` | `Type/HashTable.php` `deleteIndex()` |
| `functionNotPublished($key)` | `Type/HashTable.php` `addFunctionEntry()` |
| `cannotStoreKey($key)` | `Type/PersistentHashTable.php` `addInterned()` |
| `cannotStoreIndex($key)` | `Type/PersistentHashTable.php` `addIndex()` |
| `danglingObjectEntry()` | `Type/ObjectEntry.php` `assertObjectAlive()` |
| `referenceCountUnderflow()` | `Type/ReferenceCountedTrait.php` `decrementReferenceCount()` |

**On the class name and scope.** I read every message before naming it. `EngineTableException` would have been accurate for seven of the nine but wrong for the dangling-weak-entry and refcount-underflow guards, which are not table failures. Rather than mint a second one-method class, the name generalises to what all nine actually are: an operation on a Type-layer wrapper that the engine state refused. `HashTable::deleteIndex()` (the *"Can not delete an item with index"* twin of `delete()`) and `ReferenceCountedTrait`'s underflow guard were not in the original brief; they surfaced in the sweep and belong to the same family, so leaving them inline would have re-fragmented the wording the class exists to unify.

`StringEntry::setCachedClassEntry()`'s *"This string does not carry an engine class-entry cache slot"* stays a bare `\LogicException`: it is the only `LogicException` among the Type-layer sites, so folding it in would have forced either a base-type change (forbidden, see below) or a second class for one call site — and it is a plain programmer guard whose predicate (`hasClassEntryCache()`) is public, so the caller is told to check first.

### `ZEngine\EngineExtension\ModuleRegistrationException extends \RuntimeException`

Shaped like its neighbour `ExtensionNotRegisteredException`. `AbstractModule` previously had no module exception class whatsoever.

| Factory | Replaced site |
|---|---|
| `alreadyRegistered($moduleName)` | `AbstractModule::register()` |
| `registrationRefused($moduleName)` | `AbstractModule::register()`, after `zend_register_module_ex` |
| `startupFailed($moduleName)` | `AbstractModule::startup()` |

### `ZEngine\Memory\HeapAnchorMissingException extends PersistentHeapException`

`ZEngineModule::onHeapDestroyed()` and `ZEngineModule::recoverHeapRegistry()` hand-wrote *"The zengine module has no globals block"* twice, both as a `PersistentHeapException`.

**Deviation from the brief, deliberate.** The brief suggested folding these two into the new `EngineExtension` module class extending `\RuntimeException`. That would have changed the thrown type from `PersistentHeapException` to something outside the heap hierarchy and silently broken every `catch (PersistentHeapException)` around a heap lookup — including `ZEngineModule::getDisplayInfo()` in the very same file, which converts heap failures into an *"inert"* row rather than throwing across the `info_func` FFI boundary (issue #50). The base-type preservation guarantee wins over class placement, so the message moved onto a new subclass of what was already being thrown, following the house style of `HeapInertException` / `MissingClassException` (final subclass + one static factory) and living beside its siblings in `ZEngine\Memory`.

### `ZEngine\System\Hook\OpCodeHookException extends \RuntimeException`

| Factory | Replaced site |
|---|---|
| `handlerInstallFailed()` | `OpCodeHook::install()` |
| `handlerRestoreFailed()` | `OpCodeHook::uninstall()` |

## Base-type preservation guarantee

**Every new exception class extends exactly the type the throw it replaces was throwing**, and every replaced message is carried over verbatim. No `catch` anywhere can stop matching as a result of this PR:

| New class | Extends | Because the replaced throws were |
|---|---|---|
| `TypeOperationException` | `\RuntimeException` | all nine were `\RuntimeException` |
| `ModuleRegistrationException` | `\RuntimeException` | all three were `\RuntimeException` |
| `HeapAnchorMissingException` | `PersistentHeapException` | both were `PersistentHeapException` |
| `OpCodeHookException` | `\RuntimeException` | both were `\RuntimeException` |

Catchers verified by grep before choosing each parent:

- `Core::shutdown()`'s `find()` pre-check exists precisely *because* `HashTable::delete()` throws on an absent key — still a `\RuntimeException`, still caught.
- `tests/Type/PersistentHashTableTest.php` expects `\RuntimeException` **and** asserts `/index 2/` on the message — the factory emits the identical string.
- `tests/Type/StringEntryOwnershipTest.php` expects `\RuntimeException` from the refcount underflow, `\LogicException` from the immutable-increment guard (untouched).
- `tests/EngineExtension/fixture/module-lifecycle-order.php` catches bare `RuntimeException` around a rejected registration.
- `ZEngineModule::getDisplayInfo()` catches `PersistentHeapException`.
- No test or doc asserts any of the other replaced message strings, and `docs/` mentions none of these types.

## Latent deprecation fixed: `AbstractModule::detectModuleName()`

`strtolower(preg_replace_callback(...))` fed `strtolower()` a `?string`. `preg_replace_callback()` returns `null` on a PCRE failure (backtrack/recursion limit), and passing `null` to `strtolower()` has been deprecated since PHP 8.1 — a real runtime deprecation on that path, not just a static-analysis artifact. The error path now falls back to the unsplit class name (`$snakeCased ?? $className`), which is what the camelCase→snake_case conversion degrades to anyway. **The freed `phpstan-baseline.neon` entry is pruned by hand** (`Parameter #1 $string of function strtolower expects string, string|null given`); the second `AbstractModule` baseline entry is unrelated and stays.

## Sweep: sites kept as-is, with reasoning

`src/` was swept for `throw new \?(RuntimeException|LogicException|InvalidArgumentException|ReflectionException)(` with inline interpolated messages. Excluded from consideration: `HotSwap.php`, `Core.php`, `ReflectionMethod.php`, `PersistentHeap.php`, the `ClassExtension/Hook/*` `proceed()`/`getOriginalCallable()` throws, `AbstractMethodResolutionHook.php`, and `AbstractSyntaxTree/Node.php`'s `OutOfBoundsException` guards — all owned by concurrent PRs. Remaining hits, grouped:

- **`OpCodeHook.php`, `Cannot install an engine hook after Core::shutdown()`** — kept native `\LogicException`. It is a genuine shared-vocabulary duplicate, but the *same string* is raised verbatim by `Hook/AbstractHook.php` and `ClassExtension/Hook/IteratorBridge.php` too. Converting only OpCodeHook's copy would leave the message split between a factory and two inline twins — strictly worse than the status quo. It wants one factory for all three sites, and `AbstractHook` is owned by the in-flight hook-consolidation PR, so this belongs there.
- **`OpCodeHook.php`, out-of-order uninstall guard** — kept. Programmer-misuse guard on a public API, single site, stable message; `OpCodeHookTest` and `HookLifecycleTest` both assert only the `\LogicException` type.
- **`OpCodeHook.php`, handler-signature check** — kept `\InvalidArgumentException`. Pure argument validation, and `OpCodeHookTest` asserts the message verbatim; a factory adds no clarity and only adds a way to drift.
- **`EngineExtension/ExtensionManager.php:62`** (`Module … is already registered; use get()`) — kept `\LogicException`. Different layer and different base type from `ModuleRegistrationException::alreadyRegistered()`: this is the framework-side registry rejecting a double `register()` call (programmer error), not the *engine* module registry refusing an entry.
- **`EngineExtension/ModuleDependency.php:57,61,64`** — kept. Constructor argument validation (`\InvalidArgumentException`); `AbstractModuleTest` asserts the type.
- **`Type/StringEntry.php:308`, `Type/ReleasableTrait.php:98`, `Type/ReferenceCountedTrait.php:54,71`, `Type/StructArray.php`, `Type/ResourceEntry.php`, `Type/OpLine.php`, `Type/ObjectEntry.php:254`, `Type/ClosureEntry.php:120`** — kept. All either `\LogicException`/`\OutOfBoundsException` programmer guards with stable single-site messages, or native-reflection-parity `\ReflectionException`s.
- **`Reflection/*` `\ReflectionException`s** (`Class X should be in the engine.`, trait/alias/precedence errors) — kept. These are deliberate native-`Reflection*` parity errors; consumers catch `\ReflectionException` by contract.
- **`AbstractSyntaxTree/{DeclarationNode,ListNode,NodeFactory,NodeKind}.php`** — kept. Node-kind argument validation and "not yet supported" guards, adjacent to the AST files a concurrent dedup PR is restructuring.

Three clusters are real remaining duplication but sit outside this PR's stated scope, and each needs its own exception class in a layer this PR does not otherwise touch — flagged as follow-ups rather than smuggled in here: `Reflection/FunctionLikeTrait.php`'s eight *"… are available only for user-defined functions"* variants (three of them byte-identical), `System/ObjectStore.php`'s twice-duplicated *"Object store is read-only structure"* plus its thrice-duplicated out-of-bounds message, and the *"Unknown code … New version of PHP?"* trio spanning `NodeKind`, `OpCode` and `ReflectionValue`.

## Adjacency with in-flight PRs

- **#199** (`OpCodeHook::handle()` frame resolution) rewrites `handle()` and the two `Closure::fromCallable([$this, 'handle'])` call sites in this same file. I inspected its branch: it does not touch either throw, and only shifts them by one line via an edited const docblock. This PR stays rooted at `origin/8.4` (`70d8d4f`); expect a trivial, non-conflicting merge.
- **#197** (exception-safety / `deleteWithoutDestructor`) touches `HotSwap.php`, `Core.php`, `ReflectionMethod.php` — untouched here. `HashTable::deleteWithoutDestructor()` sits between two converted throws in `HashTable.php` but its own body is unchanged.
- The memory-ownership PR owns `PersistentHeap.php:614,663` — excluded, not touched.
- The hook-consolidation PR owns `AbstractHook::getOriginalCallable()` and the `ClassExtension/Hook/*` `proceed()` prologues — untouched, and the shutdown-guard message above is left to it on purpose.

## Validation

`vendor/bin/phpstan analyse` (level max) and `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --dry-run` are both clean, and were clean on `origin/8.4` beforehand. All four new files pass `php -l`.

**Local tests were not run, by AGENTS.md's non-negotiable version rule**: this branch targets PHP 8.4 and the container interpreter is 8.5.9. Running the suite means `Core::init()` reading `zend_class_entry` at 8.4 offsets under an 8.5 engine — silent memory corruption, not a clean failure. Validation here is static-only; CI on the 8.4 runners is the gate. The change is a pure message-relocation refactor with types and strings preserved, which is exactly the shape that survives that constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG)_