### PR TITLE
feat: adopt PHP 8.4 API surface — asymmetric visibility, enums, named arguments, #[\Deprecated]

### DIFF
--- a/src/EngineExtension/AbstractModule.php
+++ b/src/EngineExtension/AbstractModule.php
@@ -371,15 +371,15 @@ abstract class AbstractModule extends ReflectionExtension implements ModuleInter
             $rawDependency = $rawDependencies[$index];
             \assert($rawDependency instanceof CData);
             $rawDependency->name = self::newPersistentString($dependency->getName());
-            $relation            = $dependency->getRelation();
+            $relation            = $dependency->versionRelation();
             if ($relation !== null) {
-                $rawDependency->rel = self::newPersistentString($relation);
+                $rawDependency->rel = self::newPersistentString($relation->value);
             }
             $version = $dependency->getVersion();
             if ($version !== null) {
                 $rawDependency->version = self::newPersistentString($version);
             }
-            $rawDependency->type = $dependency->getDependencyType();
+            $rawDependency->type = $dependency->dependencyType()->value;
             $index++;
         }
         // The trailing element stays zero-initialized: the NULL terminator the engine

--- a/src/EngineExtension/DependencyType.php
+++ b/src/EngineExtension/DependencyType.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension;
+
+/**
+ * Named view of the `type` field of a zend_module_dep entry
+ *
+ * The backing values are the MODULE_DEP_* macros from Zend/zend_modules.h; the engine writes
+ * them as an `unsigned char` into the NULL-terminated `deps` array of a module entry.
+ *
+ * @see ModuleDependency
+ */
+enum DependencyType: int
+{
+    /** MODULE_DEP_REQUIRED: the module must be loaded and started before this one */
+    case Required = 1;
+
+    /** MODULE_DEP_CONFLICTS: this module cannot be loaded together with the named one */
+    case Conflicts = 2;
+
+    /** MODULE_DEP_OPTIONAL: no hard requirement, affects module startup ordering only */
+    case Optional = 3;
+
+    /**
+     * Normalizes a dependency type given either as a case or as one of the legacy
+     * ModuleDependency::MODULE_* integers
+     *
+     * @throws \InvalidArgumentException when the integer matches no known MODULE_DEP_* value
+     */
+    public static function fromValue(self|int $type): self
+    {
+        if ($type instanceof self) {
+            return $type;
+        }
+
+        return self::tryFrom($type) ?? throw new \InvalidArgumentException("Unknown module dependency type {$type}");
+    }
+}

