### PR TITLE
fix(opcache): invalidate before writing in BinaryCacheFile::refresh()

### DIFF
--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -84,11 +84,30 @@ script, so the next include picks up the patched binary.
 ## Refresh and shared memory
 
 Under `opcache.file_cache_only=1` there is no shared-memory copy, so writing the
-binary is enough for the next worker to load it. When opcache also uses shared
-memory, a script already resident in SHM is **not** re-read until it is
-invalidated — which is exactly what `refresh()` does. Loading a patched binary
-directly into shared memory (and wiring it to the function/method hot-swap API)
-is future work; see [hot-swap.md](hot-swap.md).
+binary is enough for the next worker to load it (`opcache_invalidate()` is a
+no-op in that mode). When opcache also uses shared memory, a script already
+resident in SHM is **not** re-read until it is invalidated — which is exactly
+what `refresh()` does.
+
+Two shared-memory subtleties `refresh()` accounts for:
+
+- **Invalidate before write.** In a process running SHM *with*
+  `opcache.file_cache`, `opcache_invalidate()` also unlinks the script's cache
+  binary (`zend_file_cache_invalidate`). `refresh()` therefore invalidates
+  first and writes second, so the unlink hits the stale binary — the worst
+  case if the write then fails is a cache miss and a recompile of the original
+  source, never a silently lost patch.
+- **Same-process pickup needs `opcache.revalidate_path=1`.** After an
+  in-process invalidation, opcache's default key lookup finds the invalidated
+  hash entry without resolving the script path and never consults the file
+  cache again, so a re-include in the *same* process recompiles the source.
+  With `opcache.revalidate_path=1` the path is resolved, the patched binary is
+  loaded from the file cache back into shared memory, and the re-include
+  executes the patched body. A **fresh** worker (an empty SHM — e.g. a pool
+  worker after restart) picks the patched binary up with default settings.
+
+Loading a patched binary directly into shared memory (and wiring it to the
+function/method hot-swap API) is future work; see [hot-swap.md](hot-swap.md).
 
 ## Scope and limits (v1)
 

--- a/src/OpCache/BinaryCacheFile.php
+++ b/src/OpCache/BinaryCacheFile.php
@@ -297,13 +297,28 @@ final class BinaryCacheFile
     }
 
     /**
-     * Writes the (patched) binary and invalidates opcache's in-memory copy of
-     * the source script, so the next include picks the patched binary up.
+     * Invalidates opcache's in-memory copy of the source script and writes the
+     * (patched) binary, so the next load picks the patched binary up.
      *
      * A script already resident in shared memory is not re-read until it is
      * invalidated, which is what this does; under opcache.file_cache_only there
-     * is no shared copy and the write alone suffices. Invalidation is a no-op
-     * when opcache is not active in this process (the write still happens).
+     * is no shared copy and the write alone suffices (opcache_invalidate() is
+     * a no-op there, and also when opcache is not active in this process - the
+     * write still happens either way).
+     *
+     * The order is deliberately invalidate-BEFORE-save: in a process running
+     * shared memory WITH opcache.file_cache, opcache_invalidate() also unlinks
+     * the script's cache binary (zend_file_cache_invalidate), so invalidating
+     * after the write would delete the patched binary it just produced (issue
+     * #252). With this order the unlink hits the stale binary, and the worst
+     * case when save() then fails is a cache miss - a recompile of the
+     * original source - never a silently lost patch.
+     *
+     * Same-process pickup caveat: after an in-process invalidation, opcache's
+     * default key lookup skips path resolution for the invalidated entry and
+     * never consults the file cache again - the patched binary is loaded on a
+     * re-include only under opcache.revalidate_path=1; a fresh worker picks it
+     * up with default settings.
      *
      * @param int|null $timestamp Source mtime to stamp; defaults to the script's
      *                            current mtime so the binary stays valid under
@@ -314,10 +329,10 @@ final class BinaryCacheFile
         if ($timestamp === null && $this->scriptPath !== null && is_file($this->scriptPath)) {
             $timestamp = filemtime($this->scriptPath) ?: null;
         }
-        $this->save(null, $timestamp);
-
         if ($this->scriptPath !== null && function_exists('opcache_invalidate')) {
             opcache_invalidate($this->scriptPath, true);
         }
+
+        $this->save(null, $timestamp);
     }
 }

--- a/tests/OpCache/SharedMemoryRefreshTest.php
+++ b/tests/OpCache/SharedMemoryRefreshTest.php
@@ -35,20 +35,21 @@ use ZEngine\Reflection\ReflectionValue;
  *  - within ONE worker process, save() alone leaves the SHM-resident body in
  *    service on re-include - the patched binary on disk is NOT re-read until
  *    invalidated, which is exactly the semantics that motivate refresh();
- *  - within ONE worker process, refresh() evicts the SHM-resident copy
- *    (opcache_is_script_cached() flips to false).
+ *  - within ONE worker process, refresh() evicts the SHM-resident copy, the
+ *    patched binary SURVIVES the invalidation (refresh() invalidates before
+ *    it writes, because opcache_invalidate() with opcache.file_cache set
+ *    unlinks the script's .bin - the ordering bug of issue #252), and a
+ *    re-include executes the patched body, loaded from the file cache back
+ *    into shared memory.
  *
- * Deliberately NOT asserted (found while building this test, reported from
- * issue #125): in the invalidating process itself a re-include after refresh()
- * does not pick the patched binary up. opcache_invalidate() with
- * opcache.file_cache set calls zend_file_cache_invalidate(), which UNLINKS the
- * .bin that refresh()'s save() has just written, so the re-include recompiles
- * the original source (and even with the ordering inverted, the re-include
- * only consults the file cache under opcache.revalidate_path=1 - with the
- * default key lookup the invalidated hash entry short-circuits path resolution
- * and zend_file_cache_script_load() bails on the unresolved opened_path).
- * Asserting the current behaviour would enshrine the bug; fixing it is
- * follow-up work on refresh(), not on this test.
+ * The same-process legs run with opcache.revalidate_path=1: after an
+ * in-process invalidation, opcache's default key lookup finds the invalidated
+ * hash entry without resolving the script path and never consults the file
+ * cache again, so same-process pickup of the patched binary requires path
+ * revalidation (a fresh worker needs no such thing - the fresh-worker leg
+ * keeps the default lookup on purpose). The negative control runs with the
+ * same ini, proving its staleness is genuine SHM shielding, not the lookup
+ * quirk.
  */
 #[Group('opcache')]
 #[Group('opcache-relocator')]
