### PR TITLE
feat(opcache): relocate trait-using classes in cache binaries

### DIFF
--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -121,12 +121,12 @@ function/method hot-swap API) is future work; see [hot-swap.md](hot-swap.md).
   macOS/arm64. ZTS payloads stay tracked in
   [#118](https://github.com/lisachenko/z-engine/issues/118).
 - **Strict, never silent.** Structures the port does not yet handle
-  (property hooks, iterator/ArrayAccess funcs, trait-using classes, compile
-  warnings) raise `unsupportedPayload` rather than writing a subtly corrupt
-  binary. Global functions, classes with constants, typed properties
-  (union/intersection/DNF type lists included), attributes (including
-  constant-expression arguments), static variables, try/catch and enums are
-  supported and round-trip byte-for-byte.
+  (property hooks, iterator/ArrayAccess funcs, compile warnings) raise
+  `unsupportedPayload` rather than writing a subtly corrupt binary. Global
+  functions, classes with constants, typed properties (union/intersection/DNF
+  type lists included), trait-using classes (aliases and insteadof precedences
+  included), attributes (including constant-expression arguments), static
+  variables, try/catch and enums are supported and round-trip byte-for-byte.
 - **Deferred.** Loading patched binaries into shared memory (ZCSG), and applying
   a patched image to already-loaded classes via `redefine()` / `ClassDelta`.
 

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -253,6 +253,32 @@ final class PayloadRelocator
         return $address;
     }
 
