### PR TITLE
refactor: syntax-pass follow-up for the sites the merged pass missed

### DIFF
--- a/src/ClassExtension/Hook/GetClosureHook.php
+++ b/src/ClassExtension/Hook/GetClosureHook.php
@@ -214,7 +214,7 @@ final class GetClosureHook extends AbstractHook
             $callable = [$instance, $methodName];
             assert(is_callable($callable));
 
-            return \Closure::fromCallable($callable);
+            return $callable(...);
         }
 
         $scope = $common->scope;
@@ -224,6 +224,6 @@ final class GetClosureHook extends AbstractHook
         $callable = StringEntry::fromCData($scopeName)->getStringValue() . '::' . $methodName;
         assert(is_callable($callable));
 
-        return \Closure::fromCallable($callable);
+        return $callable(...);
     }
 }


### PR DESCRIPTION
Verification follow-up to #217 (merged as a8600ab). The whole `src/` tree was re-swept against every family that pass covered; this PR carries the only genuine sites it missed.

## What changed

**First-class callable syntax — 2 sites** (`src/ClassExtension/Hook/GetClosureHook.php`)

`GetClosureHook::proceed()` still rebuilt its fallback closures through `Closure::fromCallable()`. #217 converted the trampoline installers in `AbstractHook` (`Closure::fromCallable([$this, 'handle'])` → `$this->handle(...)`) but did not reach these two. Since PHP 8.1 `$callable(...)` is defined to be exactly `Closure::fromCallable($callable)`, and it works for both shapes used here — the `[$instance, $methodName]` array for a bound method and the `'Scope::method'` string for a static one.

## What was checked and deliberately left alone

The re-sweep covered every family from the original pass. Everything below was examined and is correct as-is — no churn commits were made for it.

| Family | Finding |
|---|---|
| `#[\Override]` | Complete. A PHP-Parser scan resolving every `src/` class against its parent chain, interfaces and traits (plus native reflection for engine/SPL ancestors) reports **11** methods overriding an ancestor without the attribute — **all 11 are `__construct`**, which the attribute does not apply to. **0 spurious** attributes on non-overriding methods. |
| `src/System/ExecutionData.php` | Was on the original pass's skip list and is genuinely untouched by #217 — but it has **nothing to sweep**. No inheritance or interfaces (no `#[\Override]` candidates), no class constants, no `switch`, no callable literals, no search loops, no `strpos()`/`get_class()`/`empty()`/self-coalesce idioms. It is clean by construction, not by omission. |
| Typed class constants | All `int`/`string` constants are typed. The 8 remaining untyped ones are **array** constants, which the original pass did not cover — typing them is a separate decision, not a missed site. |
| `switch` → `match` | 3 `switch` statements remain (`PayloadRelocator::serializeZval()`/`unserializeZval()`, `PersistentGraphCloner::validateValue()`). None is a value-match candidate: the arms are multi-statement bodies with side effects, and two carry no `default`, so a `match` would need a synthetic `default => null` and would read worse. Correctly left as statements. |
| `array_find`/`array_any` | 2 hand-rolled search loops remain (`ClassSpecializer::typeContainsPlaceholder()`, `::methodNeedsArgInfoSubstitution()`). Both iterate **generators** (`typeListEntries()`, `argInfoEntries()`), and the array predicates require a real `array` — converting would force an `iterator_to_array()` that materializes the whole list and defeats the short-circuit. Correctly left as loops. |
| `get_class()` → `::class` | 1 site remains (`ReflectionClass::__construct()`). Attempted and **reverted**: `$classNameOrObject` is untyped (`mixed`, matching the parent signature), and `get_class()` is what narrows it to `class-string` for PHPStan. The conversion produced 3 level-max errors. Making it work needs a parameter type — a signature change, out of scope for a syntax pass. |
| `str_starts_with`, `??=`, `empty()` on typed arrays, `[$this, 'm']` callables, `is_null`, `list()`, `call_user_func` | No remaining sites. |

## Verification

Static-only (container PHP is 8.5, this branch targets 8.4 — nothing reaching `Core::init()` was run, per AGENTS.md).

- `vendor/bin/phpstan analyse` (level max) — **no errors**
- `PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix` — **0 of 312 files fixed**, `--dry-run` clean
- `phpstan-baseline.neon` untouched; no `include/`, `stubs/`, `tests/` or config files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnoZ7wuGepCTzsmFQ5sKxG)_