### PR TITLE
fix(reflection): free swap-minted resources of SHM-shared bodies; pin the optimizer-inlining semantics of redefine under opcache

### DIFF
--- a/docs/hot-swap.md
+++ b/docs/hot-swap.md
@@ -124,7 +124,7 @@ covered in [opcache-binary.md](opcache-binary.md).
 
 | Target | Behaviour |
 |--------|-----------|
-| Immutable **global function** + `redefine()` | Supported via copy-out: the per-process function-table bucket is repointed at a writable `zend_function` copy; the SHM original stays untouched and allocated. The first swap does not destroy the previous (SHM) body; later swaps behave normally. |
+| Immutable **global function** + `redefine()` | Supported via copy-out: the per-process function-table bucket is repointed at a writable `zend_function` copy; the SHM original stays untouched and allocated. The first swap does not destroy the previous (SHM) body; later swaps behave normally. Only *name resolution* is redirected - call sites that already resolved the function, and call sites the optimizer inlined at cache time, keep the original body (see the copy-out caveats). |
 | Immutable **class**: method `redefine()`, `addMethod()`, `removeMethods()`, trait configuration, `HotSwap::prepare()` | Supported via class copy-out: the class entry is deep-copied into request memory with the [class-specialization](class-specialization.md) copy model (own tables and property/constant blocks, method entries duplicated at the `zend_op_array` level with the compiled bodies still shared with SHM), the class-table bucket and the engine's fast class-name cache are repointed at the copy, and the mutation is applied to it. The copy is an ordinary userland class the engine dismantles at request end. |
 | Immutable **preloaded** class (`ZEND_ACC_PRELOADED`) | Rejected with `SharedMemoryException`: a preloaded class keeps its class-table bucket across the requests of a worker, while the copy lives in request memory - repointing the bucket would leave it dangling for the next request. |
 | Immutable class the copy machinery does not support (enum/interface/trait, property hooks, internal ancestor or internal methods) | Rejected with `SharedMemoryException` carrying the refusal reason. |
@@ -138,9 +138,10 @@ modes stay distinguishable.
 
 ### Copy-out caveats
 
-A copy-out changes which `zend_class_entry` the class name resolves to, and
-only *resolution* is redirected - structures that captured the shared entry
-earlier keep it. Copy out (or mutate) at bootstrap, before such state exists:
+A copy-out changes which structure (`zend_class_entry`, `zend_function`) the
+*name* resolves to, and only resolution is redirected - structures that
+captured the shared entry earlier keep it. Copy out (or mutate) at bootstrap,
+before such state exists:
 
 - **Instances created before the copy-out** keep the shared class entry in
   `obj->ce`: they dispatch the old method bodies and are not `instanceof` the
@@ -155,6 +156,25 @@ earlier keep it. Copy out (or mutate) at bootstrap, before such state exists:
   call site spelling the class the way it was declared uses; a call site that
   already resolved the class through another spelling (`new foo\bar()` for
   `Foo\Bar`) in this request keeps the shared entry.
