### PR TITLE
ci: skip Homebrew auto-update/cleanup on the macOS setup-php jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,14 @@ jobs:
   tests-macos:
     name: Tests (macOS ${{ matrix.runner-arch.arch }}, ${{ matrix.ts }})
     runs-on: ${{ matrix.runner-arch.runner }}
+    # setup-php installs PHP through Homebrew on macOS, and by default brew runs
+    # a full `brew update` before every install and a cleanup after it - tens of
+    # seconds of unrelated formula churn on top of the PHP install this job
+    # needs. Both are pure overhead here (the runner image already ships a recent
+    # brew and nothing else is installed), so switch them off for the whole job.
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_CLEANUP: '1'
     strategy:
       fail-fast: false
       matrix:
@@ -603,6 +611,11 @@ jobs:
   header-drift-darwin:
     name: Generated darwin headers up to date (${{ matrix.runner-arch.arch }}, ${{ matrix.ts }})
     runs-on: ${{ matrix.runner-arch.runner }}
+    # See tests-macos: skip brew's auto-update/cleanup so setup-php only pays for
+    # the PHP install it actually needs.
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_CLEANUP: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/generate-darwin-headers.yml
+++ b/.github/workflows/generate-darwin-headers.yml
@@ -40,6 +40,12 @@ env:
 jobs:
   generate:
     name: Generate darwin-${{ matrix.runner-arch.arch }}-${{ matrix.ts }}
+    # setup-php installs PHP through Homebrew on macOS; brew's default
+    # pre-install update and post-install cleanup are tens of seconds of
+    # unrelated churn this generate step does not need. Switch them off.
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_CLEANUP: '1'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What this changes

The "Set up PHP" step dominates wall-clock on the macOS legs — measured at
**36–53s on macOS arm64** and **78–101s on macOS x64**, versus 6–8s on Linux.
Most of that is not the PHP install: `shivammathur/setup-php` installs PHP
through Homebrew on macOS, and brew by default runs a full `brew update` before
every install plus a cleanup pass after it — tens of seconds of unrelated
formula churn wrapped around a single PHP install.

This sets `HOMEBREW_NO_AUTO_UPDATE=1` and `HOMEBREW_NO_INSTALL_CLEANUP=1` at job
level on every macOS runner:

- `tests-macos` (ci.yml)
- `header-drift-darwin` (ci.yml)
- `generate` (generate-darwin-headers.yml)

The runner images already ship a recent brew and these jobs install nothing but
PHP, so both passes are pure overhead.

**Windows is intentionally left untouched** — setup-php uses Chocolatey there,
not Homebrew, so these variables would be inert. No extension-caching action is
added (that was considered and declined); this is env-only tuning that changes
nothing about what the jobs build, generate, or test — only how long brew spends
before setup-php gets to work.

Fixes nothing functional; it is a CI-latency change only.

## Environment it was verified on

- PHP version: n/a — GitHub Actions workflow-only change (no library code touched)
- Thread safety: n/a
- OS / architecture: macOS arm64 + macOS x64 GitHub-hosted runners (behavior change lands in CI)
- Debug build (`--enable-debug`)? no

## Checklist

- [x] Targets the **minimum affected version branch** (`8.4`) — will cascade upward
- [x] `composer test` unaffected (no PHP source changed)
- [x] `composer phpstan` / `composer cs:check` unaffected (workflow-only change)
- [x] No `tools/generator/symbols.php` change; no `include/` regeneration needed
- [x] Conventional Commits used

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_