+    /** UNSERIALIZE_PTR on a raw pointer slot, returning the resolved address (0 for a NULL slot) */
+    private function unPtrAt(int $slotAddress): int
+    {
+        $slot   = Core::cast('uintptr_t *', Core::pointerAtAddress('void *', $slotAddress));
+        $stored = (int) $slot[0];
+        if ($stored === 0) {
+            return 0;
+        }
+        $slot[0] = $this->base + $stored;
+
+        return $this->base + $stored;
+    }
+
+    /** SERIALIZE_PTR on a raw pointer slot, returning the pre-serialization address (0 for a NULL slot) */
+    private function serPtrAt(int $slotAddress): int
+    {
+        $slot    = Core::cast('uintptr_t *', Core::pointerAtAddress('void *', $slotAddress));
+        $address = (int) $slot[0];
+        if ($address === 0) {
+            return 0;
+        }
+        $slot[0] = $address - $this->base;
+
+        return $address;
+    }
+
     // --- interned-string primitives (UNSERIALIZE_STR / SERIALIZE_STR) ------
     /**
      * @param \FFI\CData $owner
@@ -290,6 +316,36 @@ final class PayloadRelocator
             return;
         }
         $this->writePtrField($owner, $field, $this->emitInterned($address));
+    }
+
+    /** UNSERIALIZE_STR on a raw zend_string* slot (no owning struct field) */
+    private function unStrAt(int $slotAddress): void
+    {
+        $slot   = Core::cast('uintptr_t *', Core::pointerAtAddress('void *', $slotAddress));
+        $stored = (int) $slot[0];
+        if ($stored === 0) {
+            return;
+        }
+        if (($stored & 1) !== 0) {
+            $slot[0] = $this->strSectionBase + ($stored & ~1);
+        } else {
+            $slot[0] = $this->base + $stored;
+        }
+    }
+
+    /** SERIALIZE_STR on a raw zend_string* slot (no owning struct field) */
+    private function serStrAt(int $slotAddress): void
+    {
+        $slot    = Core::cast('uintptr_t *', Core::pointerAtAddress('void *', $slotAddress));
+        $address = (int) $slot[0];
+        if ($address === 0) {
+            return;
+        }
+        if ($address >= $this->base && $address < $this->base + $this->size) {
+            $slot[0] = $address - $this->base;
+        } else {
+            $slot[0] = $this->emitInterned($address);
+        }
     }
 
     /**
@@ -921,7 +977,9 @@ final class PayloadRelocator
             $this->unserializeClassNames($ce, 'interface_names', $ce->num_interfaces);
         }
         if ($ce->num_traits !== 0) {
-            throw OpCacheException::unsupportedPayload('trait-using class relocation');
+            $this->unserializeClassNames($ce, 'trait_names', $ce->num_traits);
+            $this->unserializeTraitAliases($ce);
+            $this->unserializeTraitPrecedences($ce);
         }
         foreach (self::MAGIC_METHOD_FIELDS as $field) {
             $this->unPtr($ce, $field);
@@ -957,7 +1015,9 @@ final class PayloadRelocator
             $this->serializeClassNames($ce, 'interface_names', $ce->num_interfaces);
         }
         if ($ce->num_traits !== 0) {
-            throw OpCacheException::unsupportedPayload('trait-using class relocation');
+            $this->serializeClassNames($ce, 'trait_names', $ce->num_traits);
+            $this->serializeTraitAliases($ce);
+            $this->serializeTraitPrecedences($ce);
         }
         foreach (self::MAGIC_METHOD_FIELDS as $field) {
             $this->serPtr($ce, $field);
@@ -1061,6 +1121,88 @@ final class PayloadRelocator
             $name = Core::pointerAtAddress('zend_class_name *', $address + $i * $nameSize);
             $this->serStr($name, 'name');
             $this->serStr($name, 'lc_name');
+        }
+    }
+
+    // --- traits (the num_traits branch of zend_file_cache_(un)serialize_class)
+    /**
+     * @param \FFI\CData $ce
+     */
+
+    private function unserializeTraitAliases(object $ce): void
+    {
+        if ($this->ptrValue($ce, 'trait_aliases') === 0) {
+            return;
+        }
+        // A NULL-terminated zend_trait_alias* array; each entry's strings follow
+        $slotAddress = $this->unPtr($ce, 'trait_aliases');
+        while (($aliasAddress = $this->unPtrAt($slotAddress)) !== 0) {
+            $alias = Core::pointerAtAddress('zend_trait_alias *', $aliasAddress);
+            $this->unStr($alias->trait_method, 'method_name');
+            $this->unStr($alias->trait_method, 'class_name');
+            $this->unStr($alias, 'alias');
+            $slotAddress += PHP_INT_SIZE;
+        }
+    }
+    /**
+     * @param \FFI\CData $ce
+     */
+
+    private function serializeTraitAliases(object $ce): void
+    {
+        if ($this->ptrValue($ce, 'trait_aliases') === 0) {
+            return;
+        }
+        $slotAddress = $this->serPtr($ce, 'trait_aliases');
+        while (($aliasAddress = $this->serPtrAt($slotAddress)) !== 0) {
+            $alias = Core::pointerAtAddress('zend_trait_alias *', $aliasAddress);
+            $this->serStr($alias->trait_method, 'method_name');
+            $this->serStr($alias->trait_method, 'class_name');
+            $this->serStr($alias, 'alias');
+            $slotAddress += PHP_INT_SIZE;
+        }
+    }
+    /**
+     * @param \FFI\CData $ce
+     */
+
+    private function unserializeTraitPrecedences(object $ce): void
+    {
+        if ($this->ptrValue($ce, 'trait_precedences') === 0) {
+            return;
+        }
+        // A NULL-terminated zend_trait_precedence* array with inline exclude names
+        $slotAddress = $this->unPtr($ce, 'trait_precedences');
+        while (($precedenceAddress = $this->unPtrAt($slotAddress)) !== 0) {
+            $precedence = Core::pointerAtAddress('zend_trait_precedence *', $precedenceAddress);
+            $this->unStr($precedence->trait_method, 'method_name');
+            $this->unStr($precedence->trait_method, 'class_name');
+            $excludeBase = Core::addressOf($precedence->exclude_class_names);
+            for ($j = 0; $j < $precedence->num_excludes; $j++) {
+                $this->unStrAt($excludeBase + $j * PHP_INT_SIZE);
+            }
+            $slotAddress += PHP_INT_SIZE;
+        }
+    }
+    /**
+     * @param \FFI\CData $ce
+     */
+
+    private function serializeTraitPrecedences(object $ce): void
+    {
+        if ($this->ptrValue($ce, 'trait_precedences') === 0) {
+            return;
+        }
+        $slotAddress = $this->serPtr($ce, 'trait_precedences');
+        while (($precedenceAddress = $this->serPtrAt($slotAddress)) !== 0) {
+            $precedence = Core::pointerAtAddress('zend_trait_precedence *', $precedenceAddress);
+            $this->serStr($precedence->trait_method, 'method_name');
+            $this->serStr($precedence->trait_method, 'class_name');
+            $excludeBase = Core::addressOf($precedence->exclude_class_names);
+            for ($j = 0; $j < $precedence->num_excludes; $j++) {
+                $this->serStrAt($excludeBase + $j * PHP_INT_SIZE);
+            }
+            $slotAddress += PHP_INT_SIZE;
         }
     }
     /**

--- a/tests/OpCache/TraitRelocationTest.php
+++ b/tests/OpCache/TraitRelocationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\OpCache;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Relocation coverage for trait-using classes (issue #114): trait_names,
+ * trait_aliases (with and without an explicit trait name) and trait_precedences
+ * with exclude lists must round-trip byte-for-byte and execute after a
+ * patch-and-save cycle.
+ */
+#[Group('opcache')]
+#[Group('opcache-relocator')]
+final class TraitRelocationTest extends TestCase
+{
+    use FileCacheFixture;
+
+    protected function setUp(): void
+    {
+        if (!PayloadRelocator::isSupported()) {
+            self::markTestSkipped(
+                'The file-cache relocator supports 64-bit POSIX NTS payloads only'
+                . ' (ZTS is issue #118, Windows is issue #119)',
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeCacheDir();
+    }
+
+    public function testTraitPayloadRoundTripsByteIdentical(): void
+    {
+        $binPath = self::compileFixture(self::traitFixturePath());
+        $payload = substr((string) file_get_contents($binPath), CacheMetaInfo::byteSize());
+        $meta    = CacheMetaInfo::parse((string) file_get_contents($binPath), $binPath);
+
+        $length = strlen($payload);
+        $buffer = Core::new("char[{$length}]", false);
+        Core::memcpy($buffer, $payload, $length);
+        $relocator = new PayloadRelocator($buffer, $meta);
+        $relocator->relocate();
+
+        self::assertSame($payload, $relocator->derelocate(), 'A trait round trip must reproduce the payload byte-for-byte');
+    }
+
+    public function testUnmodifiedResaveStillExecutes(): void
+    {
+        $fixture = self::traitFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        $file->getReflection(); // relocate
+        $file->save();          // re-serialize unchanged
+
+        self::assertTrue(BinaryCacheFile::read($file->binPath())->verifyChecksum());
+        self::assertSame(
+            'greeter-shared:shouter-shared:greeter:tr-ok',
+            self::runFromCache($fixture, 'zengine_bin_trait_run', self::$cacheDir),
+        );
+    }
+
+    public function testPatchedTraitFixtureExecutesFromCache(): void
+    {
+        $fixture = self::traitFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        self::patchStringLiteral($file, 'zengine_bin_trait_run', ':tr-ok', ':tr-patched-through-the-relocator');
+        $file->save();
+
+        self::assertSame(
+            'greeter-shared:shouter-shared:greeter:tr-patched-through-the-relocator',
+            self::runFromCache($fixture, 'zengine_bin_trait_run', self::$cacheDir),
+        );
+    }
+
+    private static function traitFixturePath(): string
+    {
+        $path = realpath(__DIR__ . '/fixtures/traits.php');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    private static function patchStringLiteral(BinaryCacheFile $file, string $function, string $from, string $to): void
+    {
+        $functions = $file->getReflection()->getFunctions();
+        self::assertArrayHasKey($function, $functions, "Function {$function} not found in the cached script");
+        foreach ($functions[$function]->getLiterals() as $literal) {
+            if ($literal->getBaseType() !== ReflectionValue::IS_STRING) {
+                continue;
+            }
+            $literal->getNativeValue($value);
+            if ($value === $from) {
+                $literal->setNativeValue($to);
+
+                return;
+            }
+        }
+        self::fail("String literal '{$from}' not found in {$function}");
+    }
+}

--- a/tests/OpCache/fixtures/traits.php
+++ b/tests/OpCache/fixtures/traits.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Fixture compiled into the opcache file cache by the trait relocation tests.
+ *
+ * Exercises every trait shape zend_file_cache_(un)serialize_class walks:
+ * trait_names (two traits), a trait_precedences entry with an exclude list
+ * (insteadof), an alias with an explicit trait name, and an alias without one
+ * (NULL trait_method.class_name) that also changes visibility.
+ */
+declare(strict_types=1);
+
+trait ZEngineTraitGreeter
+{
+    public function speak(): string
+    {
+        return 'greeter';
+    }
+
+    public function shared(): string
+    {
+        return 'greeter-shared';
+    }
+}
+
+trait ZEngineTraitShouter
+{
+    public function shared(): string
+    {
+        return 'shouter-shared';
+    }
+}
+
+class ZEngineTraitUser
+{
+    use ZEngineTraitGreeter, ZEngineTraitShouter {
+        ZEngineTraitGreeter::shared insteadof ZEngineTraitShouter;
+        ZEngineTraitShouter::shared as shoutedShared;
+        speak as protected whisper;
+    }
+
+    public function report(): string
+    {
+        return implode(':', [$this->shared(), $this->shoutedShared(), $this->whisper()]);
+    }
+}
+
+function zengine_bin_trait_run(): string
+{
+    return (new ZEngineTraitUser())->report() . ':tr-ok';
+}


### PR DESCRIPTION
## What this changes

Fixes #114 — second PR of the relocator-coverage chain (stacked on #256; merge that first, this retargets automatically).

Ports the `num_traits` branch of `zend_file_cache_(un)serialize_class`: `trait_names` via the existing `zend_class_name` walker; the NULL-terminated `trait_aliases`/`trait_precedences` pointer arrays with `trait_method.method_name`/`class_name`, `alias`, and every `exclude_class_names` slot — both directions. Adds raw-slot primitives (`unPtrAt`/`serPtrAt`/`unStrAt`/`serStrAt`) porting the C macros for slots without an owning struct field. Acceptance: fixture with two traits, an `insteadof` precedence (exclude list), an alias with explicit trait name and one without (NULL `class_name`) + visibility change — byte-identical round trip, resave and patched execution (`TraitRelocationTest`). `docs/opcache-binary.md` scope updated.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container opcache gate green at this chain point (37 tests)

Per-issue verification before commit: full default suite baseline-identical, opcache gate green (release + debug84), PHPStan level max clean, cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (chain → `8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; `zend_trait_alias`/`zend_trait_precedence` already in the generated defs
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_