+- **Call sites that already resolved the function**: the engine memoizes the
+  resolved `zend_function*` in the caller's run-time cache the first time a
+  call site executes. A caller that already called the function in this
+  request keeps dispatching the shared-memory entry after a function copy-out
+  (the function-side twin of the "instances created before the copy-out"
+  rule). Redefine at bootstrap, before the call sites warm up.
+- **Optimizer-inlined call sites**
+  ([#242](https://github.com/lisachenko/z-engine/issues/242)): when opcache
+  caches a script, its optimizer *inlines* a same-file call to a function
+  whose body merely returns a literal - the call site is replaced by the
+  constant (`zend_try_inline_call`, optimizer pass 4, part of the default
+  `opcache.optimization_level`), and method calls can be folded the same way
+  when the optimizer proves the receiver's class. Such call sites do not exist
+  in the compiled code at all, so no `redefine()` - before or after they run -
+  can ever affect them; only truly dynamic calls (`$name()`, a runtime
+  callable) always resolve at runtime. Give a redefine target a body the
+  optimizer cannot pre-evaluate (for example, return a runtime-defined
+  constant), declare it in a different file than its callers, or mask the pass
+  out (`opcache.optimization_level=0x7FFEBFF7`).
 - **Per-request only**: the copy dies with the request, and the next request of
   the same worker starts from the shared-memory class again - apply the
   mutation on every request (bootstrap), exactly like for a runtime-declared
@@ -164,6 +184,9 @@ earlier keep it. Copy out (or mutate) at bootstrap, before such state exists:
 
 - `redefine()` and `ClassDelta` **body swaps are memory-flat**: each swap
   releases the previous body, its heap run-time cache and its static tables.
+  This holds for donors declared in opcache-cached files too: their compiled
+  arrays live in shared memory and are never freed, but the per-entry heap
+  run-time cache and statics duplicate minted by the swap are released.
 - Each `HotSwap::prepare()` costs one class compilation. The engine allocates
   the op_array/class-entry **containers** from the request arena, which is
   only reclaimed at request end (~1 KiB per prepare for a small class, the
@@ -176,8 +199,11 @@ earlier keep it. Copy out (or mutate) at bootstrap, before such state exists:
 ## Interactions to be aware of
 
 - **Run-time cache invalidation**: swapped entries always get a fresh cache;
-  caches of *other* functions that call the swapped one are untouched but safe,
-  because the entry pointer (what those caches store) is preserved.
+  caches of *other* functions that call the swapped one are untouched but safe
+  for in-place swaps, because the entry pointer (what those caches store) is
+  preserved. The shared-memory copy-out path publishes a *new* pointer instead,
+  so callers that already resolved the old one keep it - see the copy-out
+  caveats above.
 - **`Closure::fromCallable()` over a later-swapped method**: fake closures
   share the old body and keep it alive through its refcount; they continue to
   execute the old body (and its static variables) until released.

--- a/src/Reflection/FunctionBodySwap.php
+++ b/src/Reflection/FunctionBodySwap.php
@@ -41,8 +41,11 @@ use ZEngine\Type\StringEntry;
  *    defaults; the live per-entry table materializes lazily on the first
  *    ZEND_BIND_STATIC, exactly like a plain compiled function.
  *  - The previous body is destroyed with engine semantics (destroy_op_array) when
- *    the swap is committed - unless it lives in opcache shared memory, which is
- *    never freed. The entry keeps its owned reference on the function name;
+ *    the swap is committed. A previous body living in opcache shared memory keeps
+ *    its compiled arrays (SHM is never freed), but the per-entry resources the
+ *    swap minted for it (heap run-time cache, statics defaults duplicate) are
+ *    still released, so swaps stay memory-flat with shared-memory donors too.
+ *    The entry keeps its owned reference on the function name;
  *    everything exclusively owned by the old body (opcodes, literals, vars,
  *    arg_info, static variables, heap run-time cache) is released, and bodies still
  *    shared with someone else (a template op_array, a fake closure) survive through
@@ -436,37 +439,45 @@ final class FunctionBodySwap
     {
         $previousFunction = ReflectionFunction::fromCData(Core::cast('zend_function *', Core::addr($previousBody)));
         $previousOpArray  = $previousFunction->getOpArrayPointer();
-        $refCountPointer  = $previousOpArray->refcount;
-        if ($refCountPointer === null) {
-            // No refcount means an opcache-shared body: never destroyed (and the swap
-            // paths never destroy SHM bodies in the first place)
-            return;
-        }
 
         if (self::hasLiveFrame($entryAddress)) {
             // A frame of this very entry is still executing the previous opcodes (the
-            // function redefined itself, directly or through a callee): freeing them
-            // would pull memory out from under the running VM frame. The previous body
-            // stays allocated instead - bounded to one body per such in-flight
+            // function redefined itself, directly or through a callee): freeing them -
+            // or the run-time cache the frame reads its inline caches from - would pull
+            // memory out from under the running VM frame. The previous body stays
+            // allocated instead - bounded to one body per such in-flight
             // redefinition, see docs/hot-swap.md.
             return;
         }
 
-        // All bucket shares move to the new body: drop every previous share except the
-        // one that destroy_op_array below releases itself
-        $referenceCount = self::counterValue($refCountPointer);
-        if ($releasedShares > 1) {
-            assert($referenceCount >= $releasedShares);
-            $referenceCount     = $referenceCount - ($releasedShares - 1);
-            $refCountPointer[0] = $referenceCount;
+        // A body without a refcount is opcache-shared: its compiled arrays live in
+        // shared memory and are never freed (destroy_op_array below returns before
+        // touching them), so it can never be the "last holder". The per-entry
+        // resources the swap minted for it - the HEAP_RT_CACHE run-time cache and a
+        // statics defaults duplicate - are ordinary request memory though, and are
+        // released below exactly like for a refcounted body, or repeated swaps whose
+        // donors were declared in a cached file leak one cache per swap (the
+        // fixed-donor plateau of issue #242 under opcache).
+        $refCountPointer = $previousOpArray->refcount;
+        $isLastHolder    = false;
+        if ($refCountPointer !== null) {
+            // All bucket shares move to the new body: drop every previous share except
+            // the one that destroy_op_array below releases itself
+            $referenceCount = self::counterValue($refCountPointer);
+            if ($releasedShares > 1) {
+                assert($referenceCount >= $releasedShares);
+                $referenceCount     = $referenceCount - ($releasedShares - 1);
+                $refCountPointer[0] = $referenceCount;
+            }
+            $isLastHolder = $referenceCount <= 1;
         }
-        $isLastHolder = $referenceCount <= 1;
 
         $rawOpArray = Core::cast('zend_op_array *', Core::addr($previousBody));
         if ($isLastHolder) {
             // Frees the materialized live static-variables table (if any) and clears
-            // the map slot; with other holders alive the table must survive - fake
-            // closures over the old body still reference it through their map slots
+            // the map slot; with other holders alive (or unaccountable, as for a
+            // refcount-less body) the table must survive - fake closures over the old
+            // body still reference it through their map slots
             Core::call('zend_destroy_static_vars', $rawOpArray);
         }
 
@@ -485,7 +496,11 @@ final class FunctionBodySwap
         }
 
         // The entry keeps the single owned reference on the name - the snapshot must
-        // not release it
+        // not release it. destroy_op_array releases the HEAP_RT_CACHE run-time cache
+        // (and would release the name) BEFORE its refcount check, then frees the body
+        // arrays for the last holder of a refcounted body and returns without touching
+        // the arrays of a refcount-less (opcache-shared) one - engine-exact semantics
+        // for both lifetime classes.
         $previousOpArray->function_name = null;
         Core::call('destroy_op_array', $rawOpArray);
     }

--- a/tests/HotSwap/OpcacheSupportMatrixTest.php
+++ b/tests/HotSwap/OpcacheSupportMatrixTest.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
  *    copied out of shared memory and the mutation applies to the writable copy,
  *    while the shared-memory original stays byte-for-byte untouched
  *  - runtime-declared classes keep the full mutation surface under opcache
+ *  - same-file callers observe a redefine through the repointed bucket, and the
+ *    optimizer-inlined trivial-constant call sites stay baked (issue #242)
  *
  * The child exit code doubles as the shutdown check of issue #41, whose original
  * symptom was a zend_function_dtor() assertion failure and a SIGABRT while the
@@ -38,7 +40,18 @@ class OpcacheSupportMatrixTest extends TestCase
 {
     public function testSharedMemorySupportMatrix(): void
     {
-        [$exitCode, $stdout, $report] = $this->runOpcacheChild(__DIR__ . '/scripts/opcache-matrix.php');
+        [$exitCode, $stdout, $report] = $this->runOpcacheChild(
+            __DIR__ . '/scripts/opcache-matrix.php',
+            [
+                // The same-file legs (issue #242) need the matrix script itself in shared
+                // memory: the default opcache.file_update_protection=2 refuses files
+                // modified less than 2s before the request (a fresh checkout)
+                '-d', 'opcache.file_update_protection=0',
+                // The inlined-call-site leg asserts the behavior of the default optimizer
+                // pipeline (zend_try_inline_call runs in pass 4): pin it against php.ini
+                '-d', 'opcache.optimization_level=0x7FFEBFFF',
+            ],
+        );
 
         self::assertSame(0, $exitCode, "Opcache matrix child exited with code {$exitCode}\n{$report}");
         self::assertStringContainsString('function-copy-out: ok', $stdout, $report);
@@ -47,6 +60,8 @@ class OpcacheSupportMatrixTest extends TestCase
         self::assertStringContainsString('hot-swap: ok', $stdout, $report);
         self::assertStringContainsString('runtime-class-swap: ok', $stdout, $report);
         self::assertStringContainsString('static-vars-live-table: ok', $stdout, $report);
+        self::assertStringContainsString('same-file-redefine: ok', $stdout, $report);
+        self::assertStringContainsString('inlined-call-site-limitation: ok', $stdout, $report);
         self::assertStringContainsString('MATRIX OK', $stdout, $report);
     }
 

--- a/tests/HotSwap/RedefineLeakPlateauTest.php
+++ b/tests/HotSwap/RedefineLeakPlateauTest.php
@@ -29,6 +29,11 @@ use PHPUnit\Framework\TestCase;
  *
  * Before the fix the function/method series grew by a full function body per cycle
  * over the baseline; with the previous body destroyed the redefine cost is zero.
+ *
+ * The child pins opcache ON (issue #242): the measured functions live in the same
+ * cached script as their dispatch call sites, so the run doubles as the regression
+ * test for the first-redefine-under-opcache failure, and the fixed-donor series
+ * guards the per-swap run-time-cache release for shared-memory donor bodies.
  */
 class RedefineLeakPlateauTest extends TestCase
 {
@@ -57,11 +62,20 @@ class RedefineLeakPlateauTest extends TestCase
             '-d', 'display_errors=on',
             '-d', 'error_reporting=-1',
             '-d', 'memory_limit=512M',
-            // Pinned off so the measurement is hermetic whatever php.ini says (an
-            // opcache-active runner, or Ubuntu's PHP 8.5 default opcache.enable_cli=On).
-            // TODO(#242): with opcache active in this child the very first redefine()
-            // does not take effect ("warm-up dispatch failed") - unpin once fixed
-            '-d', 'opcache.enable_cli=0',
+            // Pinned ON (never inherited from php.ini) so the child deterministically
+            // exercises the issue #242 regression shape: the measured functions are
+            // declared in the same cached script as their dispatch call sites, and the
+            // first redefine() runs the shared-memory copy-out path. Where the opcache
+            // extension is not loaded these switches are inert and the child measures
+            // the plain in-place path, as before.
+            '-d', 'opcache.enable=1',
+            '-d', 'opcache.enable_cli=1',
+            // The JIT rewrites the executor internals z-engine hooks into (AGENTS.md)
+            '-d', 'opcache.jit=off',
+            '-d', 'opcache.jit_buffer_size=0',
+            // A fresh checkout must still publish the script from shared memory (the
+            // default opcache.file_update_protection=2 refuses files modified <2s ago)
+            '-d', 'opcache.file_update_protection=0',
             __DIR__ . '/scripts/redefine-plateau.php',
         ];
         $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);

--- a/tests/HotSwap/scripts/opcache-matrix.php
+++ b/tests/HotSwap/scripts/opcache-matrix.php
@@ -38,6 +38,28 @@ if (!isset($cachedScripts[realpath(__DIR__ . '/opcache-shm-fixture.php')])) {
     exit(2);
 }
 
+// --- Same-file redefine targets (issue #242) --------------------------------------
+// Unlike everything in the fixture include, these two are declared in THIS cached
+// script: their compiled call sites live in the very shared-memory script that is
+// executing them, which is the shape the first-redefine failure of issue #242 came
+// from. The seed constant is defined at runtime, so no call to
+// zengine_samefile_function() can be pre-evaluated when the script is cached.
+define('ZENGINE_SAMEFILE_SEED', 'same-file-original');
+
+function zengine_samefile_function(): string
+{
+    return \ZENGINE_SAMEFILE_SEED;
+}
+
+/**
+ * Deliberately the optimizer-inlinable shape: a single return of a literal
+ * (see leg 8 - its same-file call sites are replaced by the constant at cache time)
+ */
+function zengine_samefile_baked(): string
+{
+    return 'baked';
+}
+
 /**
  * Fails the matrix with a diagnostic (exit code 1 = assertion failure)
  */
@@ -262,6 +284,54 @@ if ($observedCount !== 2) {
     $fail("the live static-variables table was not read through the map-ptr slot (invocations = {$observedExport}, expected 2)");
 }
 echo "static-vars-live-table: ok\n";
+
+// 7. Same-file callers (issue #242): the redefine target is declared in THIS cached
+//    script. A compiled call site that did not execute before the redefine resolves
+//    the callee through the repointed function-table bucket on its first run and
+//    must observe the writable copy - the dispatch closure below was compiled (and
+//    its op_array persisted) long before the redefine, but runs only after it
+$sameFileDispatches = static function (string $expected): bool {
+    return zengine_samefile_function() === $expected;
+};
+$sameFileFunction = new ReflectionFunction('zengine_samefile_function');
+if (!$sameFileFunction->isImmutable()) {
+    // Without shared memory behind the main script the same-file branch under test
+    // would silently not be exercised
+    fwrite(STDERR, "zengine_samefile_function is not an immutable (shared-memory) function\n");
+    exit(2);
+}
+$sameFileFunction->redefine(function (): string {
+    return 'redefined-same-file';
+});
+if (!$sameFileDispatches('redefined-same-file')) {
+    $fail('a same-file call site did not observe the redefined body');
+}
+if (zengine_samefile_function() !== 'redefined-same-file') {
+    $fail('the top-level same-file call site did not observe the redefined body');
+}
+echo "same-file-redefine: ok\n";
+
+// 8. The documented hard limitation behind issue #242: a same-file call to a function
+//    whose body merely returns a literal is inlined when the script is cached
+//    (zend_try_inline_call, optimizer pass 4) - the call site below was replaced by
+//    the constant 'baked' at cache time, so it does not exist at runtime and CANNOT
+//    observe any redefine, while a dynamic call resolves at runtime and observes it.
+//    If this leg ever fails on a new PHP build, the engine stopped inlining: revisit
+//    the copy-out caveat in docs/hot-swap.md together with this assertion.
+$bakedDispatches = static function (): string {
+    return zengine_samefile_baked();
+};
+(new ReflectionFunction('zengine_samefile_baked'))->redefine(function (): string {
+    return 'redefined-baked';
+});
+$dynamicCallee = 'zengine_samefile_baked';
+$assertSameString($dynamicCallee(), 'redefined-baked', 'a dynamic call does not observe the redefined body');
+$assertSameString(
+    $bakedDispatches(),
+    'baked',
+    'the optimizer-inlined call site changed behavior - engine inlining semantics moved',
+);
+echo "inlined-call-site-limitation: ok\n";
 
 // Reaching this point with exit code 0 also proves the request shuts down cleanly:
 // issue #41 crashed in zend_function_dtor()/destroy_zend_class() at request shutdown

--- a/tests/HotSwap/scripts/redefine-plateau.php
+++ b/tests/HotSwap/scripts/redefine-plateau.php
@@ -19,31 +19,43 @@ require __DIR__ . '/../../../vendor/autoload.php';
 
 Core::init();
 
+// Under opcache this whole script is cached and optimized before it runs, and the
+// optimizer inlines a same-file call to a function whose body merely returns a
+// literal (zend_try_inline_call, optimizer pass 4): such a call site is replaced by
+// the constant at cache time, so no redefine() can ever reach it - the original
+// failure of issue #242 (see the copy-out caveats in docs/hot-swap.md). The measured
+// bodies return a runtime-defined constant instead, which keeps every dispatch below
+// a real engine call under any optimization level.
+define('PLATEAU_ORIGINAL', 'original');
+
 function plateau_function(): string
 {
-    return 'original';
+    return \PLATEAU_ORIGINAL;
 }
 
 class PlateauClass
 {
     public function target(): string
     {
-        return 'original';
+        return \PLATEAU_ORIGINAL;
     }
 }
 
 $cycles      = 1000;
 $refFunction = new ReflectionFunction('plateau_function');
 $refMethod   = new ReflectionMethod(PlateauClass::class, 'target');
-$instance    = new PlateauClass();
 
 // Dispatch checks take the expected value as data: the bodies are replaced at
 // runtime, so no statically-known return value applies
 $functionDispatches = static function (string $expected): bool {
     return plateau_function() === $expected;
 };
-$methodDispatches = static function (string $expected) use ($instance): bool {
-    return $instance->target() === $expected;
+// The instance is created inside the dispatch: under opcache the first redefine
+// copies PlateauClass out of shared memory, and an instance created before that
+// would keep the shared class entry and dispatch the original body forever
+// (copy-out redirects name resolution only - docs/hot-swap.md caveats)
+$methodDispatches = static function (string $expected): bool {
+    return (new PlateauClass())->target() === $expected;
 };
 
 // A fixed rotation of equal-length payloads: every cycle compiles a brand-new


### PR DESCRIPTION
## What this changes

Fixes #242. The "first `redefine()` does not take effect under opcache" turned out to be **three stacked mechanisms**, only one of them a z-engine bug:

1. **Optimizer inlining (the reported symptom):** `plateau_function()` returned a constant, so opcache's pass 4 (`zend_try_inline_call`, bit `0x8` of the default `opcache.optimization_level`) replaced every *same-file* call site with the literal at cache time — the call doesn't exist at runtime, so no repointing can ever affect it. Proved by opcode dumps (`INIT_FCALL/DO_UCALL` gone), a 4-way probe matrix (only zero-arg/constant-body shapes fail), and single-bit bisection of the optimization level. Copy-out itself was verified correct (bucket repointed; dynamic `$name()` calls see the new body). Not fixable in the library — now **pinned as named semantics**: new matrix legs `same-file-redefine: ok` (a cold same-file call site must observe the copy) and `inlined-call-site-limitation: ok` (an inlined site stays baked; the leg fails loudly if a future engine changes the pass-4 behavior).
2. **Warm run-time caches (adjacent limitation, now documented):** a caller that ran before the first redefine keeps the old `zend_function*` in its run-time cache slot — mirrors the documented class-side "resolution only is redirected" model; `docs/hot-swap.md` gains the function-side caveats and corrects one sentence that claimed the opposite. A follow-up issue proposes an opt-in targeted cache patch (maintainer decision).
3. **A real leak, fixed:** `FunctionBodySwap::destroyPreviousBody()` bailed early for refcount-less previous bodies (any donor closure declared in a cached file shares its body with SHM), leaking the swap-minted `HEAP_RT_CACHE` (16 B/swap) and minted statics duplicates. Verified against php-8.4.19's `destroy_op_array`: it frees exactly those per-entry resources before its refcount check and never touches a refcount-less body's shared arrays — the fix runs it for both lifetime classes. Plateau evidence: `fixedDonor` growth 16000 B → **0** over 1000 cycles.

Test strategy: the plateau child pin flips from opcache-off (`TODO(#242)`) to explicit opcache **ON** (JIT off), so every default-suite run permanently exercises the originally failing shape, with uninlinable runtime-defined bodies; the matrix legs pin the semantics under the default optimization level.

## Environment it was verified on

- PHP version (full first line of `php -v`): PHP 8.4.19 (cli) (built: Mar 30 2026 19:28:35) (NTS)
- Thread safety: NTS
- OS / architecture: Linux x86-64 (Ubuntu)
- Debug build (`--enable-debug`)? yes — debug 8.4 container: `--group opcache --fail-on-skipped` OK (31 tests, 194 assertions), `--group internal --process-isolation` OK (165 tests); plateau + matrix children green under engine assertions

Also: reproducer exit 0 with opcache on (3 stable runs, all series flat); default suite OK (503 tests); opcache-runner suite OK (501); PHPStan level max clean; cs-fixer clean.

## Checklist

- [x] Targets the **minimum affected version branch** (`8.4`) — fixes cascade upward, never downward
- [x] `composer test` passes on the matching PHP minor
- [x] `composer phpstan` (level max) and `composer cs:check` are green
- [x] Tests added or updated; structs dereferenced already in `layout_structs`
- [x] `tools/generator/symbols.php` unchanged — nothing under `include/`, `stubs/` or `.phpstorm.meta.php` touched
- [x] Conventional Commits used for the commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_