### PR TITLE
feat(opcache): relocate closures/arrow functions (dynamic_func_defs) in cache binaries

### DIFF
--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -125,8 +125,9 @@ function/method hot-swap API) is future work; see [hot-swap.md](hot-swap.md).
   `unsupportedPayload` rather than writing a subtly corrupt binary. Global
   functions, classes with constants, typed properties (union/intersection/DNF
   type lists included), trait-using classes (aliases and insteadof precedences
-  included), attributes (including constant-expression arguments), static
-  variables, try/catch and enums are supported and round-trip byte-for-byte.
+  included), closures and arrow functions (nested dynamic_func_defs included),
+  attributes (including constant-expression arguments), static variables,
+  try/catch and enums are supported and round-trip byte-for-byte.
 - **Deferred.** Loading patched binaries into shared memory (ZCSG), and applying
   a patched image to already-loaded classes via `redefine()` / `ClassDelta`.
 

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -772,7 +772,12 @@ final class PayloadRelocator
         $this->unserializeArgInfo($opArray);
         $this->unserializeVars($opArray);
         if ($opArray->num_dynamic_func_defs !== 0) {
-            throw OpCacheException::unsupportedPayload('dynamic function definitions (closures/arrow fns) relocation');
+            // zend_op_array* array: relocate it, then recurse into each nested body
+            $defsAddress = $this->unPtr($opArray, 'dynamic_func_defs');
+            for ($i = 0; $i < $opArray->num_dynamic_func_defs; $i++) {
+                $defAddress = $this->unPtrAt($defsAddress + $i * PHP_INT_SIZE);
+                $this->unserializeOpArray(Core::pointerAtAddress('zend_op_array *', $defAddress));
+            }
         }
         $this->unStr($opArray, 'function_name');
         $this->unStr($opArray, 'filename');
@@ -831,7 +836,13 @@ final class PayloadRelocator
         $this->serializeArgInfo($opArray);
         $this->serializeVars($opArray);
         if ($opArray->num_dynamic_func_defs !== 0) {
-            throw OpCacheException::unsupportedPayload('dynamic function definitions (closures/arrow fns) relocation');
+            // Store offsets but keep walking through the still-real addresses,
+            // exactly like the C SERIALIZE_PTR/UNSERIALIZE_PTR pairs
+            $defsAddress = $this->serPtr($opArray, 'dynamic_func_defs');
+            for ($i = 0; $i < $opArray->num_dynamic_func_defs; $i++) {
+                $defAddress = $this->serPtrAt($defsAddress + $i * PHP_INT_SIZE);
+                $this->serializeOpArray(Core::pointerAtAddress('zend_op_array *', $defAddress));
+            }
         }
         $this->serStr($opArray, 'function_name');
         $this->serStr($opArray, 'filename');

