### PR TITLE
feat(opcache): relocate intersection/union type lists in cache binaries

### DIFF
--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -121,11 +121,12 @@ function/method hot-swap API) is future work; see [hot-swap.md](hot-swap.md).
   macOS/arm64. ZTS payloads stay tracked in
   [#118](https://github.com/lisachenko/z-engine/issues/118).
 - **Strict, never silent.** Structures the port does not yet handle
-  (intersection/union type lists, property hooks, iterator/ArrayAccess funcs,
-  trait-using classes, compile warnings) raise `unsupportedPayload` rather than
-  writing a subtly corrupt binary. Global functions, classes with constants,
-  typed properties, attributes (including constant-expression arguments), static
-  variables, try/catch and enums are supported and round-trip byte-for-byte.
+  (property hooks, iterator/ArrayAccess funcs, trait-using classes, compile
+  warnings) raise `unsupportedPayload` rather than writing a subtly corrupt
+  binary. Global functions, classes with constants, typed properties
+  (union/intersection/DNF type lists included), attributes (including
+  constant-expression arguments), static variables, try/catch and enums are
+  supported and round-trip byte-for-byte.
 - **Deferred.** Loading patched binaries into shared memory (ZCSG), and applying
   a patched image to already-loaded classes via `redefine()` / `ClassDelta`.
 

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -25,6 +25,8 @@ use ZEngine\Generated\zend_attribute_arg;
 use ZEngine\Generated\zend_class_name;
 use ZEngine\Generated\zend_early_binding;
 use ZEngine\Generated\zend_string;
+use ZEngine\Generated\zend_type;
+use ZEngine\Generated\zend_type_list;
 use ZEngine\Generated\zval;
 
 /**
@@ -582,13 +584,7 @@ final class PayloadRelocator
 
     private function unserializeType(object $owner, string $field): void
     {
-        $typeMask = $owner->$field->type_mask;
-        if (($typeMask & self::TYPE_LIST_BIT) !== 0) {
-            throw OpCacheException::unsupportedPayload('intersection/union type-list relocation');
-        }
-        if (($typeMask & self::TYPE_NAME_BIT) !== 0) {
-            $this->unStr($owner->$field, 'ptr');
-        }
+        $this->unserializeTypeStruct($owner->$field);
     }
     /**
      * @param \FFI\CData $owner
@@ -596,12 +592,59 @@ final class PayloadRelocator
 
     private function serializeType(object $owner, string $field): void
     {
-        $typeMask = $owner->$field->type_mask;
+        $this->serializeTypeStruct($owner->$field);
+    }
+
+    /**
+     * One zend_type in place - the ZEND_TYPE_HAS_LIST branch of
+     * zend_file_cache_unserialize_type relocates the zend_type_list pointer and
+     * recurses into every entry, so DNF sub-lists like (A&B)|C unfold naturally.
+     *
+     * @param \FFI\CData $type a zend_type view (embedded field or list entry)
+     */
+    private function unserializeTypeStruct(object $type): void
+    {
+        $typeMask = $type->type_mask;
         if (($typeMask & self::TYPE_LIST_BIT) !== 0) {
-            throw OpCacheException::unsupportedPayload('intersection/union type-list relocation');
+            $listAddress = $this->unPtr($type, 'ptr');
+            $list        = Core::pointerAtAddress('zend_type_list *', $listAddress);
+            $typeSize    = Core::sizeOfType(zend_type::class);
+            // ZEND_TYPE_LIST_FOREACH: entries start at list->types (the flexible member)
+            $entryBase = $listAddress + Core::sizeOfType(zend_type_list::class) - $typeSize;
+            for ($i = 0; $i < $list->num_types; $i++) {
+                $this->unserializeTypeStruct(Core::pointerAtAddress('zend_type *', $entryBase + $i * $typeSize));
+            }
+
+            return;
         }
         if (($typeMask & self::TYPE_NAME_BIT) !== 0) {
-            $this->serStr($owner->$field, 'ptr');
+            $this->unStr($type, 'ptr');
+        }
+    }
+
+    /**
+     * Mirror of {@see unserializeTypeStruct} - zend_file_cache_serialize_type
+     * stores the list pointer as an offset but keeps walking the entries through
+     * the still-real address (its SERIALIZE_PTR/UNSERIALIZE_PTR pair).
+     *
+     * @param \FFI\CData $type a zend_type view (embedded field or list entry)
+     */
+    private function serializeTypeStruct(object $type): void
+    {
+        $typeMask = $type->type_mask;
+        if (($typeMask & self::TYPE_LIST_BIT) !== 0) {
+            $listAddress = $this->serPtr($type, 'ptr');
+            $list        = Core::pointerAtAddress('zend_type_list *', $listAddress);
+            $typeSize    = Core::sizeOfType(zend_type::class);
+            $entryBase   = $listAddress + Core::sizeOfType(zend_type_list::class) - $typeSize;
+            for ($i = 0; $i < $list->num_types; $i++) {
+                $this->serializeTypeStruct(Core::pointerAtAddress('zend_type *', $entryBase + $i * $typeSize));
+            }
+
+            return;
+        }
+        if (($typeMask & self::TYPE_NAME_BIT) !== 0) {
+            $this->serStr($type, 'ptr');
         }
     }
 

--- a/tests/OpCache/TypeListRelocationTest.php
+++ b/tests/OpCache/TypeListRelocationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\OpCache;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Relocation coverage for zend_type_list payloads (issue #112): union,
+ * intersection and DNF types in parameters, return types and properties must
+ * round-trip byte-for-byte and still execute after a patch-and-save cycle.
+ */
+#[Group('opcache')]
+#[Group('opcache-relocator')]
+final class TypeListRelocationTest extends TestCase
+{
+    use FileCacheFixture;
+
+    protected function setUp(): void
+    {
+        if (!PayloadRelocator::isSupported()) {
+            self::markTestSkipped(
+                'The file-cache relocator supports 64-bit POSIX NTS payloads only'
+                . ' (ZTS is issue #118, Windows is issue #119)',
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeCacheDir();
+    }
+
+    public function testTypeListPayloadRoundTripsByteIdentical(): void
+    {
+        $binPath = self::compileFixture(self::typeListFixturePath());
+        $payload = substr((string) file_get_contents($binPath), CacheMetaInfo::byteSize());
+        $meta    = CacheMetaInfo::parse((string) file_get_contents($binPath), $binPath);
+
+        $length = strlen($payload);
+        $buffer = Core::new("char[{$length}]", false);
+        Core::memcpy($buffer, $payload, $length);
+        $relocator = new PayloadRelocator($buffer, $meta);
+        $relocator->relocate();
+
+        self::assertSame($payload, $relocator->derelocate(), 'A type-list round trip must reproduce the payload byte-for-byte');
+    }
+
+    public function testUnmodifiedResaveStillExecutes(): void
+    {
+        $fixture = self::typeListFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        $file->getReflection(); // relocate
+        $file->save();          // re-serialize unchanged
+
+        self::assertTrue(BinaryCacheFile::read($file->binPath())->verifyChecksum());
+        self::assertSame(
+            'ZEngineTypeListImpl:tl-ok',
+            self::runFromCache($fixture, 'zengine_bin_typelist_run', self::$cacheDir),
+        );
+    }
+
+    public function testPatchedTypeListFixtureExecutesFromCache(): void
+    {
+        $fixture = self::typeListFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        self::patchStringLiteral($file, 'zengine_bin_typelist_run', ':tl-ok', ':tl-patched-through-the-relocator');
+        $file->save();
+
+        self::assertSame(
+            'ZEngineTypeListImpl:tl-patched-through-the-relocator',
+            self::runFromCache($fixture, 'zengine_bin_typelist_run', self::$cacheDir),
+        );
+    }
+
+    private static function typeListFixturePath(): string
+    {
+        $path = realpath(__DIR__ . '/fixtures/type-lists.php');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    private static function patchStringLiteral(BinaryCacheFile $file, string $function, string $from, string $to): void
+    {
+        $functions = $file->getReflection()->getFunctions();
+        self::assertArrayHasKey($function, $functions, "Function {$function} not found in the cached script");
+        foreach ($functions[$function]->getLiterals() as $literal) {
+            if ($literal->getBaseType() !== ReflectionValue::IS_STRING) {
+                continue;
+            }
+            $literal->getNativeValue($value);
+            if ($value === $from) {
+                $literal->setNativeValue($to);
+
+                return;
+            }
+        }
+        self::fail("String literal '{$from}' not found in {$function}");
+    }
+}

--- a/tests/OpCache/fixtures/type-lists.php
+++ b/tests/OpCache/fixtures/type-lists.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Fixture compiled into the opcache file cache by the type-list relocation tests.
+ *
+ * Every zend_type_list shape the relocator must walk: a union parameter, a
+ * union return type, an intersection parameter and return type, union and DNF
+ * property types (the DNF one nests an intersection list inside a union list),
+ * plus a no-argument driver the patch tests execute straight from the cache.
+ */
+declare(strict_types=1);
+
+interface ZEngineTypeListOne {}
+interface ZEngineTypeListTwo {}
+
+class ZEngineTypeListExtra {}
+
+class ZEngineTypeListImpl implements ZEngineTypeListOne, ZEngineTypeListTwo
+{
+    public ZEngineTypeListOne|ZEngineTypeListTwo|null $union = null;
+
+    public (ZEngineTypeListOne&ZEngineTypeListTwo)|ZEngineTypeListExtra|null $dnf = null;
+}
+
+function zengine_bin_union_param(ZEngineTypeListOne|ZEngineTypeListTwo $subject): string
+{
+    return $subject::class;
+}
+
+function zengine_bin_union_return(bool $extra): ZEngineTypeListImpl|ZEngineTypeListExtra
+{
+    return $extra ? new ZEngineTypeListExtra() : new ZEngineTypeListImpl();
+}
+
+function zengine_bin_intersection(ZEngineTypeListOne&ZEngineTypeListTwo $subject): ZEngineTypeListOne&ZEngineTypeListTwo
+{
+    return $subject;
+}
+
+function zengine_bin_typelist_run(): string
+{
+    $impl        = new ZEngineTypeListImpl();
+    $impl->union = zengine_bin_intersection($impl);
+    $impl->dnf   = zengine_bin_union_return(false);
+
+    return zengine_bin_union_param($impl->union ?? $impl) . ':tl-ok';
+}


### PR DESCRIPTION
## What this changes

Fixes #112 — first of a five-PR stacked chain widening `PayloadRelocator` payload coverage (#112 → #114 → #115 → #116 → #113; merge in order, GitHub retargets each next PR automatically).

Ports the `ZEND_TYPE_HAS_LIST` branch of `zend_file_cache_(un)serialize_type` from php-src 8.4: `zend_type_list` pointer relocation plus recursion into every `zend_type` entry (the `ZEND_TYPE_LIST_FOREACH` walk), both directions, keeping the C `SERIALIZE_PTR`/`UNSERIALIZE_PTR` walk-through-real-address pattern. New `unserializeTypeStruct`/`serializeTypeStruct` in `src/OpCache/PayloadRelocator.php`; the `unsupportedPayload('intersection/union type-list relocation')` refusals are gone. Acceptance per the issue: fixture with union param/return, intersection param+return, union property and DNF property `(A&B)|C|null` round-trips byte-for-byte and executes from the patched cache (`TypeListRelocationTest`: round trip, resave-executes, size-changing string patch executes). `docs/opcache-binary.md` scope updated.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container `--group opcache --fail-on-skipped` green at this point of the chain (34 tests)

Also (verified per-issue before each commit): full default suite baseline-identical; `--group opcache --fail-on-skipped` green on release + debug; PHPStan level max clean; cs-fixer clean. Chain-final numbers on the #113 head: default suite 519 tests, opcache gate 47 tests, opcache-runner mode no new skips.

## Checklist

- [x] Targets the **minimum affected version branch** (`8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; all struct fields used (`zend_type_list` et al.) already in the generated defs
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_