### PR TITLE
test(opcache): fold-proof module-visibility checks, opcache-on request-cycle child

### DIFF
--- a/docs/long-running.md
+++ b/docs/long-running.md
@@ -124,6 +124,21 @@ Runtime-registered modules are wired for the current request only: after `Core::
 the entry keeps no callback pointers, so subsequent requests of the same process (FPM,
 workers) see the module without lifecycle callbacks unless it is registered again.
 
+### Module visibility and opcache constant folding
+
+A runtime-registered module is a genuine `module_registry` entry, and every **runtime**
+lookup sees it: `extension_loaded($name)` with a runtime-built name,
+`get_loaded_extensions()`, `new \ReflectionExtension(...)`, the `phpinfo()` module
+section. But opcache's optimizer pre-evaluates `extension_loaded('<literal>')` while the
+calling script is being **compiled** (`zend_optimizer_eval_special_func_info()`): a module
+that is not in the registry at compile time — with `enable_dl` off — folds the call to
+constant `false`, baked into the cached op array. A z-engine module registers at runtime,
+after the caller was compiled, so with opcache active such literal call sites keep
+answering `false` no matter how the registration went; `dl()`-loaded extensions face the
+same fold ([#243](https://github.com/lisachenko/z-engine/issues/243)). Ask
+`ExtensionManager::has()` / `AbstractModule::isModuleRegistered()` instead (both are
+fold-proof by construction), or pass the extension name through a variable.
+
 ## Immortal-by-design allocations
 
 The debug-build leak gate treats the following as expected, by design:

--- a/tests/EngineExtension/AbstractModuleTest.php
+++ b/tests/EngineExtension/AbstractModuleTest.php
@@ -40,7 +40,10 @@ class AbstractModuleTest extends TestCase
 
         $module->register();
         $this->assertTrue($module->isModuleRegistered());
-        $this->assertTrue(extension_loaded('lifecycle'));
+        // Runtime-built name on purpose: under an opcache-active runner the optimizer
+        // folds extension_loaded('<literal>') to constant false at compile time, before
+        // the module registers (issue #243)
+        $this->assertTrue(extension_loaded($module->getName()));
         $this->assertFalse($module->wasModuleStarted());
         $this->assertSame([], LifecycleModule::$events);
 

--- a/tests/Memory/PersistentHeapRequestCycleTest.php
+++ b/tests/Memory/PersistentHeapRequestCycleTest.php
@@ -36,11 +36,16 @@ class PersistentHeapRequestCycleTest extends TestCase
             '-d', 'report_memleaks=1',
             '-d', 'display_errors=on',
             '-d', 'error_reporting=' . (E_ALL & ~E_DEPRECATED),
-            // Pinned off so the scenario is hermetic whatever php.ini says (an
-            // opcache-active runner, or Ubuntu's PHP 8.5 default opcache.enable_cli=On).
-            // TODO(#243): with opcache active in this child the registered module is
-            // not visible ("FAILED: engine-entry-visible") - unpin once fixed
-            '-d', 'opcache.enable_cli=0',
+            // Pinned ON (JIT off, AGENTS.md) so the child hermetically runs the exact
+            // configuration issue #243 failed in: opcache's optimizer constant-folds
+            // literal extension_loaded() calls at compile time, which the scenario's
+            // engine-entry-visible checkpoint dodges with a runtime-built name. The
+            // opcache-off leg stays covered by the debug leak gate
+            // (MemoryLeakScenarioTest spawns the same scenario with php.ini defaults).
+            '-d', 'opcache.enable=1',
+            '-d', 'opcache.enable_cli=1',
+            '-d', 'opcache.jit=off',
+            '-d', 'opcache.jit_buffer_size=0',
             __DIR__ . '/scenarios/persistent-heap-request-cycle.php',
         ];
 

--- a/tests/Memory/scenarios/module-lifecycle.php
+++ b/tests/Memory/scenarios/module-lifecycle.php
@@ -22,7 +22,10 @@ $module = new LifecycleModule();
 $module->register();
 $module->startup();
 
-if (!extension_loaded('lifecycle')) {
+// Runtime-built name on purpose: opcache's optimizer folds extension_loaded('<literal>')
+// to constant false at compile time, before the module registers (issue #243) - and the
+// leak gate runs this scenario with whatever opcache state php.ini dictates
+if (!extension_loaded($module->getName())) {
     throw new RuntimeException('Module was not registered');
 }
 if (LifecycleModule::$events !== ['moduleStartup', 'requestStartup']) {

--- a/tests/Memory/scenarios/persistent-heap-request-cycle.php
+++ b/tests/Memory/scenarios/persistent-heap-request-cycle.php
@@ -72,7 +72,12 @@ try {
 $module = ExtensionManager::register(new ZEngineModule());
 $expect(ExtensionManager::has(ZEngineModule::class), 'module-registered');
 $expect(ExtensionManager::get(ZEngineModule::class) === $module, 'module-is-singleton');
-$expect(extension_loaded('zengine'), 'engine-entry-visible');
+// The name is read back from the module ON PURPOSE: with opcache active the optimizer
+// pre-evaluates extension_loaded('<literal>') while this script is being compiled -
+// before the module registers - and bakes constant false into the op array
+// (zend_optimizer_eval_special_func_info(), issue #243). A runtime-built name defeats
+// the fold, so this checkpoint asserts the engine's registry lookup itself.
+$expect(extension_loaded($module->getName()), 'engine-entry-visible');
 
 $heap = PersistentHeap::global();
 $expect($heap === $module->heap(), 'global-is-module-heap');


### PR DESCRIPTION
## What this changes

Fixes #243 — and the root cause is worth a headline: **there is no library defect**. With opcache active, the optimizer pre-evaluates `extension_loaded('<literal>')` while the *calling script* is compiled (`zend_optimizer_eval_special_func_info()`, `Zend/Optimizer/zend_optimizer.c`): a module absent from `module_registry` at compile time (with `enable_dl` off) is folded to constant `false` right in the cached op array. z-engine modules register at runtime, after the caller compiled, so the scenario's literal check could never see the entry — while every runtime lookup (runtime-built name, `get_loaded_extensions()`, native `ReflectionExtension`, registry bucket walk with matching `zend_string_hash_func`) saw it fine. `dl()`-loaded extensions face the identical fold; the mechanism exists unchanged on 8.5.

Changes:
- The affected checkpoints (`persistent-heap-request-cycle` scenario, `module-lifecycle` scenario, `AbstractModuleTest`) pass the module name through a **runtime value**, defeating the fold and asserting the engine's registry lookup itself.
- `PersistentHeapRequestCycleTest` drops the `TODO(#243)` opcache-off pin and pins the child to explicit `opcache.enable=1 + opcache.enable_cli=1` (JIT off) — the originally failing configuration is now a permanent regression test on every default-suite run; the opcache-off leg stays covered by the debug leak gate, which spawns the same scenario with php.ini defaults.
- `docs/long-running.md` gains a "module visibility and opcache constant folding" note with the fold-proof alternatives (`ExtensionManager::has()`, `AbstractModule::isModuleRegistered()`, non-literal names) — consumers' own literal `extension_loaded('zengine')` call sites remain subject to the engine's fold, which only a php-src change could alter.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug PHP 8.4.24 container (`tools/docker/php-debug.Dockerfile`): `--group opcache --fail-on-skipped` OK (31 tests), `--group internal --process-isolation` OK (165 tests)

Also verified: reproducer exit 0 with opcache on and off; default suite OK (503 tests); opcache-runner suite OK (501 tests); PHPStan level max clean; cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (`8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; no struct dereferences changed
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_