### PR TITLE
ci: key the docker layer caches on the base image so they can be refreshed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,11 @@ jobs:
     # own source (a full PHP compile) and run the tests in it. The build goes
     # through buildx so its layers can be cached across runs with actions/cache
     # - a warm cache turns the multi-minute compile into a layer restore.
+    #
+    # The cache key names every input that can change the image: OS,
+    # architecture, thread safety, PHP minor, the recipe, and the digest of the
+    # base image. See "Resolve the base image digest" below for why the last one
+    # is not optional.
     strategy:
       fail-fast: false
       matrix:
@@ -357,32 +362,105 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # `php:<minor>-cli` is a moving tag: every PHP patch release and every
+      # Debian security rebuild gives it a new digest, and buildx then rightly
+      # invalidates the compile layer built on top of it. A key that cannot
+      # notice that is a cache that can never be repaired - actions/cache reports
+      # a hit, refuses to overwrite the entry it already holds ("Cache hit
+      # occurred on the primary key ..., not saving cache"), and the freshly
+      # rebuilt layers are discarded at the end of every run. From then on every
+      # run recompiles PHP from source, forever, until somebody edits the
+      # Dockerfile. Putting the digest in the key makes the entry expire exactly
+      # when a rebuild would produce something different - and only then.
+      # imagetools reads the manifest from the registry, so this costs one API
+      # call rather than the layers a hit exists to avoid pulling.
+      - name: Resolve the base image digest
+        id: image-cache-key
+        run: |
+          # Prints the raw manifest only on success, so a failed attempt cannot
+          # feed half a response into the hash and make the key drift.
+          resolve() {
+            local raw
+            for attempt in 1 2 3; do
+              if raw="$(docker buildx imagetools inspect "$1" --raw)" && [ -n "$raw" ]; then
+                printf '%s' "$raw"
+                return 0
+              fi
+              sleep "$((attempt * 3))"
+            done
+            return 1
+          }
+          if digest="$(resolve "php:${PHP_MINOR}-cli" | sha256sum | cut -d' ' -f1)" && [ "${#digest}" -eq 64 ]; then
+            echo "php:${PHP_MINOR}-cli is sha256:${digest}"
+          else
+            # A registry hiccup must not fail this job over a cache key. A
+            # run-unique value guarantees a miss, so the restore-keys still give a
+            # warm start, the build is still correct, and the entry written under
+            # it is simply never matched again.
+            digest="unresolved-${{ github.run_id }}"
+            echo "::warning::Could not resolve the php:${PHP_MINOR}-cli digest - building without an exact cache key"
+          fi
+          # Thread safety and minor come first so the loosest restore-key below
+          # still matches entries written before OS/arch joined the key.
+          prefix="docker-debug-${{ matrix.ts }}-${PHP_MINOR}-${{ runner.os }}-${{ runner.arch }}-"
+          {
+            echo "prefix=${prefix}"
+            echo "recipe=${prefix}${{ hashFiles('tools/docker/php-debug.Dockerfile') }}-"
+            echo "key=${prefix}${{ hashFiles('tools/docker/php-debug.Dockerfile') }}-${digest}"
+          } >> "$GITHUB_OUTPUT"
+
+      # restore/save rather than the combined action: on an exact hit every layer
+      # in the directory is still valid, so there is nothing to write back and the
+      # `--cache-to` export below can be skipped outright. That export is not free
+      # - the header-drift job measures it at 13-15s per target - and today it is
+      # paid on every run only to be thrown away. The prefix keys still give a warm
+      # start when the base image moved, which is what keeps that rebuild
+      # incremental instead of a compile from zero.
       - name: Restore the debug image layer cache
-        uses: actions/cache@v6
+        id: layer-cache
+        uses: actions/cache/restore@v6
         with:
           path: /tmp/.buildx-cache
-          key: docker-debug-${{ matrix.ts }}-${{ env.PHP_MINOR }}-${{ hashFiles('tools/docker/php-debug.Dockerfile') }}
+          key: ${{ steps.image-cache-key.outputs.key }}
           restore-keys: |
+            ${{ steps.image-cache-key.outputs.recipe }}
+            ${{ steps.image-cache-key.outputs.prefix }}
             docker-debug-${{ matrix.ts }}-${{ env.PHP_MINOR }}-
 
       - name: Build the debug PHP image
         run: |
           mkdir -p /tmp/.buildx-cache