--- a/tests/OpCache/ClosureRelocationTest.php
+++ b/tests/OpCache/ClosureRelocationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\OpCache;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Relocation coverage for dynamic function definitions (issue #115): arrow
+ * functions and anonymous closures - including a closure nested inside another
+ * closure and one inside a method - must round-trip byte-for-byte and execute
+ * after a patch-and-save cycle.
+ */
+#[Group('opcache')]
+#[Group('opcache-relocator')]
+final class ClosureRelocationTest extends TestCase
+{
+    use FileCacheFixture;
+
+    protected function setUp(): void
+    {
+        if (!PayloadRelocator::isSupported()) {
+            self::markTestSkipped(
+                'The file-cache relocator supports 64-bit POSIX NTS payloads only'
+                . ' (ZTS is issue #118, Windows is issue #119)',
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeCacheDir();
+    }
+
+    public function testClosurePayloadRoundTripsByteIdentical(): void
+    {
+        $binPath = self::compileFixture(self::closureFixturePath());
+        $payload = substr((string) file_get_contents($binPath), CacheMetaInfo::byteSize());
+        $meta    = CacheMetaInfo::parse((string) file_get_contents($binPath), $binPath);
+
+        $length = strlen($payload);
+        $buffer = Core::new("char[{$length}]", false);
+        Core::memcpy($buffer, $payload, $length);
+        $relocator = new PayloadRelocator($buffer, $meta);
+        $relocator->relocate();
+
+        self::assertSame($payload, $relocator->derelocate(), 'A closure round trip must reproduce the payload byte-for-byte');
+    }
+
+    public function testUnmodifiedResaveStillExecutes(): void
+    {
+        $fixture = self::closureFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        $file->getReflection(); // relocate
+        $file->save();          // re-serialize unchanged
+
+        self::assertTrue(BinaryCacheFile::read($file->binPath())->verifyChecksum());
+        self::assertSame(
+            'cl:42:42:cl-ok',
+            self::runFromCache($fixture, 'zengine_bin_closures_run', self::$cacheDir),
+        );
+    }
+
+    public function testPatchedClosureFixtureExecutesFromCache(): void
+    {
+        $fixture = self::closureFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        self::patchStringLiteral($file, 'zengine_bin_closures_run', ':cl-ok', ':cl-patched-through-the-relocator');
+        $file->save();
+
+        self::assertSame(
+            'cl:42:42:cl-patched-through-the-relocator',
+            self::runFromCache($fixture, 'zengine_bin_closures_run', self::$cacheDir),
+        );
+    }
+
+    private static function closureFixturePath(): string
+    {
+        $path = realpath(__DIR__ . '/fixtures/closures.php');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    private static function patchStringLiteral(BinaryCacheFile $file, string $function, string $from, string $to): void
+    {
+        $functions = $file->getReflection()->getFunctions();
+        self::assertArrayHasKey($function, $functions, "Function {$function} not found in the cached script");
+        foreach ($functions[$function]->getLiterals() as $literal) {
+            if ($literal->getBaseType() !== ReflectionValue::IS_STRING) {
+                continue;
+            }
+            $literal->getNativeValue($value);
+            if ($value === $from) {
+                $literal->setNativeValue($to);
+
+                return;
+            }
+        }
+        self::fail("String literal '{$from}' not found in {$function}");
+    }
+}

--- a/tests/OpCache/fixtures/closures.php
+++ b/tests/OpCache/fixtures/closures.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Fixture compiled into the opcache file cache by the closure relocation tests.
+ *
+ * Exercises the dynamic_func_defs walk of zend_file_cache_(un)serialize_op_array:
+ * an arrow function and an anonymous function inside a global function, a
+ * closure nested inside another closure (recursion into a nested def's own
+ * dynamic_func_defs), and a scoped arrow function inside a static method.
+ */
+declare(strict_types=1);
+
+class ZEngineClosureHost
+{
+    public static function tally(): int
+    {
+        $add = fn(int $a, int $b): int => $a + $b;
+
+        return $add(40, 2);
+    }
+}
+
+function zengine_bin_closures_run(): string
+{
+    $factor = 3;
+    $arrow  = fn(int $value): int => $value * $factor;
+    $anon   = function (string $word) use ($factor): string {
+        $inner = fn(): int => $factor + 1;
+
+        return str_repeat($word, $inner() - $factor);
+    };
+
+    return $anon('cl') . ':' . $arrow(14) . ':' . ZEngineClosureHost::tally() . ':cl-ok';
+}


### PR DESCRIPTION
## What this changes

Fixes #115 — third PR of the relocator-coverage chain (stacked on #257).

Ports the `num_dynamic_func_defs` branch of `zend_file_cache_(un)serialize_op_array`: relocates the `dynamic_func_defs` array, converts each slot, and recurses into each nested op_array — closures-inside-closures handled via their own `dynamic_func_defs`, both directions. Acceptance: fixture with `fn()` + `function()` in a global function, a nested closure, and a scoped `fn()` in a static method — byte-identical round trip and patched execution proving all defs execute from the cache (`ClosureRelocationTest`). `docs/opcache-binary.md` scope updated.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container opcache gate green at this chain point (40 tests)

Per-issue verification before commit: full default suite baseline-identical, opcache gate green (release + debug84), PHPStan level max clean, cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (chain → `8.4`)
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; `dynamic_func_defs` already in the generated defs
- [x] `tools/generator/symbols.php` unchanged — nothing generated touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_