### PR TITLE
feat(opcache): relocate PHP 8.4 property hooks in cache binaries

### DIFF
--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -120,16 +120,18 @@ function/method hot-swap API) is future work; see [hot-swap.md](hot-swap.md).
   [#119](https://github.com/lisachenko/z-engine/issues/119) was rescoped to
   macOS/arm64. ZTS payloads stay tracked in
   [#118](https://github.com/lisachenko/z-engine/issues/118).
-- **Strict, never silent.** Structures the port does not yet handle
-  (property hooks, compile warnings) raise `unsupportedPayload` rather than
-  writing a subtly corrupt binary. Global functions, classes with constants,
-  typed properties (union/intersection/DNF type lists included), trait-using
-  classes (aliases and insteadof precedences included), closures and arrow
-  functions (nested dynamic_func_defs included), Iterator/IteratorAggregate/
-  ArrayAccess classes (including the linked-class iterator_funcs_ptr /
-  arrayaccess_funcs_ptr structs), attributes (including constant-expression
-  arguments), static variables, try/catch and enums are supported and
-  round-trip byte-for-byte.
+- **Strict, never silent.** Anything the port cannot handle raises
+  `unsupportedPayload` rather than writing a subtly corrupt binary; with every
+  payload shape of the 8.4 walker now ported, that guard covers the platform
+  predicates above (Windows/32-bit, and ZTS until #118). Global functions,
+  classes with constants, typed properties (union/intersection/DNF type lists
+  included), trait-using classes (aliases and insteadof precedences included),
+  closures and arrow functions (nested dynamic_func_defs included),
+  Iterator/IteratorAggregate/ArrayAccess classes (including the linked-class
+  iterator_funcs_ptr / arrayaccess_funcs_ptr structs), property hooks,
+  attributes (including constant-expression arguments), static variables,
+  compile warnings, try/catch and enums are supported and round-trip
+  byte-for-byte.
 - **Deferred.** Loading patched binaries into shared memory (ZCSG), and applying
   a patched image to already-loaded classes via `redefine()` / `ClassDelta`.
 

--- a/src/OpCache/PayloadRelocator.php
+++ b/src/OpCache/PayloadRelocator.php
@@ -77,6 +77,9 @@ final class PayloadRelocator
     private const int TYPE_LIST_BIT = 4194304;  // _ZEND_TYPE_LIST_BIT
     private const int TYPE_NAME_BIT = 16777216; // _ZEND_TYPE_NAME_BIT
 
+    /** ZEND_PROPERTY_HOOK_COUNT (zend_property_hooks.h) - get + set slots */
+    private const int PROPERTY_HOOK_COUNT = 2;
+
     private readonly int $base;
     private readonly int $size;
     private readonly int $strSectionBase;
@@ -1237,7 +1240,15 @@ final class PayloadRelocator
         $this->unserializeAttributes($prop, 'attributes');
         $this->unPtr($prop, 'prototype');
         if ($this->ptrValue($prop, 'hooks') !== 0) {
-            throw OpCacheException::unsupportedPayload('property-hook relocation');
+            // zend_function*[ZEND_PROPERTY_HOOK_COUNT]: relocate the array, then
+            // each non-NULL hook and its op_array (a shared body returns early)
+            $hooksAddress = $this->unPtr($prop, 'hooks');
+            for ($i = 0; $i < self::PROPERTY_HOOK_COUNT; $i++) {
+                $hookAddress = $this->unPtrAt($hooksAddress + $i * PHP_INT_SIZE);
+                if ($hookAddress !== 0) {
+                    $this->unserializeOpArray(Core::pointerAtAddress('zend_function *', $hookAddress)->op_array);
+                }
+            }
         }
         $this->unserializeType($prop, 'type');
     }
@@ -1262,7 +1273,15 @@ final class PayloadRelocator
         $this->serializeAttributes($prop, 'attributes');
         $this->serPtr($prop, 'prototype');
         if ($this->ptrValue($prop, 'hooks') !== 0) {
-            throw OpCacheException::unsupportedPayload('property-hook relocation');
+            // Offsets are stored while the walk continues through the still-real
+            // addresses, mirroring the C SERIALIZE_PTR/UNSERIALIZE_PTR pairs
+            $hooksAddress = $this->serPtr($prop, 'hooks');
+            for ($i = 0; $i < self::PROPERTY_HOOK_COUNT; $i++) {
+                $hookAddress = $this->serPtrAt($hooksAddress + $i * PHP_INT_SIZE);
+                if ($hookAddress !== 0) {
+                    $this->serializeOpArray(Core::pointerAtAddress('zend_function *', $hookAddress)->op_array);
+                }
+            }
         }
         $this->serializeType($prop, 'type');
     }

--- a/tests/OpCache/PropertyHookRelocationTest.php
+++ b/tests/OpCache/PropertyHookRelocationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Z-Engine framework
+ *
+ * @copyright Copyright 2026, Lisachenko Alexander <lisachenko.it@gmail.com>
+ *
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ *
+ */
+declare(strict_types=1);
+
+namespace ZEngine\OpCache;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use ZEngine\Core;
+use ZEngine\Reflection\ReflectionValue;
+
+/**
+ * Relocation coverage for property hooks (issue #113): get/set hook op_arrays
+ * hanging off zend_property_info - including single-hook properties with a
+ * NULL slot - must round-trip byte-for-byte and execute after a patch-and-save
+ * cycle.
+ */
+#[Group('opcache')]
+#[Group('opcache-relocator')]
+final class PropertyHookRelocationTest extends TestCase
+{
+    use FileCacheFixture;
+
+    protected function setUp(): void
+    {
+        if (!PayloadRelocator::isSupported()) {
+            self::markTestSkipped(
+                'The file-cache relocator supports 64-bit POSIX NTS payloads only'
+                . ' (ZTS is issue #118, Windows is issue #119)',
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        self::removeCacheDir();
+    }
+
+    public function testPropertyHookPayloadRoundTripsByteIdentical(): void
+    {
+        $binPath = self::compileFixture(self::hookFixturePath());
+        $payload = substr((string) file_get_contents($binPath), CacheMetaInfo::byteSize());
+        $meta    = CacheMetaInfo::parse((string) file_get_contents($binPath), $binPath);
+
+        $length = strlen($payload);
+        $buffer = Core::new("char[{$length}]", false);
+        Core::memcpy($buffer, $payload, $length);
+        $relocator = new PayloadRelocator($buffer, $meta);
+        $relocator->relocate();
+
+        self::assertSame($payload, $relocator->derelocate(), 'A property-hook round trip must reproduce the payload byte-for-byte');
+    }
+
+    public function testUnmodifiedResaveStillExecutes(): void
+    {
+        $fixture = self::hookFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        $file->getReflection(); // relocate
+        $file->save();          // re-serialize unchanged
+
+        self::assertTrue(BinaryCacheFile::read($file->binPath())->verifyChecksum());
+        self::assertSame(
+            '0:40:gauge-40:0:ph-ok',
+            self::runFromCache($fixture, 'zengine_bin_hooks_run', self::$cacheDir),
+        );
+    }
+
+    public function testPatchedPropertyHookFixtureExecutesFromCache(): void
+    {
+        $fixture = self::hookFixturePath();
+        $file    = BinaryCacheFile::read(self::compileFixture($fixture), $fixture);
+        self::patchStringLiteral($file, 'zengine_bin_hooks_run', ':ph-ok', ':ph-patched-through-the-relocator');
+        $file->save();
+
+        self::assertSame(
+            '0:40:gauge-40:0:ph-patched-through-the-relocator',
+            self::runFromCache($fixture, 'zengine_bin_hooks_run', self::$cacheDir),
+        );
+    }
+
+    private static function hookFixturePath(): string
+    {
+        $path = realpath(__DIR__ . '/fixtures/property-hooks.php');
+        self::assertIsString($path);
+
+        return $path;
+    }
+
+    private static function patchStringLiteral(BinaryCacheFile $file, string $function, string $from, string $to): void
+    {
+        $functions = $file->getReflection()->getFunctions();
+        self::assertArrayHasKey($function, $functions, "Function {$function} not found in the cached script");
+        foreach ($functions[$function]->getLiterals() as $literal) {
+            if ($literal->getBaseType() !== ReflectionValue::IS_STRING) {
+                continue;
+            }
+            $literal->getNativeValue($value);
+            if ($value === $from) {
+                $literal->setNativeValue($to);
+
+                return;
+            }
+        }
+        self::fail("String literal '{$from}' not found in {$function}");
+    }
+}

--- a/tests/OpCache/fixtures/property-hooks.php
+++ b/tests/OpCache/fixtures/property-hooks.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Fixture compiled into the opcache file cache by the property-hook relocation
+ * tests.
+ *
+ * Exercises the prop->hooks walk of zend_file_cache_(un)serialize_prop_info: a
+ * property with both get and set hooks, a get-only virtual property (NULL set
+ * slot) and a set-only backed property (NULL get slot).
+ */
+declare(strict_types=1);
+
+class ZEngineHookedGauge
+{
+    public int $level = 1 {
+        get => $this->level * 10;
+        set(int $value) {
+            $this->level = max(0, $value);
+        }
+    }
+
+    public string $label {
+        get => 'gauge-' . $this->level;
+    }
+
+    public int $floor = 0 {
+        set => max(0, $value);
+    }
+}
+
+function zengine_bin_hooks_run(): string
+{
+    $gauge        = new ZEngineHookedGauge();
+    $gauge->level = -5;
+    $before       = $gauge->level;
+    $gauge->level = 4;
+    $gauge->floor = -9;
+
+    return implode(':', [$before, $gauge->level, $gauge->label, $gauge->floor]) . ':ph-ok';
+}


### PR DESCRIPTION
## What this changes

Fixes #113 — final PR of the relocator-coverage chain (stacked on #259). With this, **the last payload-shape refusal is gone**: `PayloadRelocator` handles every compile-producible 8.4 payload; only the platform refusals remain (Windows/32-bit by policy, ZTS pending #118).

Ports the `prop->hooks` branch of `zend_file_cache_(un)serialize_prop_info`: relocates the `zend_function*[ZEND_PROPERTY_HOOK_COUNT]` array (count 2, private const following the file's precedent — `constants.php` doesn't export it), converts each non-NULL slot, and recurses into each hook op_array (shared bodies early-return via the opcodes guard, as in C). Acceptance: fixture with get+set hooks, a get-only virtual property, and a set-only backed property — byte-identical round trip and patched execution proving both hooks, the virtual getter and the set clamp run from the cache (`PropertyHookRelocationTest`). `docs/opcache-binary.md` scope updated.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container `--group opcache --fail-on-skipped` OK (47 tests, 318 assertions) on this chain head

Chain-final verification on this head: full default suite `Tests: 519, Assertions: 5250` (baseline skips/incompletes only); opcache-runner mode `Tests: 517, Skipped: 6` (all pre-existing/issue-linked); PHPStan level max clean; cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (chain → `8.4`)
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; `prop->hooks` field already in the generated defs
- [x] `tools/generator/symbols.php` unchanged — nothing generated touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_