+          # Export the layers only when this run may actually store them.
+          cache_to=""
+          if [ "${{ steps.layer-cache.outputs.cache-hit }}" != "true" ]; then
+            cache_to="--cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max"
+          fi
           docker buildx build \
             -f tools/docker/php-debug.Dockerfile \
             --build-arg "PHP_VERSION=${PHP_MINOR}" \
             --build-arg "PHP_TS=${{ matrix.ts }}" \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache-new,mode=max" \
+            $cache_to \
             --load \
             -t z-engine-php:debug .
 
       # Rotate instead of appending: a reused local cache dir accumulates stale
       # layers without bound, so each run saves only the layers it actually used
       - name: Rotate the layer cache
+        if: steps.layer-cache.outputs.cache-hit != 'true'
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      # Saved before the tests run, not in a post step: these layers are the
+      # expensive part and they are already correct here, so a failing test
+      # should not cost the next run the compile as well.
+      - name: Save the debug image layer cache
+        if: steps.layer-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ steps.image-cache-key.outputs.key }}
 
       - name: Run internal group with process isolation
         run: |
@@ -408,17 +486,71 @@ jobs:
       # Caches the generator image's toolchain layers (apt/clang/ext-ffi); the
       # emit stage itself always re-runs - it is the step that produces the
       # artifacts being drift-checked. generate.php rotates per-target subdirs.
