### PR TITLE
feat(opcache): relocate iterator-aware and ArrayAccess classes in cache binaries

### DIFF
--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -121,13 +121,15 @@ function/method hot-swap API) is future work; see [hot-swap.md](hot-swap.md).
   macOS/arm64. ZTS payloads stay tracked in
   [#118](https://github.com/lisachenko/z-engine/issues/118).
 - **Strict, never silent.** Structures the port does not yet handle
-  (property hooks, iterator/ArrayAccess funcs, compile warnings) raise
-  `unsupportedPayload` rather than writing a subtly corrupt binary. Global
-  functions, classes with constants, typed properties (union/intersection/DNF
-  type lists included), trait-using classes (aliases and insteadof precedences
-  included), closures and arrow functions (nested dynamic_func_defs included),
-  attributes (including constant-expression arguments), static variables,
-  try/catch and enums are supported and round-trip byte-for-byte.
+  (property hooks, compile warnings) raise `unsupportedPayload` rather than
+  writing a subtly corrupt binary. Global functions, classes with constants,
+  typed properties (union/intersection/DNF type lists included), trait-using
+  classes (aliases and insteadof precedences included), closures and arrow
+  functions (nested dynamic_func_defs included), Iterator/IteratorAggregate/
+  ArrayAccess classes (including the linked-class iterator_funcs_ptr /
+  arrayaccess_funcs_ptr structs), attributes (including constant-expression
+  arguments), static variables, try/catch and enums are supported and
+  round-trip byte-for-byte.
 - **Deferred.** Loading patched binaries into shared memory (ZCSG), and applying
   a patched image to already-loaded classes via `redefine()` / `ClassDelta`.
 

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -1312,13 +1312,38 @@ final class PayloadRelocator
      * @param \FFI\CData $ce
      */
 
+    /**
+     * zf_* field order matches the C walk (zend_file_cache.c), not the struct layout.
+     * Only linked classes carry these structs - a plain compile stores classes
+     * unlinked with both pointers NULL - but payloads from other producers (e.g.
+     * preload-era images) may hold them, and the walk must be faithful when they do.
+     */
+    private const ITERATOR_FUNC_FIELDS    = ['zf_new_iterator', 'zf_rewind', 'zf_valid', 'zf_key', 'zf_current', 'zf_next'];
+    private const ARRAYACCESS_FUNC_FIELDS = ['zf_offsetget', 'zf_offsetexists', 'zf_offsetset', 'zf_offsetunset'];
+
+    /**
+     * The get_iterator <-> HOOKED_ITERATOR_PLACEHOLDER swap the C load path performs
+     * is deliberately NOT mirrored: the image is never executed in this process, so
+     * the placeholder is preserved verbatim like every other execution-only field
+     * and the written file keeps the exact bytes the engine expects.
+     *
+     * @param \FFI\CData $ce
+     */
     private function unserializeIteratorFuncs(object $ce): void
     {
         if ($this->ptrValue($ce, 'iterator_funcs_ptr') !== 0) {
-            throw OpCacheException::unsupportedPayload('iterator-aware class relocation');
+            $address = $this->unPtr($ce, 'iterator_funcs_ptr');
+            $funcs   = Core::pointerAtAddress('zend_class_iterator_funcs *', $address);
+            foreach (self::ITERATOR_FUNC_FIELDS as $field) {
+                $this->unPtr($funcs, $field);
+            }
         }
         if ($this->ptrValue($ce, 'arrayaccess_funcs_ptr') !== 0) {
-            throw OpCacheException::unsupportedPayload('ArrayAccess class relocation');
+            $address = $this->unPtr($ce, 'arrayaccess_funcs_ptr');
+            $funcs   = Core::pointerAtAddress('zend_class_arrayaccess_funcs *', $address);
+            foreach (self::ARRAYACCESS_FUNC_FIELDS as $field) {
+                $this->unPtr($funcs, $field);
+            }
         }
     }
     /**
@@ -1327,11 +1352,23 @@ final class PayloadRelocator
 
     private function serializeIteratorFuncs(object $ce): void
     {
-        if ($this->ptrValue($ce, 'iterator_funcs_ptr') !== 0) {
-            throw OpCacheException::unsupportedPayload('iterator-aware class relocation');
+        // The C serialize converts the zf_* members through the still-real struct
+        // pointer first and the struct pointer itself last; mirrored exactly
+        $iteratorAddress = $this->ptrValue($ce, 'iterator_funcs_ptr');
+        if ($iteratorAddress !== 0) {
+            $funcs = Core::pointerAtAddress('zend_class_iterator_funcs *', $iteratorAddress);
+            foreach (self::ITERATOR_FUNC_FIELDS as $field) {
+                $this->serPtr($funcs, $field);
+            }
+            $this->serPtr($ce, 'iterator_funcs_ptr');
         }
-        if ($this->ptrValue($ce, 'arrayaccess_funcs_ptr') !== 0) {
-            throw OpCacheException::unsupportedPayload('ArrayAccess class relocation');
+        $arrayAccessAddress = $this->ptrValue($ce, 'arrayaccess_funcs_ptr');
+        if ($arrayAccessAddress !== 0) {
+            $funcs = Core::pointerAtAddress('zend_class_arrayaccess_funcs *', $arrayAccessAddress);
+            foreach (self::ARRAYACCESS_FUNC_FIELDS as $field) {
+                $this->serPtr($funcs, $field);
+            }
+            $this->serPtr($ce, 'arrayaccess_funcs_ptr');
         }
     }
 

--- a/tests/OpCache/IteratorFuncsRelocationTest.php
+++ b/tests/OpCache/IteratorFuncsRelocationTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\OpCache;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Relocation coverage for iterator_funcs_ptr / arrayaccess_funcs_ptr payloads
+ * (issue #116). Classes compiled into the file cache are stored unlinked (the
+ * compiler does not early-bind classes that implement interfaces), so the
+ * Iterator / IteratorAggregate / ArrayAccess fixture proves such classes
+ * round-trip byte-for-byte and execute after a patch-and-save cycle; the
+ * crafted-buffer test drives the pointer walk itself, which only fires for
+ * payloads whose classes were persisted linked.
+ */
+#[Group('opcache')]
+#[Group('opcache-relocator')]
+final class IteratorFuncsRelocationTest extends TestCase
+{
+    use FileCacheFixture;
+
+    protected function setUp(): void
+    {
+        if (!PayloadRelocator::isSupported()) {
+            self::markTestSkipped(
+                'The file-cache relocator supports 64-bit POSIX NTS payloads only'
+                . ' (ZTS is issue #118, Windows is issue #119)',
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeCacheDir();
+    }
+
+    public function testIteratorPayloadRoundTripsByteIdentical(): void
+    {
+        $binPath = self::compileFixture(self::iteratorFixturePath());
+        $payload = substr((string) file_get_contents($binPath), CacheMetaInfo::byteSize());
+        $meta    = CacheMetaInfo::parse((string) file_get_contents($binPath), $binPath);
+
+        $length = strlen($payload);
+        $buffer = Core::new("char[{$length}]", false);
+        Core::memcpy($buffer, $payload, $length);
+        $relocator = new PayloadRelocator($buffer, $meta);
+        $relocator->relocate();
+
+        self::assertSame($payload, $relocator->derelocate(), 'An iterator round trip must reproduce the payload byte-for-byte');
+    }
+
+    public function testUnmodifiedResaveStillExecutes(): void
+    {
+        $fixture = self::iteratorFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        $file->getReflection(); // relocate
+        $file->save();          // re-serialize unchanged
+
+        self::assertTrue(BinaryCacheFile::read($file->binPath())->verifyChecksum());
+        self::assertSame(
+            'alpha:beta:gamma:delta:it-ok',
+            self::runFromCache($fixture, 'zengine_bin_iterators_run', self::$cacheDir),
+        );
+    }
+
+    public function testPatchedIteratorFixtureExecutesFromCache(): void
+    {
+        $fixture = self::iteratorFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        self::patchStringLiteral($file, 'zengine_bin_iterators_run', ':it-ok', ':it-patched-through-the-relocator');
+        $file->save();
+
+        self::assertSame(
+            'alpha:beta:gamma:delta:it-patched-through-the-relocator',
+            self::runFromCache($fixture, 'zengine_bin_iterators_run', self::$cacheDir),
+        );
+    }
+
+    /**
+     * Drives the ported iterator_funcs_ptr / arrayaccess_funcs_ptr walk against a
+     * crafted image: a zend_class_entry whose struct pointers and zf_* members hold
+     * serialized offsets (NULL slots included) must relocate to real addresses and
+     * serialize back to the exact original bytes.
+     */
+    public function testCraftedIteratorFuncsRelocateAndSerializeBack(): void
+    {
+        $memSize = 4096;
+        $buffer  = Core::new("char[{$memSize}]", false);
+        $meta    = CacheMetaInfo::forPayload(
+            systemId: SystemId::current(),
+            memSize: $memSize,
+            strSize: 0,
+            scriptOffset: 0,
+            timestamp: 0,
+            checksum: 0,
+        );
+        $relocator = new PayloadRelocator($buffer, $meta);
+        $base      = Core::addressOf(Core::addr($buffer));
+
+        $ceOffset          = 512;
+        $iteratorOffset    = 1024;
+        $arrayAccessOffset = 1280;
+        $iteratorSlots     = [
+            'zf_new_iterator' => 2048,
+            'zf_rewind'       => 2112,
+            'zf_valid'        => 2176,
+            'zf_key'          => 0, // NULL member must stay NULL through both directions
+            'zf_current'      => 2240,
+            'zf_next'         => 2304,
+        ];
+        $arrayAccessSlots = [
+            'zf_offsetget'    => 2368,
+            'zf_offsetexists' => 2432,
+            'zf_offsetset'    => 0,
+            'zf_offsetunset'  => 2496,
+        ];
+
+        $ce                        = Core::pointerAtAddress('zend_class_entry *', $base + $ceOffset);
+        $ce->iterator_funcs_ptr    = Core::pointerAtAddress('zend_class_iterator_funcs *', $iteratorOffset);
+        $ce->arrayaccess_funcs_ptr = Core::pointerAtAddress('zend_class_arrayaccess_funcs *', $arrayAccessOffset);
+        $iteratorFuncs             = Core::pointerAtAddress('zend_class_iterator_funcs *', $base + $iteratorOffset);
+        foreach ($iteratorSlots as $field => $offset) {
+            $iteratorFuncs->$field = $offset === 0 ? null : Core::pointerAtAddress('zend_function *', $offset);
+        }
+        $arrayAccessFuncs = Core::pointerAtAddress('zend_class_arrayaccess_funcs *', $base + $arrayAccessOffset);
+        foreach ($arrayAccessSlots as $field => $offset) {
+            $arrayAccessFuncs->$field = $offset === 0 ? null : Core::pointerAtAddress('zend_function *', $offset);
+        }
+        $serializedBytes = \FFI::string($buffer, $memSize);
+
+        $unserialize = new \ReflectionMethod(PayloadRelocator::class, 'unserializeIteratorFuncs');
+        $unserialize->invoke($relocator, $ce);
+
+        self::assertSame($base + $iteratorOffset, Core::addressOf($ce->iterator_funcs_ptr));
+        self::assertSame($base + $arrayAccessOffset, Core::addressOf($ce->arrayaccess_funcs_ptr));
+        foreach ($iteratorSlots as $field => $offset) {
+            self::assertMemberRelocated($iteratorFuncs->$field, $base, $offset, $field);
+        }
+        foreach ($arrayAccessSlots as $field => $offset) {
+            self::assertMemberRelocated($arrayAccessFuncs->$field, $base, $offset, $field);
+        }
+
+        $serialize = new \ReflectionMethod(PayloadRelocator::class, 'serializeIteratorFuncs');
+        $serialize->invoke($relocator, $ce);
+
+        self::assertSame($serializedBytes, \FFI::string($buffer, $memSize), 'Serializing back must restore the exact original bytes');
+    }
+
+    private static function assertMemberRelocated(mixed $member, int $base, int $offset, string $field): void
+    {
+        if ($offset === 0) {
+            self::assertNull($member, "{$field} must stay NULL");
+
+            return;
+        }
+        self::assertInstanceOf(\FFI\CData::class, $member, "{$field} must still be a pointer");
+        self::assertSame($base + $offset, Core::addressOf($member), "{$field} must be relocated");
+    }
+
+    private static function iteratorFixturePath(): string
+    {
+        $path = realpath(__DIR__ . '/fixtures/iterators.php');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    private static function patchStringLiteral(BinaryCacheFile $file, string $function, string $from, string $to): void
+    {
+        $functions = $file->getReflection()->getFunctions();
+        self::assertArrayHasKey($function, $functions, "Function {$function} not found in the cached script");
+        foreach ($functions[$function]->getLiterals() as $literal) {
+            if ($literal->getBaseType() !== ReflectionValue::IS_STRING) {
+                continue;
+            }
+            $literal->getNativeValue($value);
+            if ($value === $from) {
+                $literal->setNativeValue($to);
+
+                return;
+            }
+        }
+        self::fail("String literal '{$from}' not found in {$function}");
+    }
+}

--- a/tests/OpCache/fixtures/iterators.php
+++ b/tests/OpCache/fixtures/iterators.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Fixture compiled into the opcache file cache by the iterator relocation tests.
+ *
+ * Exercises the iterator_funcs_ptr and arrayaccess_funcs_ptr branches of
+ * zend_file_cache_(un)serialize_class: a class implementing Iterator (all five
+ * zf_* slots), one implementing IteratorAggregate (zf_new_iterator only) and
+ * one implementing ArrayAccess (all four zf_offset* slots).
+ */
+declare(strict_types=1);
+
+/** @implements Iterator<int, string> */
+class ZEngineIteratorSteps implements Iterator
+{
+    /** @var list<string> */
+    private array $steps = ['alpha', 'beta'];
+    private int $index   = 0;
+
+    public function current(): string
+    {
+        return $this->steps[$this->index];
+    }
+
+    public function key(): int
+    {
+        return $this->index;
+    }
+
+    public function next(): void
+    {
+        ++$this->index;
+    }
+
+    public function rewind(): void
+    {
+        $this->index = 0;
+    }
+
+    public function valid(): bool
+    {
+        return isset($this->steps[$this->index]);
+    }
+}
+
+/** @implements IteratorAggregate<int, string> */
+class ZEngineIteratorBag implements IteratorAggregate
+{
+    /** @return ArrayIterator<int, string> */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator(['gamma']);
+    }
+}
+
+/** @implements ArrayAccess<string, string> */
+class ZEngineArrayShelf implements ArrayAccess
+{
+    /** @var array<string, string> */
+    private array $items = [];
+
+    public function offsetExists(mixed $offset): bool
+    {
+        return is_string($offset) && isset($this->items[$offset]);
+    }
+
+    public function offsetGet(mixed $offset): ?string
+    {
+        return is_string($offset) ? ($this->items[$offset] ?? null) : null;
+    }
+
+    public function offsetSet(mixed $offset, mixed $value): void
+    {
+        if (is_string($offset) && is_string($value)) {
+            $this->items[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset(mixed $offset): void
+    {
+        if (is_string($offset)) {
+            unset($this->items[$offset]);
+        }
+    }
+}
+
+function zengine_bin_iterators_run(): string
+{
+    $collected = [];
+    foreach (new ZEngineIteratorSteps() as $step) {
+        $collected[] = $step;
+    }
+    foreach (new ZEngineIteratorBag() as $extra) {
+        $collected[] = $extra;
+    }
+
+    $shelf          = new ZEngineArrayShelf();
+    $shelf['delta'] = 'delta';
+    $collected[]    = $shelf['delta'] ?? 'missing';
+    unset($shelf['delta']);
+
+    return implode(':', $collected) . ':it-ok';
+}


### PR DESCRIPTION
## What this changes

Fixes #116 — fourth PR of the relocator-coverage chain (stacked on #258).

Ports the `iterator_funcs_ptr`/`arrayaccess_funcs_ptr` branches of `zend_file_cache_(un)serialize_class` with the exact C ordering (serialize walks the zf_* slots through the live struct pointer first and converts the struct pointer last; unserialize reversed); NULL zf_* slots stay NULL. The 8.4 file cache's `get_iterator` ↔ `HOOKED_ITERATOR_PLACEHOLDER` swap applies only to images the engine will execute — the relocator never executes an image, so the placeholder is preserved verbatim (byte-identical, and the written file keeps the bytes the engine expects; documented on `unserializeIteratorFuncs`).

**Reviewer note:** plain compiles never set these pointers — zend_compile does not early-bind classes implementing interfaces, so compile-produced `.bin` classes are stored unlinked with both pointers NULL; only linked-class producers (preload-era images) carry them. Coverage is therefore the acceptance fixture (Iterator, IteratorAggregate, ArrayAccess — round trip + patched execution) **plus** `testCraftedIteratorFuncsRelocateAndSerializeBack`, which drives the ported walk against a crafted image (both structs, all zf_* slots incl. NULLs → relocate → assert addresses → serialize back → exact original bytes). If a real linked-class producer lands later, a fixture-level test can replace the crafted one.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container opcache gate green at this chain point (44 tests)

Per-issue verification before commit: full default suite baseline-identical, opcache gate green (release + debug84), PHPStan level max clean, cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (chain → `8.4`)
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; `zend_class_iterator_funcs`/`zend_class_arrayaccess_funcs` already in the generated defs
- [x] `tools/generator/symbols.php` unchanged — nothing generated touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_