@@ -113,13 +114,15 @@ final class SharedMemoryRefreshTest extends TestCase
         self::assertSame('value=42 shm=1', self::runShmWorker($fixture, $cacheDir));
     }
 
-    public function testRefreshEvictsTheSharedMemoryResidentCopy(): void
+    public function testSameWorkerReExecutesPatchedBodyAfterRefresh(): void
     {
         $stdout = self::runShmPatchWorker('refresh', self::shmFixturePath(), self::freshShmCacheDir());
 
         self::assertStringContainsString('shm-populated: ok', $stdout);
         self::assertStringContainsString('patched-literal: ok', $stdout);
         self::assertStringContainsString('refresh-evicts-shm: ok', $stdout);
+        self::assertStringContainsString('bin-survives-refresh: ok', $stdout);
+        self::assertStringContainsString('patched-body-on-reinclude: ok', $stdout);
         self::assertStringContainsString('SHM REFRESH OK', $stdout);
     }
 
@@ -157,7 +160,12 @@ final class SharedMemoryRefreshTest extends TestCase
 
     /**
      * Runs the include -> patch -> save()/refresh() sequence inside ONE worker
-     * process whose private SHM holds the fixture, and returns its stdout
+     * process whose private SHM holds the fixture, and returns its stdout.
+     *
+     * revalidate_path=1 is what same-process pickup of a refreshed binary
+     * requires (see the class docblock); the save mode runs with it too, so
+     * its staleness is proven to be SHM shielding rather than the default
+     * lookup never consulting the file cache.
      */
     private static function runShmPatchWorker(string $mode, string $fixture, string $cacheDir): string
     {
@@ -169,6 +177,7 @@ final class SharedMemoryRefreshTest extends TestCase
             '-d', 'display_errors=on',
             '-d', 'error_reporting=-1',
             '-d', 'memory_limit=512M',
+            '-d', 'opcache.revalidate_path=1',
             ...self::sharedMemoryOptions($cacheDir),
             __DIR__ . '/scripts/shm-refresh-worker.php',
             $mode,

--- a/tests/OpCache/scripts/shm-refresh-worker.php
+++ b/tests/OpCache/scripts/shm-refresh-worker.php
@@ -14,8 +14,13 @@
  *  - save:    save() only (no invalidation). A re-include must STILL execute
  *             the original body - the SHM-resident copy is served and the
  *             patched binary on disk is not re-read.
- *  - refresh: refresh() (save + opcache_invalidate). The SHM-resident copy
- *             must be evicted: opcache_is_script_cached() flips to false.
+ *  - refresh: refresh() (opcache_invalidate + save, in that order - issue
+ *             #252). The SHM-resident copy must be evicted, the patched
+ *             binary must SURVIVE the invalidation (the unlink hits the stale
+ *             binary, not the fresh one), and a re-include must execute the
+ *             PATCHED body, loaded from the file cache back into shared
+ *             memory. Same-process pickup only happens under
+ *             opcache.revalidate_path=1, so this mode requires that ini.
  *
  * argv: [1] = mode ("save" | "refresh")
  *       [2] = fixture script (must `return` a patchable long literal 41)
@@ -53,6 +58,16 @@ $assertResidency = static function (string $path, bool $resident, string $messag
     }
 };
 
+// Binary presence also changes over the script's lifetime (the ordering bug of
+// issue #252 was refresh() unlinking its own fresh binary), and PHP's stat
+// cache would otherwise keep reporting the pre-refresh() state
+$assertBinaryOnDisk = static function (string $path, string $message) use ($fail): void {
+    clearstatcache(true, $path);
+    if (!is_file($path)) {
+        $fail($message);
+    }
+};
+
 $mode     = $argv[1] ?? '';
 $fixture  = realpath($argv[2] ?? '');
 $cacheDir = $argv[3] ?? '';
@@ -71,9 +86,7 @@ if ($first !== 41) {
 }
 $assertResidency($fixture, true, 'the fixture is not resident in shared memory after the include');
 $binPath = BinaryCacheFile::locate($cacheDir, $fixture);
-if (!is_file($binPath)) {
-    $fail("the include did not populate the file cache: {$binPath} is missing");
-}
+$assertBinaryOnDisk($binPath, "the include did not populate the file cache: {$binPath} is missing");
 echo "shm-populated: ok\n";
 
 // 2. Patch the compiled body in the .bin through the framework wrappers
@@ -107,12 +120,26 @@ if ($mode === 'save') {
     echo "stale-shm-after-save: ok\n";
     echo "SHM SAVE OK\n";
 } else {
-    // 3b. refresh(): the invalidation half of the contract - the SHM-resident
-    //     copy is evicted, so this process no longer serves the stale body.
-    //     The reload half (a re-include picking the patched binary back up
-    //     in THIS process) is deliberately NOT asserted: see the test class.
+    // 3b. refresh(): both halves of the contract inside one process. The
+    //     invalidation half evicts the SHM-resident copy; the reload half
+    //     re-includes the script, which must execute the PATCHED body loaded
+    //     from the surviving binary back into shared memory. Same-process
+    //     pickup requires opcache.revalidate_path=1 (with the default key
+    //     lookup the invalidated hash entry short-circuits path resolution
+    //     and the file cache is never consulted again)
+    if (ini_get('opcache.revalidate_path') !== '1') {
+        $fail('the refresh mode must run with opcache.revalidate_path=1 - fix the parent test command');
+    }
     $file->refresh();
     $assertResidency($fixture, false, 'refresh() must evict the shared-memory copy of the fixture');
     echo "refresh-evicts-shm: ok\n";
+    $assertBinaryOnDisk($binPath, 'refresh() must leave the patched binary in place, not unlink it (issue #252)');
+    echo "bin-survives-refresh: ok\n";
+    $second = include $fixture;
+    if ($second !== 42) {
+        $fail('the re-include after refresh() must execute the patched body, got ' . var_export($second, true));
+    }
+    $assertResidency($fixture, true, 'the re-include must load the patched binary back into shared memory');
+    echo "patched-body-on-reinclude: ok\n";
     echo "SHM REFRESH OK\n";
 }


### PR DESCRIPTION
## What this changes

Fixes #252 — stacked on PR #251 (merge that first; GitHub retargets this to `8.4` automatically).

With shared memory + `opcache.file_cache` both active, `refresh()`'s save-then-invalidate ordering self-destructed: `opcache_invalidate($path, true)` reaches `zend_file_cache_invalidate()`, which unlinks the `.bin` that `save()` just wrote — the patch was lost pool-wide and the next include recompiled the original source. Reordering to **invalidate-before-save** makes the unlink hit the stale binary, never the patched one, and flips the failure direction: if `save()` throws after invalidation, the worst case is a cache miss + recompile of the original source — never a silently lost patch (documented in the docblock).

Also delivered:
- `docs/opcache-binary.md` "Refresh and shared memory" rewritten: the ordering rationale, the same-process pickup caveat (`opcache.revalidate_path=1`, or a fresh worker — fresh workers pick the patched bin up with default settings), and `file_cache_only` semantics unchanged (`opcache_invalidate` is a no-op there — `RefreshWorkflowTest` stays green, verified).
- The PR #251 tests now **assert the fixed contract** instead of documenting the broken one: bin survives `refresh()` (behind a `clearstatcache()`-first check so PHP's stat cache can't mask a regression), same-worker re-include executes the patched body under `revalidate_path=1`, SHM residency restored; the fresh-worker leg deliberately keeps default lookup settings, and the save-without-invalidate negative control runs under `revalidate_path=1` to prove its staleness is genuine SHM shielding.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container: `--group opcache --fail-on-skipped` OK (34 tests, 220 assertions)

Also: default suite OK (506 tests), opcache-runner mode OK (504 tests, no new skips), release opcache gate OK, PHPStan level max clean, cs-fixer clean. Pre-commit probe matches the #252 characterization exactly: `bin-survives=true`, re-include 42 with `revalidate_path=1`, source recompile with default lookup.

## Checklist

- [x] Targets the **minimum affected version branch** (stacked onto #251 → `8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; no new struct dereferences
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_