+      #
+      # Both base images go into the key: this job builds one image per target
+      # and nts starts from `php:<minor>-cli` while zts starts from
+      # `php:<minor>-zts`, so either tag moving invalidates the toolchain layer.
+      # Without them the entry freezes at whatever the first run produced and can
+      # never be rewritten - which is the state this job was already in, paying
+      # ~16s to reinstall clang and ~15s to export a cache nobody would store, on
+      # every single run. See the same reasoning in tests-internal-debug.
+      - name: Resolve the base image digests
+        id: gen-cache-key
+        run: |
+          # Same helper as tests-internal-debug: prints the raw manifest only on
+          # success, so a failed attempt cannot feed half a response into the hash.
+          resolve() {
+            local raw
+            for attempt in 1 2 3; do
+              if raw="$(docker buildx imagetools inspect "$1" --raw)" && [ -n "$raw" ]; then
+                printf '%s' "$raw"
+                return 0
+              fi
+              sleep "$((attempt * 3))"
+            done
+            return 1
+          }
+          if cli="$(resolve "php:${PHP_MINOR}-cli")" && zts="$(resolve "php:${PHP_MINOR}-zts")"; then
+            digest="$(printf '%s%s' "$cli" "$zts" | sha256sum | cut -d' ' -f1)"
+            echo "php:${PHP_MINOR}-cli + php:${PHP_MINOR}-zts hash to ${digest}"
+          else
+            # As above: a registry hiccup costs an exact key, never the job.
+            digest="unresolved-${{ github.run_id }}"
+            echo "::warning::Could not resolve the php:${PHP_MINOR} base image digests - building without an exact cache key"
+          fi
+          prefix="docker-gen-${PHP_MINOR}-${{ runner.os }}-${{ runner.arch }}-"
+          {
+            echo "prefix=${prefix}"
+            echo "recipe=${prefix}${{ hashFiles('tools/generator/Dockerfile') }}-"
+            echo "key=${prefix}${{ hashFiles('tools/generator/Dockerfile') }}-${digest}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Restore the generator image layer cache
-        uses: actions/cache@v6
+        id: gen-layer-cache
+        uses: actions/cache/restore@v6
         with:
           path: /tmp/.buildx-gen-cache
-          key: docker-gen-${{ env.PHP_MINOR }}-${{ hashFiles('tools/generator/Dockerfile') }}
+          key: ${{ steps.gen-cache-key.outputs.key }}
           restore-keys: |
+            ${{ steps.gen-cache-key.outputs.recipe }}
+            ${{ steps.gen-cache-key.outputs.prefix }}
             docker-gen-${{ env.PHP_MINOR }}-
+
+      # On an exact hit the restored layers are still valid, so generate.php is
+      # told to read the cache without exporting it again - the export is the
+      # expensive half and there would be nowhere to put the result.
       - name: Regenerate engine definitions
         run: composer gen-headers
         env:
           Z_ENGINE_BUILDX_CACHE_DIR: /tmp/.buildx-gen-cache
+          Z_ENGINE_BUILDX_CACHE_READONLY: ${{ steps.gen-layer-cache.outputs.cache-hit == 'true' && '1' || '' }}
+
+      - name: Save the generator image layer cache
+        if: steps.gen-layer-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: /tmp/.buildx-gen-cache
+          key: ${{ steps.gen-cache-key.outputs.key }}
       - name: Fail if the committed artifacts are stale
         run: |
           if ! git diff --exit-code -- include/ stubs/ .phpstorm.meta.php; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,35 @@ FFI `CData` access is dynamically typed and cannot be statically resolved;
 those violations are captured in `phpstan-baseline.neon`. New code must be
 clean at level max — do not add to the baseline without good reason.
 
+### A docker cache key must name the base image, not only the recipe
+
+Two CI jobs build docker images from a `php:<minor>-*` tag — `tests-internal-debug`
+(a full `--enable-debug` PHP compile) and `header-drift` (the generator toolchain) —
+and both wrap the buildx layer cache in `actions/cache`. Those tags **move**: every
+PHP patch release and every Debian security rebuild republishes them under a new
+digest, and buildx correctly invalidates every layer built on top.
+
+`actions/cache` entries are **immutable**. So a key derived only from the Dockerfile
+cannot express that change: the restore reports a hit, the save is refused (`Cache
+hit occurred on the primary key ..., not saving cache`), and the layers the run just
+rebuilt are discarded when it ends. Every later run then repeats the rebuild —
+minutes of PHP compile for the debug image — and can never repair itself until
+somebody happens to edit the Dockerfile. `header-drift` sat in exactly that state,
+paying ~16s to reinstall clang plus ~15s to export a cache that was never stored,
+on every run.
+
+So the key resolves the base image digest first (`docker buildx imagetools inspect
+--raw`, a registry read — do not `docker pull` for this) and carries it, alongside
+OS, architecture, thread safety and the PHP minor. The entry then expires exactly
+when a rebuild would produce something different, and only then. Two rules follow:
+
+- **Never reduce that key to the Dockerfile hash again**, and never "fix" a stale
+  image by bumping a version suffix by hand — the digest is the version suffix.
+- The `--cache-to` export is skipped on an exact hit (`Z_ENGINE_BUILDX_CACHE_READONLY`
+  for the generator), because an exact hit means every restored layer is still valid
+  and there is nowhere to store a new copy. Keep the restore/save split that makes
+  this possible instead of collapsing it back into `actions/cache`.
+
 ## Public APIs never leak CData
 
 Only the z-engine core layer (`Core`, the `Type\*`/`Reflection\*` wrappers) deals in

--- a/tools/generator/generate.php
+++ b/tools/generator/generate.php
@@ -463,6 +463,14 @@ if ($usesProxy && is_string($caBundle) && $caBundle !== '' && is_readable($caBun
 $layerCacheDir = getenv('Z_ENGINE_BUILDX_CACHE_DIR');
 $layerCacheDir = is_string($layerCacheDir) && $layerCacheDir !== '' ? rtrim($layerCacheDir, '/') : '';
 
+// Z_ENGINE_BUILDX_CACHE_READONLY=1 reads the cache without writing it back.
+// Exporting the layers again costs real time (13-15s per target) and is pure
+// waste when the caller already knows the cache it restored is current and will
+// not be storing a new copy - which is exactly the case on an actions/cache hit,
+// since its entries are immutable.
+$layerCacheReadOnly = getenv('Z_ENGINE_BUILDX_CACHE_READONLY');
+$layerCacheReadOnly = is_string($layerCacheReadOnly) && $layerCacheReadOnly !== '' && $layerCacheReadOnly !== '0';
+
 $failures = 0;
 foreach ($targets as $target) {
     $baseImage = $mirror . ($target['ts'] === 'zts' ? "php:{$target['php']}-zts" : "php:{$target['php']}-cli");
@@ -475,7 +483,9 @@ foreach ($targets as $target) {
         if (is_dir($targetCacheDir)) {
             $cacheArguments .= ' --cache-from ' . escapeshellarg("type=local,src={$targetCacheDir}");
         }
-        $cacheArguments .= ' --cache-to ' . escapeshellarg("type=local,dest={$targetCacheDir}-new,mode=max");
+        if (!$layerCacheReadOnly) {
+            $cacheArguments .= ' --cache-to ' . escapeshellarg("type=local,dest={$targetCacheDir}-new,mode=max");
+        }
     }
 
     $command = 'docker buildx build --progress=plain'


### PR DESCRIPTION
## What this changes

Both docker-building CI jobs cache their buildx layers through `actions/cache` under a key derived only from the Dockerfile:

```yaml
key: docker-debug-${{ matrix.ts }}-${{ env.PHP_MINOR }}-${{ hashFiles('tools/docker/php-debug.Dockerfile') }}
key: docker-gen-${{ env.PHP_MINOR }}-${{ hashFiles('tools/generator/Dockerfile') }}
```

`actions/cache` entries are **immutable**, so that key cannot change while the recipe stands still — and the images it describes do not stand still. `php:<minor>-cli` and `php:<minor>-zts` are moving tags: a PHP patch release or a Debian security rebuild republishes them under a new digest, buildx correctly invalidates every layer above the `FROM`, and the run rebuilds them. Then the save is refused and the repaired layers are discarded when the job ends. Every later run repeats the same rebuild, and the cache can never heal itself — until somebody happens to edit the Dockerfile.

**`header-drift` is already in that state.** From the logs of the latest `master` run (job 95286967428):

```
#10 [build 5/6] RUN apt-get update && apt-get install ... clang ...
#10 DONE 15.7s                                  ← re-ran, was not CACHED
#14 exporting cache to client directory
#14 preparing build cache for export 13.2s done
#14 DONE 14.8s                                  ← mode=max export, ~30s for both targets
...
Cache hit occurred on the primary key docker-gen-8.5-fcdc8a1d…, not saving cache.
```

~30s of rebuild plus ~30s of export, thrown away, on every run. `tests-internal-debug` carries the same key and therefore the same trap, except the layer it would rebuild is a full `--enable-debug` PHP compile — minutes, not seconds. Its logs (job 95286967496) currently show `#12 CACHED`, so it has not been tripped yet; nothing prevents it.

### The fix

The key now names every input that can change the image — thread safety, PHP minor, OS, architecture, the recipe hash, and the **digest of the base image**:

```
docker-debug-<ts>-<minor>-<os>-<arch>-<dockerfile-hash>-<base-digest>
docker-gen-<minor>-<os>-<arch>-<dockerfile-hash>-<digest of cli + zts>
```

The digest comes from `docker buildx imagetools inspect --raw` — a registry manifest read, not a pull, so a hit still costs nothing. The entry now expires exactly when a rebuild would produce something different, and only then; there is no date rotation and no key to bump by hand. Thread safety and minor stay at the **front** of the key so the loosest `restore-key` still matches today's entries — the first run after this merge gets a warm start instead of a cold compile.

Two consequences come with it:

- **`actions/cache` is split into `restore` + `save`.** On an exact hit every restored layer is valid and there is nowhere to store a new copy, so the save is skipped — and the `--cache-to` export is skipped with it. That export is the expensive half (13–15s per target measured above). For the generator this needed a new `Z_ENGINE_BUILDX_CACHE_READONLY` switch in `generate.php`, which drops `--cache-to` (and with it the rotate, which is already conditional on the `-new` directory existing).
- **A registry hiccup costs an exact key, never the job.** `imagetools` is retried three times with backoff; on failure the step warns and falls back to a run-unique digest value, which guarantees a miss — the restore-keys still warm the build, the result is still correct, and the entry written under that key is simply never matched again.

`AGENTS.md` gains a short section under "Quality gates" recording why the digest is in the key, so this does not get simplified back to `hashFiles()` later.

## Environment it was verified on

- PHP version (full first line of `php -v`): `PHP 8.5.9 (cli) (built: Jul 30 2026 15:13:42) (NTS)` — host only; see the note below
- Thread safety: NTS
- OS / architecture: Linux x64
- Debug build (`--enable-debug`)? no

**What was and was not verified locally.** This change is CI configuration, and the box it was prepared on runs PHP 8.5.9, which does not satisfy this branch's `php ~8.4.0` — so `composer install` cannot resolve here and `composer test` / `phpstan` / `cs:check` were **not** run. That is the version-matching rule working as intended, not something to route around. What was verified instead:

- Both new key steps were **executed** under GitHub's exact shell (`bash --noprofile --norc -eo pipefail`) with a stubbed `$GITHUB_OUTPUT`. They produce the expected `prefix` / `recipe` / `key` values, and the digest for `php:8.4-cli` matches what Docker Hub reports for that tag.
- The failure path was exercised with a `docker` stub that always exits 1: three retries, one `::warning::`, fallback key, step exits 0.
- `php -l` is clean on `generate.php`; the workflow parses as YAML and every `run:` block passes `bash -n`.
- The docker builds themselves were not run (no daemon available). The first CI run on this PR is the real check — expect a **restore-key** hit rather than an exact one on both jobs, since these keys are new.

## Checklist

- [x] Targets the **minimum affected version branch** — the bug is present on `8.4` and `master`, so it lands on `8.4` and cascades up
- [ ] `composer test` passes on the matching PHP minor — not runnable here (host is PHP 8.5, branch requires ~8.4.0); no runtime code changed
- [ ] `composer phpstan` (level max) and `composer cs:check` are green — same reason; the only PHP change is 8 lines in `tools/generator/generate.php` following the style of the lines above it
- [ ] Tests added or updated — n/a, no `src/` change and no new struct dereference
- [x] `tools/generator/symbols.php` unchanged, so nothing under `include/`, `stubs/` or `.phpstorm.meta.php` needed regenerating
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBWEmGUKhtVGSwtQ6ixuQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBWEmGUKhtVGSwtQ6ixuQT)_