### PR TITLE
docs(opcache): align hot-swap statics wording with the PHP 8.5 ownership model

### DIFF
--- a/docs/hot-swap.md
+++ b/docs/hot-swap.md
@@ -32,12 +32,16 @@ dispatch the new body. The implementation is centralized in
 - **The run-time cache is reset per swap.** Inline caches are scope-dependent
   and sized for one specific body, so every swap installs a fresh zeroed
   `ZEND_ACC_HEAP_RT_CACHE` cache that the engine (or the next swap) releases.
-- **Static variables are unshared.** A closure destroys its own static table
-  when it dies, so the entry duplicates the defaults (`zend_array_dup`) and
-  lets the live per-entry table materialize lazily on the first
-  `ZEND_BIND_STATIC`, exactly like a plain compiled function. The class entry
-  is flagged with `ZEND_HAS_STATIC_IN_METHODS` so the engine's shutdown walk
-  releases the live table.
+- **Static variables are unshared - the live table only.** The entry's
+  `ZEND_MAP_PTR` slot is dropped so the live per-entry table materializes
+  lazily on the first `ZEND_BIND_STATIC`, exactly like a plain compiled
+  function. The defaults table behind it stays shared and is guarded by the
+  body refcount alone: on PHP 8.5 no donor kind owns it
+  (`zend_create_closure_ex` duplicates the prototype defaults into the map
+  slot only), so the last body holder frees it exactly once - see
+  `FunctionBodySwap::unshareStaticVariables()` for the ownership rules. The
+  class entry is flagged with `ZEND_HAS_STATIC_IN_METHODS` so the engine's
+  shutdown walk releases the live table.
 - **Declaration identity is preserved.** The entry keeps its name, scope,
   prototype and declaration-level flags (visibility, static, final);
   body-level flags (variadic, generator, return type, strict types) follow the

--- a/docs/opcache-binary.md
+++ b/docs/opcache-binary.md
@@ -247,7 +247,9 @@ $report->appliedMethods;                   // what actually happened, per entry
   a payload).
 - **Strict, never silent.** Anything the port cannot handle raises
   `unsupportedPayload` rather than writing a subtly corrupt binary; with every
-  payload shape of the 8.4 walker now ported, that guard covers the platform
+  payload shape of the engine's walker now ported (the PHP 8.5-only shapes -
+  attributed constants, closures in constant expressions - included), that
+  guard covers the platform
   predicates above (Windows/32-bit). Global functions,
   classes with constants, typed properties (union/intersection/DNF type lists
   included), trait-using classes (aliases and insteadof precedences included),


### PR DESCRIPTION
## What this changes

A docs-only follow-up from auditing both branches' opcache-limitation docs after the epic landed. One pre-existing staleness found, on `master` only (it predates the #273 cascade — the code changed when the minted-duplicate machinery was removed, the doc didn't):

- **`docs/hot-swap.md`** — the "Static variables are unshared" bullet still described the PHP 8.4 mechanics (the swap duplicating the defaults via `zend_array_dup`). On PHP 8.5 no donor kind owns the defaults table (`zend_create_closure_ex` duplicates into the map slot only): only the live `ZEND_MAP_PTR` slot is unshared and the body refcount guards the shared defaults. The bullet now states that model and points at `FunctionBodySwap::unshareStaticVariables()`. The `8.4` branch's wording stays as-is — it is correct for the 8.4 engine.
- **`docs/opcache-binary.md`** — the "every payload shape of the 8.4 walker" phrase now reads as the engine walker's shapes, PHP 8.5-only ones (attributed constants, closures in constant expressions) included, since this line handles them.

Everything else audited clean and consistent across both branches: ZTS supported since #118, Windows an intentional non-goal, 32-bit refused, macOS/arm64 with the addressing-model tripwire, graph growth (#117) scoped, #121 recorded infeasible with `refresh()` as the SHM path, `CacheImageSync` (#122) documented, the optimizer/`hasLocalVariable` docs, and the inheritance-cache decline row.

## Environment it was verified on

- PHP version: n/a — docs-only change (cs-fixer clean, 353 files)
- Thread safety: n/a
- OS / architecture: n/a
- Debug build (`--enable-debug`)? no

## Checklist

- [x] Targets the correct branch: `master` only — the corrected wording is PHP 8.5-specific; 8.4's text is right for 8.4
- [x] `composer test` unaffected (no code changed)
- [x] `composer cs:check` green; PHPStan unaffected
- [x] Tests — n/a (docs)
- [x] No generated files touched
- [x] Conventional Commits used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDcCQiYqbMkjRPyhWgLL6M)_