### PR TITLE
fix(core): load the engine-constants artifact eagerly in init() — un-breaks the debug legs on master

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -332,6 +332,7 @@ class Core
         self::$isShutdown = false;
 
         self::preloadFrameworkClasses();
+        self::loadEngineConstants();
 
         self::$initialized = true;
     }
@@ -1135,14 +1136,37 @@ class Core
      */
     public static function engineConstant(string $name): int
     {
-        self::$engineConstants ??= require self::resolveArtifact('constants.php');
-        if (!array_key_exists($name, self::$engineConstants)) {
+        $engineConstants = self::loadEngineConstants();
+        if (!array_key_exists($name, $engineConstants)) {
             throw new \InvalidArgumentException(
                 "Unknown engine constant {$name}: it is not exported by tools/generator/symbols.php",
             );
         }
 
-        return self::$engineConstants[$name];
+        return $engineConstants[$name];
+    }
+
+    /**
+     * Loads the generated engine-constants table (idempotent)
+     *
+     * Called eagerly from init(): the artifact must never be require'd lazily from
+     * inside an engine callback. With opcache active that include compiles through
+     * persistent_compile_file(), whose unconditional zend_begin_record_errors() nests
+     * inside the recording a linking path already holds (zend_do_link_class) and
+     * aborts debug builds - and the interface_gets_implemented hook is exactly such a
+     * callback-during-linking site.
+     *
+     * @return array<string, int>
+     */
+    private static function loadEngineConstants(): array
+    {
+        if (self::$engineConstants === null) {
+            /** @var array<string, int> $engineConstants The artifact returns the generated table */
+            $engineConstants       = require self::resolveArtifact('constants.php');
+            self::$engineConstants = $engineConstants;
+        }
+
+        return self::$engineConstants;
     }
 
     /**


### PR DESCRIPTION
## What this changes

Fixes the red debug legs on `master` after the #246 cascade (run [32294472570](https://github.com/lisachenko/z-engine/actions/runs/32294472570)): the interface-hook child of `OpcacheSupportMatrixTest::testHandlerInstallationDuringLazyLinkingIsRejected` aborted on the **PHP 8.5 debug build** with

```
Zend/zend.c:1779: zend_begin_record_errors: Assertion `!(executor_globals.record_errors) && "Error recording already enabled"' failed.
```

**Root cause** (gdb-confirmed against a `--enable-debug` PHP 8.5.9 built from `tools/docker/php-debug.Dockerfile`): `Core::engineConstant()` `require`'d the generated `constants.php` artifact lazily on first use. In the child, that first use happened **inside the `interface_gets_implemented` hook**, i.e. while `zend_do_link_class` holds error recording for the inheritance cache. With opcache active the include compiles through `persistent_compile_file()`, whose *unconditional* `zend_begin_record_errors()` nests and trips the debug assertion. The 8.4 debug leg passed only by load-order luck — the same latent hazard exists on both lines, so per the branch model this lands on `8.4` and cascades.

**Fix**: load the constants table once during `Core::init()` — before any hook can fire — via a shared `loadEngineConstants()`; `engineConstant()` keeps its exact contract. On release builds the nested recording was silently tolerated (mis-scoped error records at worst), so this also removes a latent correctness wart, not just a debug-only abort.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — additionally verified against a debug **PHP 8.5.9** built with `tools/docker/php-debug.Dockerfile`: the child reproduces the abort without this change; `phpunit --group opcache --fail-on-skipped` (the exact failing CI invocation) and `--group internal --process-isolation` are green with it.

## Checklist

- [x] Targets the **minimum affected version branch** (`8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor (both `opcache.enable_cli` modes)
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated — the existing interface-hook child is the regression test (it aborts on debug 8.5 without this fix); no new struct dereferences
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_