--- a/src/EngineExtension/ModuleDependency.php
+++ b/src/EngineExtension/ModuleDependency.php
@@ -31,36 +31,40 @@ namespace ZEngine\EngineExtension;
  */
 final class ModuleDependency
 {
+    /**
+     * @deprecated Use the DependencyType enum (DependencyType::Required/Conflicts/Optional) instead;
+     *             these int aliases are kept for consumers that pass or compare raw MODULE_DEP_* values
+     */
     public const MODULE_REQUIRED  = 1;
     public const MODULE_CONFLICTS = 2;
     public const MODULE_OPTIONAL  = 3;
 
     /**
-     * Version relationships understood by the engine (zend_modules.h)
+     * Dependency type as the engine stores it in zend_module_dep.type
      */
-    private const KNOWN_RELATIONS = ['lt', 'le', 'eq', 'ge', 'gt'];
+    private readonly DependencyType $dependencyType;
 
     /**
-     * @param string      $name           Name of the module this dependency points to (eg 'standard')
-     * @param int         $dependencyType One of the MODULE_REQUIRED/MODULE_CONFLICTS/MODULE_OPTIONAL constants
-     * @param string|null $relation       Version relationship: null (module just has to exist) or one of lt|le|eq|ge|gt
-     * @param string|null $version        Version to compare against; required when $relation is given
+     * Version relationship, or null when the module just has to exist
+     */
+    private readonly ?VersionRelation $relation;
+
+    /**
+     * @param string                      $name           Name of the module this dependency points to (eg 'standard')
+     * @param DependencyType|int          $dependencyType Dependency type, or a legacy MODULE_* constant
+     * @param VersionRelation|string|null $relation       Version relationship: null (module just has to exist),
+     *                                                    a VersionRelation case or one of the raw lt|le|eq|ge|gt strings
+     * @param string|null                 $version        Version to compare against; required when $relation is given
      */
     public function __construct(
         private readonly string $name,
-        private readonly int $dependencyType = self::MODULE_REQUIRED,
-        private readonly ?string $relation = null,
+        DependencyType|int $dependencyType = DependencyType::Required,
+        VersionRelation|string|null $relation = null,
         private readonly ?string $version = null,
     ) {
-        $knownTypes = [self::MODULE_REQUIRED, self::MODULE_CONFLICTS, self::MODULE_OPTIONAL];
-        if (!in_array($dependencyType, $knownTypes, true)) {
-            throw new \InvalidArgumentException("Unknown module dependency type {$dependencyType}");
-        }
-        if ($relation !== null && !in_array($relation, self::KNOWN_RELATIONS, true)) {
-            $known = implode('|', self::KNOWN_RELATIONS);
-            throw new \InvalidArgumentException("Unknown version relation '{$relation}', expected one of {$known}");
-        }
-        if (($relation === null) !== ($version === null)) {
+        $this->dependencyType = DependencyType::fromValue($dependencyType);
+        $this->relation       = VersionRelation::fromValue($relation);
+        if (($this->relation === null) !== ($version === null)) {
             throw new \InvalidArgumentException('Version relation and version must be provided together');
         }
     }
@@ -68,9 +72,12 @@ final class ModuleDependency
     /**
      * Declares that the given module must be loaded and started before this one
      */
-    public static function required(string $name, ?string $relation = null, ?string $version = null): self
-    {
-        return new self($name, self::MODULE_REQUIRED, $relation, $version);
+    public static function required(
+        string $name,
+        VersionRelation|string|null $relation = null,
+        ?string $version = null,
+    ): self {
+        return new self($name, DependencyType::Required, $relation, $version);
     }
 
     /**
@@ -78,15 +85,18 @@ final class ModuleDependency
      */
     public static function conflicts(string $name): self
     {
-        return new self($name, self::MODULE_CONFLICTS);
+        return new self($name, DependencyType::Conflicts);
     }
 
     /**
      * Declares an optional relationship (affects module startup ordering only)
      */
-    public static function optional(string $name, ?string $relation = null, ?string $version = null): self
-    {
-        return new self($name, self::MODULE_OPTIONAL, $relation, $version);
+    public static function optional(
+        string $name,
+        VersionRelation|string|null $relation = null,
+        ?string $version = null,
+    ): self {
+        return new self($name, DependencyType::Optional, $relation, $version);
     }
 
     /**
@@ -98,9 +108,9 @@ final class ModuleDependency
     }
 
     /**
-     * Returns the dependency type (one of the MODULE_* constants)
+     * Returns the dependency type
      */
-    public function getDependencyType(): int
+    public function dependencyType(): DependencyType
     {
         return $this->dependencyType;
     }
@@ -108,9 +118,29 @@ final class ModuleDependency
     /**
      * Returns the version relationship (null when the module just has to exist)
      */
-    public function getRelation(): ?string
+    public function versionRelation(): ?VersionRelation
     {
         return $this->relation;
+    }
+
+    /**
+     * Returns the dependency type (one of the MODULE_* constants)
+     *
+     * @deprecated Use dependencyType() instead, which returns the DependencyType enum
+     */
+    public function getDependencyType(): int
+    {
+        return $this->dependencyType->value;
+    }
+
+    /**
+     * Returns the version relationship (null when the module just has to exist)
+     *
+     * @deprecated Use versionRelation() instead, which returns the VersionRelation enum
+     */
+    public function getRelation(): ?string
+    {
+        return $this->relation?->value;
     }
 
     /**

--- a/src/EngineExtension/VersionRelation.php
+++ b/src/EngineExtension/VersionRelation.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\EngineExtension;
+
+/**
+ * The version relationships the engine understands in the `rel` field of a zend_module_dep entry
+ *
+ * The backing values are the exact strings zend_modules.h documents and php_check_dep_version()
+ * compares against; a dependency with no relation stores a NULL `rel` instead of one of these
+ * (modelled as a null VersionRelation rather than a case of its own).
+ *
+ * @see ModuleDependency
+ */
+enum VersionRelation: string
+{
+    /** The dependency version must be lower than the given one */
+    case LessThan = 'lt';
+
+    /** The dependency version must be lower than or equal to the given one */
+    case LessOrEqual = 'le';
+
+    /** The dependency version must be exactly the given one */
+    case Equal = 'eq';
+
+    /** The dependency version must be greater than or equal to the given one */
+    case GreaterOrEqual = 'ge';
+
+    /** The dependency version must be greater than the given one */
+    case GreaterThan = 'gt';
+
+    /**
+     * Normalizes a relation given either as a case or as one of the raw engine strings,
+     * passing a missing relation (null) through unchanged
+     *
+     * @throws \InvalidArgumentException when the string matches no relation the engine understands
+     */
+    public static function fromValue(self|string|null $relation): ?self
+    {
+        if ($relation === null || $relation instanceof self) {
+            return $relation;
+        }
+
+        return self::tryFrom($relation) ?? throw new \InvalidArgumentException(
+            "Unknown version relation '{$relation}', expected one of "
+            . implode('|', array_column(self::cases(), 'value')),
+        );
+    }
+}

--- a/src/Memory/DescriptorSlot.php
+++ b/src/Memory/DescriptorSlot.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Memory;
+
+/**
+ * The fixed slots of a persistent key's descriptor table
+ *
+ * Unlike almost every other numeric constant in z-engine these values mirror no engine ABI:
+ * the descriptor table is z-engine's own on-heap layout, written and read back only by
+ * PersistentHeap. The backing values are therefore the integer keys the descriptor's inventory
+ * entries are stored under, and they must stay stable because a persistent region survives the
+ * process that wrote it.
+ *
+ * @see PersistentHeap
+ */
+enum DescriptorSlot: int
+{
+    /** The graph root object (IS_PTR to a zend_object) */
+    case Root = 0;
+
+    /** Inventory table of every cloned object in the graph */
+    case Objects = 1;
+
+    /** Class names of the cloned objects, positionally aligned with Objects */
+    case ObjectClasses = 2;
+
+    /** Allocation sizes of the cloned objects, positionally aligned with Objects */
+    case ObjectSizes = 3;
+
+    /** Inventory table of every cloned string */
+    case Strings = 4;
+
+    /** Inventory table of every cloned array */
+    case Arrays = 5;
+
+    /** Recorded payload byte count of the whole graph (IS_LONG) */
+    case Bytes = 6;
+}

--- a/src/Memory/PersistentHeap.php
+++ b/src/Memory/PersistentHeap.php
@@ -72,17 +72,6 @@ use ZEngine\Type\StructArray;
 final class PersistentHeap
 {
     /**
-     * Descriptor slot indexes (integer keys inside a key's descriptor table)
-     */
-    private const SLOT_ROOT           = 0;
-    private const SLOT_OBJECTS        = 1;
-    private const SLOT_OBJECT_CLASSES = 2;
-    private const SLOT_OBJECT_SIZES   = 3;
-    private const SLOT_STRINGS        = 4;
-    private const SLOT_ARRAYS         = 5;
-    private const SLOT_BYTES          = 6;
-
-    /**
      * Keys re-attached in the current request (per-request state, reset by the hooks)
      *
      * @var array<string, true>
@@ -193,13 +182,13 @@ final class PersistentHeap
         }
 
         $descriptor = new PersistentHashTable();
-        $this->addPointerEntry($descriptor, self::SLOT_ROOT, $graph->root);
-        $this->addPointerEntry($descriptor, self::SLOT_OBJECTS, $objectsTable->getRawValue());
-        $this->addPointerEntry($descriptor, self::SLOT_OBJECT_CLASSES, $classesTable->getRawValue());
-        $this->addPointerEntry($descriptor, self::SLOT_OBJECT_SIZES, $sizesTable->getRawValue());
-        $this->addPointerEntry($descriptor, self::SLOT_STRINGS, $stringsTable->getRawValue());
-        $this->addPointerEntry($descriptor, self::SLOT_ARRAYS, $arraysTable->getRawValue());
-        $this->addLongEntry($descriptor, self::SLOT_BYTES, $graph->bytes);
+        $this->addPointerEntry($descriptor, DescriptorSlot::Root->value, $graph->root);
+        $this->addPointerEntry($descriptor, DescriptorSlot::Objects->value, $objectsTable->getRawValue());
+        $this->addPointerEntry($descriptor, DescriptorSlot::ObjectClasses->value, $classesTable->getRawValue());
+        $this->addPointerEntry($descriptor, DescriptorSlot::ObjectSizes->value, $sizesTable->getRawValue());
+        $this->addPointerEntry($descriptor, DescriptorSlot::Strings->value, $stringsTable->getRawValue());
+        $this->addPointerEntry($descriptor, DescriptorSlot::Arrays->value, $arraysTable->getRawValue());
+        $this->addLongEntry($descriptor, DescriptorSlot::Bytes->value, $graph->bytes);
 
         $descriptorValue = ReflectionValue::newEntry(ReflectionValue::IS_PTR, StructArray::at($descriptor->getRawValue()));
         $this->registry->addInterned($keyEntry, $descriptorValue);
@@ -228,7 +217,7 @@ final class PersistentHeap
 
         $this->attach($key, $descriptor);
 
-        $rootPointer = Core::cast('zend_object *', $this->requireEntry($descriptor, self::SLOT_ROOT)->getRawPointer());
+        $rootPointer = Core::cast('zend_object *', $this->requireEntry($descriptor, DescriptorSlot::Root->value)->getRawPointer());
 
         return ObjectEntry::fromCData($rootPointer)->getNativeValue();
     }
@@ -273,9 +262,9 @@ final class PersistentHeap
             $descriptor = PersistentHashTable::fromCData(Core::cast('HashTable *', $value->getRawPointer()));
 
             $keyStats = [
-                'objects' => $this->tableSlot($descriptor, self::SLOT_OBJECTS)->count(),
-                'strings' => $this->tableSlot($descriptor, self::SLOT_STRINGS)->count(),
-                'arrays'  => $this->tableSlot($descriptor, self::SLOT_ARRAYS)->count(),
+                'objects' => $this->tableSlot($descriptor, DescriptorSlot::Objects)->count(),
+                'strings' => $this->tableSlot($descriptor, DescriptorSlot::Strings)->count(),
+                'arrays'  => $this->tableSlot($descriptor, DescriptorSlot::Arrays)->count(),
                 'bytes'   => $this->byteCount($descriptor),
             ];
 
@@ -375,9 +364,9 @@ final class PersistentHeap
             return;
         }
 
-        $objectsTable = $this->tableSlot($descriptor, self::SLOT_OBJECTS);
-        $classesTable = $this->tableSlot($descriptor, self::SLOT_OBJECT_CLASSES);
-        $sizesTable   = $this->tableSlot($descriptor, self::SLOT_OBJECT_SIZES);
+        $objectsTable = $this->tableSlot($descriptor, DescriptorSlot::Objects);
+        $classesTable = $this->tableSlot($descriptor, DescriptorSlot::ObjectClasses);
+        $sizesTable   = $this->tableSlot($descriptor, DescriptorSlot::ObjectSizes);
 
         $objectCount = $objectsTable->count();
 
@@ -413,8 +402,8 @@ final class PersistentHeap
         foreach ($objects as $objectPointer) {
             $objectAddresses[Core::addressOf($objectPointer)] = true;
         }
-        $stringAddresses = $this->addressSet($this->tableSlot($descriptor, self::SLOT_STRINGS));
-        $arrayAddresses  = $this->addressSet($this->tableSlot($descriptor, self::SLOT_ARRAYS));
+        $stringAddresses = $this->addressSet($this->tableSlot($descriptor, DescriptorSlot::Strings));
+        $arrayAddresses  = $this->addressSet($this->tableSlot($descriptor, DescriptorSlot::Arrays));
 
         foreach ($objects as $index => $objectPointer) {
             // A stored object still carries the class entry of the request that minted the
@@ -466,11 +455,11 @@ final class PersistentHeap
      */
     private function evict(string $key, PersistentHashTable $descriptor): void
     {
-        $objectsTable = $this->tableSlot($descriptor, self::SLOT_OBJECTS);
-        $classesTable = $this->tableSlot($descriptor, self::SLOT_OBJECT_CLASSES);
-        $sizesTable   = $this->tableSlot($descriptor, self::SLOT_OBJECT_SIZES);
-        $stringsTable = $this->tableSlot($descriptor, self::SLOT_STRINGS);
-        $arraysTable  = $this->tableSlot($descriptor, self::SLOT_ARRAYS);
+        $objectsTable = $this->tableSlot($descriptor, DescriptorSlot::Objects);
+        $classesTable = $this->tableSlot($descriptor, DescriptorSlot::ObjectClasses);
+        $sizesTable   = $this->tableSlot($descriptor, DescriptorSlot::ObjectSizes);
+        $stringsTable = $this->tableSlot($descriptor, DescriptorSlot::Strings);
+        $arraysTable  = $this->tableSlot($descriptor, DescriptorSlot::Arrays);
 
         $objectCount = $objectsTable->count();
         $objects     = [];
@@ -541,7 +530,7 @@ final class PersistentHeap
             if ($descriptor === null) {
                 continue;
             }
-            $objectsTable = $this->tableSlot($descriptor, self::SLOT_OBJECTS);
+            $objectsTable = $this->tableSlot($descriptor, DescriptorSlot::Objects);
             $objectCount  = $objectsTable->count();
             for ($index = 0; $index < $objectCount; $index++) {
                 $this->releasePropertiesCache(
@@ -669,7 +658,7 @@ final class PersistentHeap
      */
     private function byteCount(PersistentHashTable $descriptor): int
     {
-        $this->requireEntry($descriptor, self::SLOT_BYTES)->getNativeValue($bytes);
+        $this->requireEntry($descriptor, DescriptorSlot::Bytes->value)->getNativeValue($bytes);
         assert(is_int($bytes));
 
         return $bytes;
@@ -678,10 +667,10 @@ final class PersistentHeap
     /**
      * Resolves a descriptor slot holding a nested inventory table
      */
-    private function tableSlot(PersistentHashTable $descriptor, int $slot): PersistentHashTable
+    private function tableSlot(PersistentHashTable $descriptor, DescriptorSlot $slot): PersistentHashTable
     {
         return PersistentHashTable::fromCData(
-            Core::cast('HashTable *', $this->requireEntry($descriptor, $slot)->getRawPointer()),
+            Core::cast('HashTable *', $this->requireEntry($descriptor, $slot->value)->getRawPointer()),
         );
     }
 

--- a/src/OpCache/CacheMetaInfo.php
+++ b/src/OpCache/CacheMetaInfo.php
@@ -37,13 +37,19 @@ final class CacheMetaInfo
      */
     public const MAGIC = "OPCACHE\0";
 
+    /**
+     * The fields are published as public readonly and every reconstruction below passes them by
+     * NAME: four of the six are plain ints, so a positional call that transposes two of them
+     * compiles, runs and silently writes a corrupt cache header that only surfaces as a cache
+     * miss or a wrong payload much later.
+     */
     private function __construct(
-        private readonly SystemId $systemId,
-        private readonly int $memSize,
-        private readonly int $strSize,
-        private readonly int $scriptOffset,
-        private readonly int $timestamp,
-        private readonly int $checksum,
+        public readonly SystemId $systemId,
+        public readonly int $memSize,
+        public readonly int $strSize,
+        public readonly int $scriptOffset,
+        public readonly int $timestamp,
+        public readonly int $checksum,
     ) {}
 
     /**
@@ -65,12 +71,12 @@ final class CacheMetaInfo
         }
 
         return new self(
-            SystemId::fromBinary(FFI::string($struct->system_id, SystemId::LENGTH)),
-            $struct->mem_size,
-            $struct->str_size,
-            $struct->script_offset,
-            $struct->timestamp,
-            $struct->checksum,
+            systemId: SystemId::fromBinary(FFI::string($struct->system_id, SystemId::LENGTH)),
+            memSize: $struct->mem_size,
+            strSize: $struct->str_size,
+            scriptOffset: $struct->script_offset,
+            timestamp: $struct->timestamp,
+            checksum: $struct->checksum,
         );
     }
 
@@ -85,7 +91,14 @@ final class CacheMetaInfo
         int $timestamp,
         int $checksum,
     ): self {
-        return new self($systemId, $memSize, $strSize, $scriptOffset, $timestamp, $checksum);
+        return new self(
+            systemId: $systemId,
+            memSize: $memSize,
+            strSize: $strSize,
+            scriptOffset: $scriptOffset,
+            timestamp: $timestamp,
+            checksum: $checksum,
+        );
     }
 
     /**
@@ -113,6 +126,11 @@ final class CacheMetaInfo
         return (int) hexdec(hash('adler32', $payloadAndStrings));
     }
 
+    /**
+     * The accessors below are kept as the established reading API of this value object; each one
+     * is a thin delegate to the identically named public readonly property, so both spellings
+     * always agree and neither can be made to disagree by a future edit.
+     */
     public function systemId(): SystemId
     {
         return $this->systemId;
@@ -149,12 +167,26 @@ final class CacheMetaInfo
      */
     public function withTimestamp(int $timestamp): self
     {
-        return new self($this->systemId, $this->memSize, $this->strSize, $this->scriptOffset, $timestamp, $this->checksum);
+        return new self(
+            systemId: $this->systemId,
+            memSize: $this->memSize,
+            strSize: $this->strSize,
+            scriptOffset: $this->scriptOffset,
+            timestamp: $timestamp,
+            checksum: $this->checksum,
+        );
     }
 
     public function withChecksum(int $checksum): self
     {
-        return new self($this->systemId, $this->memSize, $this->strSize, $this->scriptOffset, $this->timestamp, $checksum);
+        return new self(
+            systemId: $this->systemId,
+            memSize: $this->memSize,
+            strSize: $this->strSize,
+            scriptOffset: $this->scriptOffset,
+            timestamp: $this->timestamp,
+            checksum: $checksum,
+        );
     }
 
     /**
@@ -162,7 +194,14 @@ final class CacheMetaInfo
      */
     public function withStrSize(int $strSize): self
     {
-        return new self($this->systemId, $this->memSize, $strSize, $this->scriptOffset, $this->timestamp, $this->checksum);
+        return new self(
+            systemId: $this->systemId,
+            memSize: $this->memSize,
+            strSize: $strSize,
+            scriptOffset: $this->scriptOffset,
+            timestamp: $this->timestamp,
+            checksum: $this->checksum,
+        );
     }
 
     /**

--- a/src/Reflection/FunctionBodySwap.php
+++ b/src/Reflection/FunctionBodySwap.php
@@ -261,7 +261,7 @@ final class FunctionBodySwap
         // The published bucket owns one reference on the name and one body share
         $namePointer = $containerCommon->function_name;
         assert($namePointer !== null);
-        StringEntry::fromCData($namePointer)->copy();
+        StringEntry::fromCData($namePointer)->addReference();
 
         self::addBodyReference($containerFunction);
         self::installFreshRunTimeCache($containerFunction);
@@ -278,7 +278,7 @@ final class FunctionBodySwap
     {
         $namePointer = $entryFunction->getCommonPointer()->function_name;
         assert($namePointer instanceof CData);
-        StringEntry::fromCData($namePointer)->copy();
+        StringEntry::fromCData($namePointer)->addReference();
 
         self::addBodyReference($entryFunction);
     }

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -175,7 +175,7 @@ class ReflectionClassConstant extends NativeReflectionClassConstant
         $docComment = $container->doc_comment;
         if ($docComment !== null) {
             assert($docComment instanceof CData);
-            StringEntry::fromCData($docComment)->copy();
+            StringEntry::fromCData($docComment)->addReference();
         }
         $adopted->referenceAttributes(1);
 

--- a/src/System/Compiler.php
+++ b/src/System/Compiler.php
@@ -89,18 +89,25 @@ class Compiler
     public const COMPILE_DEFAULT_FOR_EVAL = 0;
 
     /**
+     * The engine views below are bound to their compiler-globals table once, in the constructor,
+     * and are therefore published as `public private(set)`: everybody may read (and mutate through)
+     * the wrapper, nobody may swap the wrapper itself. A replaced view would silently detach the
+     * whole process from the engine table it is supposed to reflect.
+     */
+
+    /**
      * Contains a hashtable with all registered classes
      *
      * @var HashTable|ReflectionValue[]
      */
-    public HashTable $classTable;
+    public private(set) HashTable $classTable;
 
     /**
      * Contains a hashtable with all registered functions
      *
      * @var HashTable|ReflectionValue[]
      */
-    public HashTable $functionTable;
+    public private(set) HashTable $functionTable;
 
     /**
      * Holds an internal pointer to the compiler_globals structure

--- a/src/System/Executor.php
+++ b/src/System/Executor.php
@@ -23,18 +23,25 @@ use ZEngine\Type\ObjectEntry;
 class Executor
 {
     /**
+     * The engine views below are bound to their executor-globals table once, in the constructor,
+     * and are therefore published as `public private(set)`: everybody may read (and mutate through)
+     * the wrapper, nobody may swap the wrapper itself. A replaced view would silently detach the
+     * whole process from the engine table it is supposed to reflect.
+     */
+
+    /**
      * Contains a hashtable with all registered classes
      *
      * @var HashTable|ReflectionValue[string]
      */
-    public HashTable $classTable;
+    public private(set) HashTable $classTable;
 
     /**
      * Contains a hashtable with all registered functions
      *
      * @var HashTable|ReflectionValue[]
      */
-    public HashTable $functionTable;
+    public private(set) HashTable $functionTable;
 
     /**
      * Contains a hashtable with all registered constants (EG(zend_constants))
@@ -42,14 +49,14 @@ class Executor
      * Bucket values are IS_PTR zvals pointing to zend_constant structures, keyed by the
      * case-sensitive constant name (including persistent engine/extension constants).
      */
-    public HashTable $constantTable;
+    public private(set) HashTable $constantTable;
 
     /**
      * Represents the global object storage
      *
      * @var ObjectStore|ObjectEntry[]
      */
-    public ObjectStore $objectStore;
+    public private(set) ObjectStore $objectStore;
 
     /**
      * Holds an internal pointer to the executor_globals structure

--- a/src/Type/ArgumentEntry.php
+++ b/src/Type/ArgumentEntry.php
@@ -61,6 +61,9 @@ class ArgumentEntry
      * Argument send modes as returned by getSendMode()
      *
      * @see zend_compile.h:ZEND_SEND_BY_VAL/ZEND_SEND_BY_REF/ZEND_SEND_PREFER_REF
+     *
+     * @deprecated Use the SendMode enum (SendMode::ByValue/ByReference/PreferReference) instead;
+     *             these int aliases are kept for consumers that compare getSendMode() by value
      */
     public const SEND_BY_VAL     = 0;
     public const SEND_BY_REF     = 1;
@@ -139,11 +142,25 @@ class ArgumentEntry
     }
 
     /**
+     * Returns the argument send mode decoded from the type mask
+     *
+     * The engine only ever encodes three of the four bit patterns the two-bit field can hold, so
+     * the strict from() doubles as an invariant guard: a fourth pattern means the entry was read
+     * at a wrong offset and a ValueError is far better than a plausible-looking wrong answer.
+     */
+    public function sendMode(): SendMode
+    {
+        return SendMode::from(($this->typeMask >> self::SEND_MODE_SHIFT) & 3);
+    }
+
+    /**
      * Returns the argument send mode (one of the SEND_* constants)
+     *
+     * @deprecated Use sendMode() instead, which returns the SendMode enum
      */
     public function getSendMode(): int
     {
-        return ($this->typeMask >> self::SEND_MODE_SHIFT) & 3;
+        return $this->sendMode()->value;
     }
 
     /**
@@ -151,7 +168,7 @@ class ArgumentEntry
      */
     public function isByReference(): bool
     {
-        return $this->getSendMode() !== self::SEND_BY_VAL;
+        return $this->sendMode()->isByReference();
     }
 
     /**

--- a/src/Type/SendMode.php
+++ b/src/Type/SendMode.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\Type;
+
+/**
+ * Named view of the argument send mode packed into zend_type.type_mask
+ *
+ * The engine stores the mode in the two bits above _ZEND_SEND_MODE_SHIFT, so the decoded value is
+ * always one of exactly three states - a closed set that an int can only approximate. The backing
+ * values are the ZEND_SEND_* macro values from Zend/zend_compile.h for the PHP minor this branch
+ * targets; they are internal macros the header generator does not export, which is why the decode
+ * lives here rather than behind Core::engineConstant().
+ *
+ * @see ArgumentEntry::sendMode()
+ */
+enum SendMode: int
+{
+    /** ZEND_SEND_BY_VAL: the argument is passed by value (the default) */
+    case ByValue = 0;
+
+    /** ZEND_SEND_BY_REF: the argument is declared by reference and always passed as one */
+    case ByReference = 1;
+
+    /** ZEND_SEND_PREFER_REF: internal-function argument taken by reference when the caller has one */
+    case PreferReference = 2;
+
+    /**
+     * Checks if this mode passes the argument by reference (including the prefer-ref internal form)
+     */
+    public function isByReference(): bool
+    {
+        return $this !== self::ByValue;
+    }
+}

--- a/src/Type/StringEntry.php
+++ b/src/Type/StringEntry.php
@@ -216,19 +216,39 @@ class StringEntry implements ReferenceCountedInterface
     }
 
     /**
-     * Creates a copy of string value
+     * Takes one more engine reference on this string and returns the very same entry
+     *
+     * No copy is made and no new wrapper is produced: this is zend_string_copy(), which shares
+     * the existing string by bumping its counter, and is what a call site needs when an engine
+     * structure starts holding the string too. Interned and other immutable strings are handled
+     * exactly as the engine does - they are immortal, so no reference is taken - which is what
+     * separates this from the raw incrementReferenceCount() primitive underneath (that one
+     * refuses immutable payloads outright).
      *
      * @see zend_string.h::zend_string_copy function
-     *
-     * @return self
      */
-    public function copy(): self
+    public function addReference(): self
     {
         if (!$this->isInterned()) {
             $this->incrementReferenceCount();
         }
 
         return $this;
+    }
+
+    /**
+     * Creates a copy of string value
+     *
+     * @see zend_string.h::zend_string_copy function
+     *
+     * @return self
+     *
+     * @deprecated Use addReference() instead - this method never copied anything
+     */
+    #[\Deprecated(message: 'use StringEntry::addReference() instead - this method never copied anything', since: '8.4.1')]
+    public function copy(): self
+    {
+        return $this->addReference();
     }
 
     /**


### PR DESCRIPTION
## What this changes

Adopts the PHP 8.4 language features that actually change the shape of z-engine's public API, one focused commit per area. No behaviour change anywhere: every public entry point that worked before works after.

### 1. Asymmetric visibility on the engine-view instance properties (`258b762`)

`Executor::$classTable/$functionTable/$constantTable/$objectStore` and `Compiler::$classTable/$functionTable` are bound to their engine-globals table once in the constructor and only ever read afterwards — yet any consumer could overwrite them and silently detach the whole process from the table the wrapper is supposed to reflect. They are now `public private(set)`.

Verified with a grep over `src/` **and** `tests/` before the change: the only assignments to these properties are the constructor's own (`tests/System/ObjectStoreTest.php:26` assigns *its own* `$this->objectStore` property, not the executor's). Reads and mutations *through* the view are untouched.

`Core::$executor` / `$compiler` / `$modules` are **not** touched — they are static properties, and asymmetric visibility does not exist for statics.

### 2. Property hooks — evaluated per site, **skipped everywhere** (no commit)

Each candidate was checked against the one question that decides it: does the hook let anything be deleted?

| Site | Verdict | Why |
|---|---|---|
| `Compiler::isInCompilation()` / `setCompilationMode()` | **skip** | The setter is `void`, so a hook pair is technically possible — but both methods are public API and one of them is called internally by `parseString()`, so neither can be removed. The result would be two spellings of one field with nothing deleted. |
| `Compiler::getOptions()` / `setOptions()` | **skip** | Same shape, same conclusion. It would additionally churn a `phpstan-baseline.neon` entry (`getOptions() should return int but returns mixed`) for no gain. |
| `Node::getLine()` / `setLine()` | **skip** | Both are declared in `NodeInterface` and **overridden** in `ValueNode` and `DeclarationNode` (which read `val.u2.lineno` and `start_lineno` instead). Replacing them with a virtual `$line` hook means either leaving the interface methods in place (two spellings across a three-class hierarchy) or declaring hooks in the interface — a BC break for any external `NodeInterface` implementor. |
| `Executor::setErrorReporting()`, `Compiler::setExtraFnFlags()` | **stay methods** | Both **return the previous value** (`error_reporting()`-style swap). A `set` hook returns nothing, so these cannot be hooks at all. `setCompilationMode()` was checked too: it returns `void`, so it was not excluded on this ground — it was excluded on the duplication ground above. |

So this PR ships **no property hooks**. Adding them would have meant, in every single case, a second way to do the same thing with no deletion possible.

### 3. Backed enums for the constant groups z-engine owns (`eb5fbf2`)

Only for sets that z-engine itself defines; ABI-mirrored values stay class constants. Style follows the existing precedents `ClassExtension\Hook\CastType` and `PropertyPurpose`.

- **`ZEngine\Type\SendMode`** — the three argument send modes decoded from the two bits above `_ZEND_SEND_MODE_SHIFT`. New `ArgumentEntry::sendMode(): SendMode`; the strict `from()` now doubles as an invariant guard, because the fourth bit pattern the field can physically hold is one the engine never writes (so it means the entry was read at a wrong offset).
  *Decision:* `tests/Reflection/FunctionLikeInfoTest.php:128,132` does `assertSame(ArgumentEntry::SEND_BY_VAL, $first->getSendMode())`, i.e. it reads the constants and the return value as **ints**. As instructed, `getSendMode(): int` is therefore **kept** (now a `->value` delegate, marked `@deprecated`) and the enum-returning accessor was **added** alongside as `sendMode()`. The `SEND_*` int constants stay as `@deprecated` aliases. The test passes untouched.
- **`ZEngine\EngineExtension\DependencyType` + `VersionRelation`** — replacing `MODULE_*` ints and the `KNOWN_RELATIONS` string list. Both enums own the normalization of legacy scalar input via `fromValue()`, which is what let the two hand-rolled `in_array()` validation blocks be deleted from the `ModuleDependency` constructor.
  *Decision:* `tests/EngineExtension/AbstractModuleTest.php:162` calls `ModuleDependency::required('standard', 'unknown-relation', '1.0')` and expects an `InvalidArgumentException`. A hard `VersionRelation` parameter type would raise a `TypeError` instead and fail that test, so the constructor and factories accept `VersionRelation|string|null` (and `DependencyType|int`) and normalize inside — same exception class, same messages. `getDependencyType(): int` and `getRelation(): ?string` are kept as `@deprecated` scalar delegates; `dependencyType()` and `versionRelation()` return the enums, and `AbstractModule::attachDependencies()` (the only internal consumer) is migrated to them.
- **`ZEngine\Memory\DescriptorSlot`** — the persistent-heap descriptor slots. These were `private const`, so this one is fully internal: `tableSlot()` takes the enum, and the generic integer-keyed helpers (`requireEntry()`, `addPointerEntry()`, `addLongEntry()` — which also serve plain payload indexes, not just slots) take `->value` at the boundary. The backing values are documented as layout that must stay stable, because a persistent region outlives the process that wrote it.

### 4. `CacheMetaInfo`: named arguments for every reconstruction (`b209942`)

Six fields, four of them plain `int`, rebuilt positionally in three `with*()` methods plus `parse()` and `forPayload()`. Transposing `memSize` with `strSize` (or `timestamp` with `checksum`) compiles, runs and writes a silently corrupt file-cache header that only surfaces much later as a cache miss or a wrong payload. All five reconstructions now pass arguments **by name**.

*Decision:* `tests/OpCache/CacheMetaInfoTest.php` reads the header exclusively through the accessor methods (`memSize()`, `timestamp()`, …), so those stay — plain, not deprecated — as thin delegates to the now `public readonly` properties of the same name. The test file is unchanged.

### 5. `StringEntry::copy()` → `addReference()` (`f5d7b0e`)

`copy()` never copied anything: it mirrors `zend_string_copy()`, which shares the string by taking one more reference (none for an immortal interned string) and returns the same entry. The name invited call sites to believe they held an independent string — for engine memory, that misunderstanding ends in a double release.

*Similar-name check, as requested:* `ReferenceCountedTrait::incrementReferenceCount()` already exists and is **not** a substitute — it refuses immutable payloads outright, while this operation must apply the engine's interned-is-immortal rule and no-op for them. `StringEntry` had no `addReference`/`acquire` of its own (`ReflectionValue::addReference()` is the analogous method on the zval wrapper, so the name is consistent). A new method is therefore justified, and `copy()` becomes a delegate.

*Decision on the deprecation mechanism:* no test calls `copy()`, and all three internal callers (`FunctionBodySwap` ×2, `ReflectionClassConstant::fromRawEntry()`'s adopted doc comment — the third one the brief did not list) are migrated, so nothing in the library emits the deprecation. That makes the runtime `#[\Deprecated(message: …, since: '8.4.1')]` attribute safe under the suite's `failOnDeprecation="true"`, and it is used rather than a docblock-only deprecation.

### Adjacency with #213

PR #213 (open) owns the `getAST()` region of `src/System/Compiler.php` and the `fromCData()` region of `src/AbstractSyntaxTree/Node.php`. This PR touches **neither**: the only `Compiler.php` hunk is the property block at the top of the class (lines ~91-105), and `Node.php` is **not modified at all** (the `getLine()`/`setLine()` hook was evaluated and skipped, see §2). No textual overlap is expected on merge.

### BC guarantees

- No public method, constant or property was removed or had its signature narrowed.
- `ArgumentEntry::SEND_*`, `ArgumentEntry::getSendMode(): int`, `ModuleDependency::MODULE_*`, `getDependencyType(): int`, `getRelation(): ?string`, all six `CacheMetaInfo` accessors and `StringEntry::copy()` keep working; the first six are `@deprecated` docblocks only (no runtime notice), `copy()` carries the runtime attribute.
- `ModuleDependency`'s constructor and factories widened (`DependencyType|int`, `VersionRelation|string|null`) — accepting strictly more than before.
- `public private(set)` only removes an ability nothing in the repository ever used.
- The entire `tests/` tree is untouched by this PR.

## Environment it was verified on

- PHP version (full first line of `php -v`): `PHP 8.5.9 (cli) (built: Jul 30 2026 15:13:42) (NTS)` — **this is PHP 8.5, not the 8.4 this branch targets**
- Thread safety: NTS
- OS / architecture: Linux x86_64
- Debug build (`--enable-debug`)? no

**Running the test suite locally was impossible and was deliberately not attempted.** The container interpreter is 8.5.9 while this branch targets PHP 8.4; per AGENTS.md's non-negotiable version rule, no z-engine code — nothing reaching `Core::init()` — was executed. Verification was static only:

- `vendor/bin/phpstan analyse --no-progress` → **[OK] No errors** (level max)
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix` → **0 of 309 files fixed**, and the follow-up `--dry-run` is clean
- `php -l` on every changed file
- Baseline audit: re-ran the analysis with `reportUnmatchedIgnoredErrors: true` — no `phpstan-baseline.neon` entry was freed by these changes, so nothing was pruned (the 8 unmatched inline ignores reported are pre-existing, in `ClassExtension/Hook/*` files this PR does not touch). No baseline entries were added either.

CI on the 8.4 runners is the real gate for `composer test`.

## Checklist

- [x] Targets the **minimum affected version branch** — base is `8.4`
- [ ] `composer test` passes on the matching PHP minor — **could not be run**: container is PHP 8.5, branch targets 8.4 (see above). Left to CI.
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated — none needed and none changed: this is an additive API-shaping PR whose whole point is that the existing suite passes unmodified. No new struct is dereferenced, so `layout_structs` is unaffected.
- [x] `tools/generator/symbols.php` unchanged; nothing under `include/`, `stubs/` or `.phpstorm.meta.php` was touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG)_