### PR TITLE
chore: extend cascade flow to 8.4 => 8.5 => master

### DIFF
--- a/.github/branch-flow.json
+++ b/.github/branch-flow.json
@@ -1,5 +1,6 @@
 {
     "$comment": "Cascade-merge flow: fixes land on the minimum affected version branch and are merged upward. Key = source branch, value = successor branch (null = frozen, no cascade). See AGENTS.md.",
     "8.0": null,
-    "8.4": "master"
+    "8.4": "8.5",
+    "8.5": "master"
 }


### PR DESCRIPTION
A new `8.5` maintenance branch has been created from master (which is moving on to PHP 8.6). This updates `.github/branch-flow.json` on the `8.4` branch so pushes to `8.4` cascade into `8.5` instead of jumping straight to `master`:

```json
{ "8.0": null, "8.4": "8.5", "8.5": "master" }
```

`merge-up.yml` resolves the successor from the pushed branch's own copy of the flow file, so the `8.4` branch needs this map for the new chain `8.4 => 8.5 => master (8.6)` to take effect. The same change is already on the `8.5` branch and is part of the PHP 8.6 bump for `master`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvwX3zFemZVZENmF3fSrcE)_