### PR TITLE
test(opcache): prove BinaryCacheFile::refresh() semantics under real shared memory

### DIFF
--- a/tests/OpCache/SharedMemoryRefreshTest.php
+++ b/tests/OpCache/SharedMemoryRefreshTest.php
@@ -1,0 +1,252 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\OpCache;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * BinaryCacheFile::refresh() semantics under REAL opcache shared memory - the
+ * SHM-active counterpart of RefreshWorkflowTest (issue #125). Every worker here
+ * runs with opcache.enable_cli=1 + opcache.file_cache=<dir> and WITHOUT
+ * file_cache_only, so scripts live in shared memory with the file cache as the
+ * second-level store.
+ *
+ * Each CLI process owns a private SHM segment, so the legs are explicit about
+ * what they prove:
+ *
+ *  - a warm worker's single include populates BOTH shared memory and the .bin,
+ *    and after a patch + refresh() a FRESH worker (empty SHM, like a pool
+ *    worker after restart) executes the patched body - loaded through
+ *    opcache's own file-cache-into-SHM path, checksums verified, and resident
+ *    in shared memory afterwards (something file_cache_only never exercises);
+ *  - within ONE worker process, save() alone leaves the SHM-resident body in
+ *    service on re-include - the patched binary on disk is NOT re-read until
+ *    invalidated, which is exactly the semantics that motivate refresh();
+ *  - within ONE worker process, refresh() evicts the SHM-resident copy
+ *    (opcache_is_script_cached() flips to false).
+ *
+ * Deliberately NOT asserted (found while building this test, reported from
+ * issue #125): in the invalidating process itself a re-include after refresh()
+ * does not pick the patched binary up. opcache_invalidate() with
+ * opcache.file_cache set calls zend_file_cache_invalidate(), which UNLINKS the
+ * .bin that refresh()'s save() has just written, so the re-include recompiles
+ * the original source (and even with the ordering inverted, the re-include
+ * only consults the file cache under opcache.revalidate_path=1 - with the
+ * default key lookup the invalidated hash entry short-circuits path resolution
+ * and zend_file_cache_script_load() bails on the unresolved opened_path).
+ * Asserting the current behaviour would enshrine the bug; fixing it is
+ * follow-up work on refresh(), not on this test.
+ */
+#[Group('opcache')]
+#[Group('opcache-relocator')]
+final class SharedMemoryRefreshTest extends TestCase
+{
+    use FileCacheFixture;
+
+    protected function setUp(): void
+    {
+        if (!PayloadRelocator::isSupported()) {
+            self::markTestSkipped(
+                'The file-cache relocator supports 64-bit POSIX NTS payloads only'
+                . ' (ZTS is issue #118, Windows is issue #119)',
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeCacheDir();
+    }
+
+    public function testFreshWorkerExecutesPatchedBodyFromSharedMemoryAfterRefresh(): void
+    {
+        $fixture  = self::shmFixturePath();
+        $cacheDir = self::freshShmCacheDir();
+
+        // One include in a warm worker fills shared memory AND the file cache
+        self::assertSame('value=41 shm=1', self::runShmWorker($fixture, $cacheDir));
+        $binPath = BinaryCacheFile::locate($cacheDir, $fixture);
+        self::assertFileExists($binPath, 'the warm worker must populate the file cache alongside shared memory');
+
+        // Patch the compiled body in the .bin and refresh it
+        $file = BinaryCacheFile::read($binPath, $fixture);
+        self::patchAnswerLiteral($file);
+        $file->refresh();
+
+        // A fresh worker (empty SHM) must execute the PATCHED body - and shm=1
+        // proves opcache loaded the patched binary INTO shared memory through
+        // its own consistency-checked file-cache path, not a process-memory
+        // fallback and not a recompile of the (unchanged) source
+        self::assertSame('value=42 shm=1', self::runShmWorker($fixture, $cacheDir));
+    }
+
+    public function testSharedMemoryResidentScriptIsServedUntilInvalidated(): void
+    {
+        $fixture  = self::shmFixturePath();
+        $cacheDir = self::freshShmCacheDir();
+
+        // The negative control: in one worker process, patch + save() WITHOUT
+        // refresh() - the re-include keeps executing the SHM-resident original
+        $stdout = self::runShmPatchWorker('save', $fixture, $cacheDir);
+        self::assertStringContainsString('shm-populated: ok', $stdout);
+        self::assertStringContainsString('patched-literal: ok', $stdout);
+        self::assertStringContainsString('stale-shm-after-save: ok', $stdout);
+        self::assertStringContainsString('SHM SAVE OK', $stdout);
+
+        // ...while the patched binary really is on disk: a fresh worker (whose
+        // empty SHM cannot mask the file cache) executes the patched body, so
+        // the stale 41 above was shared memory shielding the script - not a
+        // patch that failed to land
+        self::assertSame('value=42 shm=1', self::runShmWorker($fixture, $cacheDir));
+    }
+
+    public function testRefreshEvictsTheSharedMemoryResidentCopy(): void
+    {
+        $stdout = self::runShmPatchWorker('refresh', self::shmFixturePath(), self::freshShmCacheDir());
+
+        self::assertStringContainsString('shm-populated: ok', $stdout);
+        self::assertStringContainsString('patched-literal: ok', $stdout);
+        self::assertStringContainsString('refresh-evicts-shm: ok', $stdout);
+        self::assertStringContainsString('SHM REFRESH OK', $stdout);
+    }
+
+    /**
+     * Patches the fixture's single long literal 41 -> 42 through the wrappers
+     */
+    private static function patchAnswerLiteral(BinaryCacheFile $file): void
+    {
+        $patched = 0;
+        foreach ($file->getReflection()->getScriptFunction()->getLiterals() as $literal) {
+            $literal->getNativeValue($value);
+            if ($literal->getBaseType() === ReflectionValue::IS_LONG && $value === 41) {
+                $literal->setNativeValue(42);
+                ++$patched;
+            }
+        }
+        self::assertSame(1, $patched, 'expected to patch exactly one literal in the fixture');
+    }
+
+    /**
+     * Includes the fixture in a worker with shared memory active (file cache as
+     * the second level, NOT file_cache_only) and returns "value=<v> shm=<0|1>"
+     */
+    private static function runShmWorker(string $fixture, string $cacheDir): string
+    {
+        $command = [
+            PHP_BINARY,
+            ...self::sharedMemoryOptions($cacheDir),
+            __DIR__ . '/scripts/run-shm.php',
+            $fixture,
+        ];
+
+        return self::runWorker($command, 'shared-memory run');
+    }
+
+    /**
+     * Runs the include -> patch -> save()/refresh() sequence inside ONE worker
+     * process whose private SHM holds the fixture, and returns its stdout
+     */
+    private static function runShmPatchWorker(string $mode, string $fixture, string $cacheDir): string
+    {
+        $command = [
+            PHP_BINARY,
+            '-d', 'ffi.enable=1',
+            '-d', 'zend.assertions=1',
+            '-d', 'assert.exception=1',
+            '-d', 'display_errors=on',
+            '-d', 'error_reporting=-1',
+            '-d', 'memory_limit=512M',
+            ...self::sharedMemoryOptions($cacheDir),
+            __DIR__ . '/scripts/shm-refresh-worker.php',
+            $mode,
+            $fixture,
+            $cacheDir,
+        ];
+
+        return self::runWorker($command, "shared-memory {$mode}");
+    }
+
+    /**
+     * The ini set that makes shared memory + second-level file cache active and
+     * deterministic: no file_cache_only, no update protection (the fixture may
+     * be freshly checked out), no timestamp validation (the legs compare cache
+     * contents, not mtimes) and no JIT (it refuses the file cache)
+     *
+     * @return list<string>
+     */
+    private static function sharedMemoryOptions(string $cacheDir): array
+    {
+        return [
+            '-d', 'opcache.enable=1',
+            '-d', 'opcache.enable_cli=1',
+            '-d', 'opcache.file_cache=' . $cacheDir,
+            '-d', 'opcache.file_cache_consistency_checks=1',
+            '-d', 'opcache.file_update_protection=0',
+            '-d', 'opcache.validate_timestamps=0',
+            '-d', 'opcache.jit=off',
+            '-d', 'opcache.jit_buffer_size=0',
+        ];
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    private static function runWorker(array $command, string $label): string
+    {
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        self::assertIsResource($process, "Unable to spawn the {$label} worker");
+        $stdout = stream_get_contents($pipes[1]) ?: '';
+        $stderr = stream_get_contents($pipes[2]) ?: '';
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        $report = "STDOUT:\n{$stdout}\nSTDERR:\n{$stderr}";
+        if ($exitCode === 2) {
+            // Never a silent pass: the shared-memory shape was not exercised at all
+            self::markTestSkipped("Opcache shared memory could not be activated in the {$label} worker\n{$report}");
+        }
+        self::assertSame(0, $exitCode, "The {$label} worker failed ({$exitCode})\n{$report}");
+
+        return trim($stdout);
+    }
+
+    private static function shmFixturePath(): string
+    {
+        $path = realpath(__DIR__ . '/fixtures/shm-answer.php');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    /**
+     * A per-test cache directory for the shared-memory workers. Opcache
+     * disables the file cache when the directory does not exist, so it is
+     * created here rather than left to the child.
+     */
+    private static function freshShmCacheDir(): string
+    {
+        if (!extension_loaded('Zend OPcache')) {
+            self::markTestSkipped('Zend OPcache extension is not loaded');
+        }
+        self::$cacheDir = sys_get_temp_dir() . '/zengine-opcache-' . bin2hex(random_bytes(6));
+        if (!mkdir(self::$cacheDir, 0o755, true)) {
+            self::fail('Cannot create the file-cache directory ' . self::$cacheDir);
+        }
+
+        return self::$cacheDir;
+    }
+}

--- a/tests/OpCache/fixtures/shm-answer.php
+++ b/tests/OpCache/fixtures/shm-answer.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Fixture for the shared-memory refresh tests: the whole script is a single
+ * patchable long literal returned from the file-level op_array.
+ *
+ * Unlike answer.php it defines nothing, so the SAME worker process can include
+ * it repeatedly - which is what the shared-memory legs need to observe whether
+ * a re-include is served from the SHM-resident copy or re-read from the cache.
+ */
+declare(strict_types=1);
+
+return 41;

--- a/tests/OpCache/scripts/run-shm.php
+++ b/tests/OpCache/scripts/run-shm.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Child driver for the shared-memory refresh tests: includes a value-returning
+ * fixture with opcache shared memory ACTIVE (opcache.file_cache set, but NOT
+ * file_cache_only) and reports what executed and whether the script ended up
+ * resident in shared memory.
+ *
+ * A fresh worker starts with an empty SHM, so its include goes SHM-miss ->
+ * file-cache load: `value` is the body the engine actually executed and
+ * `shm=1` proves the cache binary passed opcache's own loader checks INTO
+ * shared memory (opcache_is_script_cached() is false for process-memory
+ * fallbacks).
+ *
+ * argv: [1] = fixture script to include (must `return` a value)
+ *
+ * Output: "value=<v> shm=<0|1>". Exit 2 when opcache shared memory is not
+ * active in this process - the parent skips, never a silent pass.
+ */
+declare(strict_types=1);
+
+$status = function_exists('opcache_get_status') ? opcache_get_status(false) : false;
+if (!is_array($status) || !empty($status['file_cache_only'])) {
+    fwrite(STDERR, "opcache shared memory is not active in the child process\n");
+    exit(2);
+}
+
+$fixture = realpath($argv[1] ?? '');
+if ($fixture === false) {
+    fwrite(STDERR, "fixture script not found\n");
+    exit(1);
+}
+
+$value = include $fixture;
+if (!is_int($value)) {
+    fwrite(STDERR, 'the fixture must return an int, got ' . var_export($value, true) . "\n");
+    exit(1);
+}
+$shm = opcache_is_script_cached($fixture) ? 1 : 0;
+
+echo "value={$value} shm={$shm}\n";

--- a/tests/OpCache/scripts/shm-refresh-worker.php
+++ b/tests/OpCache/scripts/shm-refresh-worker.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Child worker for the shared-memory refresh tests. Runs with opcache shared
+ * memory ACTIVE (opcache.file_cache set, but NOT file_cache_only), so each CLI
+ * process owns a private SHM segment - which makes this the one place where
+ * "a script resident in SHM" can be observed honestly: everything below
+ * happens inside the single process whose shared memory holds the fixture.
+ *
+ * The worker includes the fixture (populating BOTH shared memory and the file
+ * cache .bin), patches the .bin through the BinaryCacheFile API, and then
+ * exercises one of two modes:
+ *
+ *  - save:    save() only (no invalidation). A re-include must STILL execute
+ *             the original body - the SHM-resident copy is served and the
+ *             patched binary on disk is not re-read.
+ *  - refresh: refresh() (save + opcache_invalidate). The SHM-resident copy
+ *             must be evicted: opcache_is_script_cached() flips to false.
+ *
+ * argv: [1] = mode ("save" | "refresh")
+ *       [2] = fixture script (must `return` a patchable long literal 41)
+ *       [3] = the opcache.file_cache directory this process runs with
+ *
+ * Exit codes: 0 = all checks passed, 1 = an assertion failed (diagnostic on
+ * stderr), 2 = opcache shared memory could not be activated (parent skips -
+ * never a silent pass).
+ */
+declare(strict_types=1);
+
+use ZEngine\Core;
+use ZEngine\OpCache\BinaryCacheFile;
+use ZEngine\Reflection\ReflectionValue;
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+$status = function_exists('opcache_get_status') ? opcache_get_status(false) : false;
+if (!is_array($status) || !empty($status['file_cache_only'])) {
+    fwrite(STDERR, "opcache shared memory is not active in the child process\n");
+    exit(2);
+}
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, "{$message}\n");
+    exit(1);
+};
+
+// Residency is asserted through this closure because the answer genuinely
+// changes over the script's lifetime (include -> resident, refresh() ->
+// evicted): each call site states the expectation that holds at that point
+$assertResidency = static function (string $path, bool $resident, string $message) use ($fail): void {
+    if (opcache_is_script_cached($path) !== $resident) {
+        $fail($message);
+    }
+};
+
+$mode     = $argv[1] ?? '';
+$fixture  = realpath($argv[2] ?? '');
+$cacheDir = $argv[3] ?? '';
+if (!in_array($mode, ['save', 'refresh'], true)) {
+    $fail("unknown mode '{$mode}', expected 'save' or 'refresh'");
+}
+if ($fixture === false || $cacheDir === '') {
+    $fail('usage: shm-refresh-worker.php <mode> <fixture> <cache-dir>');
+}
+
+// 1. Load the fixture: with SHM active + opcache.file_cache set, one include
+//    populates both the shared-memory hash and the file-cache .bin
+$first = include $fixture;
+if ($first !== 41) {
+    $fail('the pristine fixture must return 41, got ' . var_export($first, true));
+}
+$assertResidency($fixture, true, 'the fixture is not resident in shared memory after the include');
+$binPath = BinaryCacheFile::locate($cacheDir, $fixture);
+if (!is_file($binPath)) {
+    $fail("the include did not populate the file cache: {$binPath} is missing");
+}
+echo "shm-populated: ok\n";
+
+// 2. Patch the compiled body in the .bin through the framework wrappers
+Core::init();
+$file    = BinaryCacheFile::read($binPath, $fixture);
+$main    = $file->getReflection()->getScriptFunction();
+$patched = 0;
+foreach ($main->getLiterals() as $literal) {
+    $literal->getNativeValue($value);
+    if ($literal->getBaseType() === ReflectionValue::IS_LONG && $value === 41) {
+        $literal->setNativeValue(42);
+        ++$patched;
+    }
+}
+if ($patched !== 1) {
+    $fail("expected to patch exactly one literal, patched {$patched}");
+}
+echo "patched-literal: ok\n";
+
+if ($mode === 'save') {
+    // 3a. save() alone: the patched binary lands on disk, but the script stays
+    //     resident in shared memory - a re-include in THIS process must keep
+    //     executing the original body, proving a SHM-resident script is not
+    //     re-read until it is invalidated (the semantics that motivate refresh())
+    $file->save();
+    $second = include $fixture;
+    if ($second !== 41) {
+        $fail('save() alone must leave the SHM-resident body in service, got ' . var_export($second, true));
+    }
+    $assertResidency($fixture, true, 'save() alone must not evict the shared-memory copy');
+    echo "stale-shm-after-save: ok\n";
+    echo "SHM SAVE OK\n";
+} else {
+    // 3b. refresh(): the invalidation half of the contract - the SHM-resident
+    //     copy is evicted, so this process no longer serves the stale body.
+    //     The reload half (a re-include picking the patched binary back up
+    //     in THIS process) is deliberately NOT asserted: see the test class.
+    $file->refresh();
+    $assertResidency($fixture, false, 'refresh() must evict the shared-memory copy of the fixture');
+    echo "refresh-evicts-shm: ok\n";
+    echo "SHM REFRESH OK\n";
+}


### PR DESCRIPTION
## What this changes

Fixes #125 — integration coverage for the patch→refresh→run loop under **real opcache shared memory** (`opcache.enable_cli=1` + `opcache.file_cache=<dir>`, NOT `file_cache_only`), which was previously documented but untested. Child-process pattern with the exit-2 no-silent-skip convention; groups `opcache` + `opcache-relocator`.

Three legs, honest about what CLI (per-process SHM) can prove:
1. **Fresh worker after `refresh()`** executes the patched body and loads it into SHM through opcache's own consistency-checked file-cache→SHM path (`value=42 shm=1`).
2. **Negative control**: a `save()` *without* invalidation leaves the SHM-resident original being served on re-include in the same worker, while the patched `.bin` really is on disk — proving the shielding is SHM residency, not a failed patch.
3. **`refresh()` evicts the SHM-resident copy** (`opcache_is_script_cached()` flips false) — the invalidation half of the contract that is a no-op under `file_cache_only`.

**Bug found while writing this (deliberately NOT asserted here; documented in the class docblock):** in a process with SHM + `opcache.file_cache`, `refresh()`'s save-then-invalidate ordering self-destructs — `opcache_invalidate($path, true)` calls `zend_file_cache_invalidate()`, which **unlinks the `.bin` that `save()` just wrote**, so the subsequent include recompiles the original source and the patch is lost pool-wide. Filed as a follow-up issue with the verified fix shape (invalidate-before-save; `opcache.revalidate_path=1` caveat for same-process pickup); a stacked PR follows.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container: `--group opcache --fail-on-skipped` OK (34 tests, 218 assertions)

Also: full default suite OK (506 tests), opcache-runner mode OK (504 tests, no new skips), `--group opcache --fail-on-skipped` OK on the release build, PHPStan level max clean, cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (`8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; no new struct dereferences
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_